### PR TITLE
[FEATURE] 전역 예외 처리 설정 (#11)

### DIFF
--- a/src/main/java/com/kakaotech/team18/backend_server/global/exception/dto/ErrorResponseDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/exception/dto/ErrorResponseDto.java
@@ -1,11 +1,13 @@
 package com.kakaotech.team18.backend_server.global.exception.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.kakaotech.team18.backend_server.global.exception.code.ErrorCode;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ErrorResponseDto {
 
     private final String errorCode;

--- a/src/test/java/com/kakaotech/team18/backend_server/global/exception/handler/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/global/exception/handler/GlobalExceptionHandlerTest.java
@@ -1,5 +1,10 @@
 package com.kakaotech.team18.backend_server.global.exception.handler;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.kakaotech.team18.backend_server.global.exception.code.ErrorCode;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.CustomException;
@@ -24,17 +29,12 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 @WebMvcTest(
-    excludeAutoConfiguration = {
-        SecurityAutoConfiguration.class,
-        HibernateJpaAutoConfiguration.class,
-        JpaRepositoriesAutoConfiguration.class
-    }
+        excludeAutoConfiguration = {
+                SecurityAutoConfiguration.class,
+                HibernateJpaAutoConfiguration.class,
+                JpaRepositoriesAutoConfiguration.class
+        }
 )
 @Import({GlobalExceptionHandler.class, GlobalExceptionHandlerTest.TestController.class})
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
@@ -99,7 +99,7 @@ class GlobalExceptionHandlerTest {
         resultActions.andExpect(status().is(errorCode.getHttpStatus().value()))
                 .andExpect(jsonPath("$.errorCode").value(errorCode.getCode()))
                 .andExpect(jsonPath("$.message").value(errorCode.getMessage()))
-                .andExpect(jsonPath("$.detail").isEmpty()); // detail이 null 인지 확인
+                .andExpect(jsonPath("$.detail").doesNotExist());
     }
 
     @Test


### PR DESCRIPTION
## 🚀 작업 내용
ErrorResponseDto에 @JsonInclude(JsonInclude.Include.NON_NULL)을 적용 
이 변경으로, detail 필드와 같이 값이 null인 필드는 JSON 응답 본문에 포함되지 않습니다.


## 🤔 고민했던 내용


## 💬 리뷰 중점사항


## 🔗관련 이슈
- Close #11 