### PR TITLE
[FEATURE] 전역 예외 처리 설정 (#11)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.5.5'
-	id 'io.spring.dependency-management' version '1.1.7'
+    id 'java'
+    id 'org.springframework.boot' version '3.5.5'
+    id 'io.spring.dependency-management' version '1.1.7'
 }
 
 group = 'com.kakaotech.team18'
@@ -9,35 +9,42 @@ version = '0.0.1-SNAPSHOT'
 description = 'Demo project for Spring Boot'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 //	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
-	developmentOnly 'org.springframework.boot:spring-boot-devtools'
-	runtimeOnly 'com.h2database:h2'
-	runtimeOnly 'com.mysql:mysql-connector-j'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    compileOnly 'org.projectlombok:lombok'
+    developmentOnly 'org.springframework.boot:spring-boot-devtools'
+    runtimeOnly 'com.h2database:h2'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
 //	testImplementation 'org.springframework.security:spring-security-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // validation 관련 의존성 추가
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    // 테스트 코드에서 Lombok 사용을 위한 의존성 추가
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/Team18BeApplication.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/Team18BeApplication.java
@@ -2,10 +2,8 @@ package com.kakaotech.team18.backend_server;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
-@EnableJpaAuditing
 public class Team18BeApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/applicationFormField/entity/ApplicationFormField.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/applicationFormField/entity/ApplicationFormField.java
@@ -21,7 +21,7 @@ public class ApplicationFormField extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "application_form_id")
+    @Column(name = "application_form_field_id")
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/kakaotech/team18/backend_server/global/config/JpaAuditingConfig.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/config/JpaAuditingConfig.java
@@ -1,0 +1,10 @@
+package com.kakaotech.team18.backend_server.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/global/exception/code/ErrorCode.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/exception/code/ErrorCode.java
@@ -1,0 +1,43 @@
+package com.kakaotech.team18.backend_server.global.exception.code;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+/**
+ * 애플리케이션 전역에서 사용될 비즈니스 예외 코드를 정의하는 Enum 클래스입니다.
+ * <p>
+ * <strong>ErrorCode 원칙</strong>
+ * <ul>
+ *     <li>'예측 가능한 비즈니스 예외'를 명시적으로 다루기 위해 사용됩니다.</li>
+ * </ul>
+ *
+ * <strong>활용 워크플로우 (정의 → 발생 → 처리)</strong>
+ * <ol>
+ *     <li><b>정의</b>: 이 Enum에 새로운 에러(코드, 메시지, HttpStatus)를 정의합니다.</li>
+ *     <li><b>발생</b>: 서비스 계층에서 비즈니스 규칙 위반 시 <code>throw new CustomException(ErrorCode.YOUR_ERROR, "상세 정보");</code>를 호출합니다.</li>
+ *     <li><b>처리</b>: <code>GlobalExceptionHandler</code>가 예외를 감지하여, 정의된 HttpStatus와 메시지로 일관된 에러 응답(JSON)을 생성합니다.</li>
+ * </ol>
+ */
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+
+    // 400 BAD_REQUEST: 잘못된 요청
+    INVALID_INPUT_VALUE("4000", "입력 값이 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
+
+    // 404 NOT_FOUND: 리소스를 찾을 수 없음
+    USER_NOT_FOUND("4040", "유저를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    CLUB_NOT_FOUND("4041", "동아리를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+
+    // 409 CONFLICT: 리소스 충돌
+    USER_ALREADY_EXISTS("4090", "이미 존재하는 사용자입니다.", HttpStatus.CONFLICT),
+
+    // 500 INTERNAL_SERVER_ERROR: 서버 내부 에러
+    INTERNAL_SERVER_ERROR("5000", "서버 내부에 문제가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+
+    private final String code;
+    private final String message;
+    private final HttpStatus httpStatus;
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/global/exception/dto/ErrorResponseDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/exception/dto/ErrorResponseDto.java
@@ -1,0 +1,32 @@
+package com.kakaotech.team18.backend_server.global.exception.dto;
+
+import com.kakaotech.team18.backend_server.global.exception.code.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ErrorResponseDto {
+
+    private final String errorCode;
+    private final String message;
+    private final String detail;
+
+    /**
+     * ErrorCode와 상세 정보(detail)을 기반으로 ErrorResponseDto를 생성합니다.
+     * <p>
+     * 에러가 특정 값 때문에 발생하여, "어떤 값 때문에?" 라는 개발자의 질문에 답해야 할 때 사용합니다. (예: 요청된 userId: 123)
+     */
+    public static ErrorResponseDto of(final ErrorCode code, final String detail) {
+        return new ErrorResponseDto(code.getCode(), code.getMessage(), detail);
+    }
+
+    /**
+     * ErrorCode를 기반으로 ErrorResponseDto를 생성합니다. (상세 정보 detail 없음)
+     * <p>
+     * 에러 메시지만으로 의미가 충분하거나, 내부 로직 같은 민감정보를 외부에 노출하면 안 될 때 (예: 접근 권한이 없습니다.)
+     */
+    public static ErrorResponseDto from(final ErrorCode code) {
+        return new ErrorResponseDto(code.getCode(), code.getMessage(), null);
+    }
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/global/exception/exceptions/CustomException.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/exception/exceptions/CustomException.java
@@ -1,0 +1,42 @@
+package com.kakaotech.team18.backend_server.global.exception.exceptions;
+
+import com.kakaotech.team18.backend_server.global.exception.code.ErrorCode;
+import lombok.Getter;
+
+/**
+ * [확장 가이드라인]
+ * <p>
+ * 보다 명확한 예외 표현을 위해 CustomException을 직접 사용하기보다,
+ * <p>
+ * 이를 상속받는 구체적인 예외 클래스를 만드는 것을 권장합니다.
+ * <p>
+ * 예시: UserNotFoundException과 같은 사용자 관련 예외는
+ * <p>
+ * com.kakaotech.team18.backend_server.user.exception 패키지를 생성하고,
+ * <p>
+ * 해당 패키지 내에서 CustomException을 상속받아 작성합니다.
+ * <p>
+ * 이렇게 하면 예외의 책임과 발생 위치를 명확히 할 수 있습니다.
+ */
+
+@Getter
+public class CustomException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+    private final String detail; // 디버깅 및 로깅을 위한 상세 정보
+
+    // detail 정보가 필요한 경우
+    public CustomException(ErrorCode errorCode, String detail) {
+        // 부모 생성자에 에러 메시지를 전달하여 스택 트레이스에 포함되도록 함
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+        this.detail = detail;
+    }
+
+    // detail 정보가 필요 없는 경우
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+        this.detail = null; // detail은 null로 설정
+    }
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/global/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/exception/handler/GlobalExceptionHandler.java
@@ -1,0 +1,96 @@
+package com.kakaotech.team18.backend_server.global.exception.handler;
+
+import com.kakaotech.team18.backend_server.global.exception.code.ErrorCode;
+import com.kakaotech.team18.backend_server.global.exception.dto.ErrorResponseDto;
+import com.kakaotech.team18.backend_server.global.exception.exceptions.CustomException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+/**
+ * 애플리케이션 전역에서 발생하는 예외를 중앙에서 처리하는 클래스입니다.
+ *
+ * @RestControllerAdvice 어노테이션을 통해 모든 @RestController 에서 발생하는 예외를 감지 및 처리합니다.
+ */
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    /**
+     * CustomException 예외를 처리
+     * <p>
+     * CustomException 발생 시, 해당 예외의 ErrorCode와 detail을 사용하여 ErrorResponseDto를 생성하고, 적절한 HttpStatus와
+     * 함께 응답합니다.
+     *
+     * @return ErrorResponseDto와 해당 ErrorCode에 매핑된 HttpStatus를 포함하는 ResponseEntity
+     */
+    @ExceptionHandler(CustomException.class)
+    protected ResponseEntity<ErrorResponseDto> handleCustomException(final CustomException e) {
+
+        final ErrorCode errorCode = e.getErrorCode();
+        final String detail = e.getDetail();
+        final ErrorResponseDto response = (detail != null) ?
+                ErrorResponseDto.of(errorCode, detail) :
+                ErrorResponseDto.from(errorCode);
+
+        log.warn("handleCustomException: {} (detail: {})",
+                errorCode.getMessage(),
+                detail);
+
+        return new ResponseEntity<>(response, errorCode.getHttpStatus());
+    }
+
+    /**
+     * MethodArgumentNotValidException 예외를 처리
+     * <p>
+     * MethodArgumentNotValidException: @Valid 어노테이션을 사용한 DTO 유효성 검사 실패 시 발생
+     * <p>
+     * BindingResult 에서 유효성 검증 실패 정보를 가공 및 취합하여 ErrorResponseDto 형태로 반환합니다.
+     * <p>
+     *
+     * @return ErrorResponseDto와 해당 ErrorCode에 매핑된 HttpStatus를 포함하는 ResponseEntity
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    protected ResponseEntity<ErrorResponseDto> handleMethodArgumentNotValidException(
+            final MethodArgumentNotValidException e) {
+
+        // BindingResult 에서 유효성 검증 실패 정보를 가공
+        final BindingResult bindingResult = e.getBindingResult();
+        final StringBuilder sb = new StringBuilder();
+        for (final FieldError fieldError : bindingResult.getFieldErrors()) {
+            sb.append(fieldError.getField()).append(": ").append(fieldError.getDefaultMessage())
+                    .append(", ");
+        }
+        // 마지막 ", " 제거
+        final String detail = sb.substring(0, sb.length() - 2);
+
+        final ErrorCode errorCode = ErrorCode.INVALID_INPUT_VALUE;
+        final ErrorResponseDto response = ErrorResponseDto.of(errorCode, detail);
+
+        log.warn("MethodArgumentNotValidException: {} (detail: {})",
+                errorCode.getMessage(),
+                detail);
+
+        return new ResponseEntity<>(response, errorCode.getHttpStatus());
+    }
+
+    /**
+     * 모든 예상치 못한 예외를 처리
+     */
+
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<ErrorResponseDto> handleException(final Exception e) {
+
+        final ErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
+        final ErrorResponseDto response = ErrorResponseDto.from(errorCode);
+
+        log.error("Unhandled Exception : {}", errorCode.getMessage(), e);
+
+        return new ResponseEntity<>(response, errorCode.getHttpStatus());
+    }
+
+}

--- a/src/test/java/com/kakaotech/team18/backend_server/global/exception/handler/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/global/exception/handler/GlobalExceptionHandlerTest.java
@@ -10,6 +10,8 @@ import lombok.NoArgsConstructor;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.data.jpa.JpaRepositoriesAutoConfiguration;
+import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
@@ -27,10 +29,14 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-// excludeAutoConfiguration을 사용하여 Spring Security 자동 구성을 제외
-@WebMvcTest(excludeAutoConfiguration = SecurityAutoConfiguration.class)
+@WebMvcTest(
+    excludeAutoConfiguration = {
+        SecurityAutoConfiguration.class,
+        HibernateJpaAutoConfiguration.class,
+        JpaRepositoriesAutoConfiguration.class
+    }
+)
 @Import({GlobalExceptionHandler.class, GlobalExceptionHandlerTest.TestController.class})
-// 각 테스트 메소드 실행 후 컨텍스트를 초기화하여 테스트 간의 독립성 보장
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 class GlobalExceptionHandlerTest {
 

--- a/src/test/java/com/kakaotech/team18/backend_server/global/exception/handler/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/global/exception/handler/GlobalExceptionHandlerTest.java
@@ -1,0 +1,155 @@
+package com.kakaotech.team18.backend_server.global.exception.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kakaotech.team18.backend_server.global.exception.code.ErrorCode;
+import com.kakaotech.team18.backend_server.global.exception.exceptions.CustomException;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+// excludeAutoConfiguration을 사용하여 Spring Security 자동 구성을 제외
+@WebMvcTest(excludeAutoConfiguration = SecurityAutoConfiguration.class)
+@Import({GlobalExceptionHandler.class, GlobalExceptionHandlerTest.TestController.class})
+// 각 테스트 메소드 실행 후 컨텍스트를 초기화하여 테스트 간의 독립성 보장
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+class GlobalExceptionHandlerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    // 테스트를 위한 가짜 컨트롤러
+    @RestController
+    static class TestController {
+
+        // CustomException (detail 없음)
+        @GetMapping("/test/custom-exception-no-detail")
+        public void throwCustomExceptionNoDetail() {
+            throw new CustomException(ErrorCode.USER_ALREADY_EXISTS);
+        }
+
+        // CustomException (detail 있음)
+        @GetMapping("/test/custom-exception-with-detail")
+        public void throwCustomExceptionWithDetail() {
+            throw new CustomException(ErrorCode.USER_NOT_FOUND, "userId: 123");
+        }
+
+        // MethodArgumentNotValidException (@Valid 실패)
+        @PostMapping("/test/validation-Exception")
+        public void validateInput(@Valid @RequestBody TestDto testDto) {
+            // 이 메소드는 요청이 유효하면 아무것도 하지 않음
+        }
+
+        // 처리되지 않은 일반 예외
+        @GetMapping("/test/unhandled-exception")
+        public void throwUnhandledException() {
+            throw new RuntimeException("예상치 못한 에러 발생");
+        }
+    }
+
+    // MethodArgumentNotValidException (@Valid 실패) 테스트용 DTO
+    @Data
+    @NoArgsConstructor
+    static class TestDto {
+
+        @NotBlank(message = "이름은 비워둘 수 없습니다.")
+        private String name;
+    }
+
+    @Test
+    @DisplayName("CustomException 처리 테스트 (detail 없음)")
+    void handleCustomException_noDetail_test() throws Exception {
+        // given
+        final String url = "/test/custom-exception-no-detail";
+        final ErrorCode errorCode = ErrorCode.USER_ALREADY_EXISTS;
+
+        // when
+        ResultActions resultActions = mockMvc.perform(get(url)
+                .contentType(MediaType.APPLICATION_JSON));
+
+        // then
+        resultActions.andExpect(status().is(errorCode.getHttpStatus().value()))
+                .andExpect(jsonPath("$.errorCode").value(errorCode.getCode()))
+                .andExpect(jsonPath("$.message").value(errorCode.getMessage()))
+                .andExpect(jsonPath("$.detail").isEmpty()); // detail이 null 인지 확인
+    }
+
+    @Test
+    @DisplayName("CustomException 처리 테스트 (detail 있음)")
+    void handleCustomException_withDetail_test() throws Exception {
+        // given
+        final String url = "/test/custom-exception-with-detail";
+        final ErrorCode errorCode = ErrorCode.USER_NOT_FOUND;
+        final String detail = "userId: 123";
+
+        // when
+        ResultActions resultActions = mockMvc.perform(get(url)
+                .contentType(MediaType.APPLICATION_JSON));
+
+        // then
+        resultActions.andExpect(status().is(errorCode.getHttpStatus().value()))
+                .andExpect(jsonPath("$.errorCode").value(errorCode.getCode()))
+                .andExpect(jsonPath("$.message").value(errorCode.getMessage()))
+                .andExpect(jsonPath("$.detail").value(detail));
+    }
+
+    @Test
+    @DisplayName("@Valid 유효성 검사 실패 테스트")
+    void handleMethodArgumentNotValidException_test() throws Exception {
+        // given
+        final String url = "/test/validation-Exception";
+        final TestDto invalidDto = new TestDto(); // name을 null로 설정하여 @NotBlank 위반
+        final String requestBody = objectMapper.writeValueAsString(invalidDto);
+        final ErrorCode errorCode = ErrorCode.INVALID_INPUT_VALUE;
+
+        // when
+        ResultActions resultActions = mockMvc.perform(post(url)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody));
+
+        // then
+        resultActions.andExpect(status().is(errorCode.getHttpStatus().value()))
+                .andExpect(jsonPath("$.errorCode").value(errorCode.getCode()))
+                .andExpect(jsonPath("$.message").value(errorCode.getMessage()))
+                .andExpect(jsonPath("$.detail").value("name: 이름은 비워둘 수 없습니다."));
+    }
+
+    @Test
+    @DisplayName("처리되지 않은 일반 예외 테스트")
+    void handleException_test() throws Exception {
+        // given
+        final String url = "/test/unhandled-exception";
+        final ErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
+
+        // when
+        ResultActions resultActions = mockMvc.perform(get(url)
+                .contentType(MediaType.APPLICATION_JSON));
+
+        // then
+        resultActions.andExpect(status().is(errorCode.getHttpStatus().value()))
+                .andExpect(jsonPath("$.errorCode").value(errorCode.getCode()))
+                .andExpect(jsonPath("$.message").value(errorCode.getMessage()));
+    }
+}


### PR DESCRIPTION
## 🚀 작업 내용

애플리케이션 전역에서 발생하는 예외를 일관되게 처리하고, 클라이언트에게 표준화된 에러 응답을 제공하기 위한 기반 마련

**1. 전역 예외 처리 시스템 구축**
* `CustomException`: 모든 비즈니스 예외의 부모가 되는 커스텀 예외 클래스를 추가했습니다.
* `ErrorCode`: 예외 상황을 enum으로 정의하여 에러 코드, 메시지, HTTP 상태를 한 곳에서 관리합니다.
* `ErrorResponseDto`: 클라이언트에게 반환될 표준 에러 JSON의 형식을 정의했습니다.
* `GlobalExceptionHandler`: `@RestControllerAdvice`를 사용하여 `CustomException`, `@Valid` 유효성 검증 실패 등 다양한 예외를 감지하고, `ErrorResponseDto` 형식으로 변환하여 응답하도록 구현했습니다.

**2. 테스트 코드 작성**
* `@WebMvcTest`를 사용하여, 각 예외 시나리오별로 `GlobalExceptionHandler`가 의도한 대로 정확한 상태 코드와 응답을 반환하는지 검증하는 테스트 코드를 작성했습니다.

**3. JPA 충돌 관련 리팩토링**
* `@EnableJpaAuditing` 설정을 메인 클래스에서 `JpaAuditingConfig`로 분리했습니다. 이를 통해 DB 연결이 필요 없는 웹 계층 테스트(`@WebMvcTest`)의 격리 수준과 안정성을 높였습니다.

***
## 🤔 고민했던 내용

**1. `ErrorResponseDto`의 `detail` 필드 처리**
에러 응답 시 `detail` 정보가 없는 경우, `null`로 보낼지 또는 필드를 생략할지 고민했습니다. 현재는 `null`을 포함하도록 구현했으며, 추후 프론트엔드와의 협의를 통해 `null` 필드를 어떻게 할지 논의해볼 필요가 있습니다.

***
## 💬 리뷰 중점사항

* `ErrorCode`, `CustomException` 등 예외 처리 클래스들의 역할 분리가 명확하고 적절한지 검토 부탁드립니다.
* `ErrorResponseDto`의 `detail` 필드 처리(null)에 대해 같이 고민해주시면 감사하겠습니다.
* 새로 추가된 에러 코드나 클래스, 메소드의 네이밍이 팀 컨벤션에 맞고 가독성이 좋은지 함께 봐주시면 좋겠습니다.


## 🔗관련 이슈
- Close #11 