### PR TITLE
[FEATURE] 지원자 목록에서 특정 지원자 선택 시, 해당 지원서 페이지로 이동 (#31)

### DIFF
--- a/src/main/java/com/kakaotech/team18/backend_server/domain/application/controller/ApplicationController.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/application/controller/ApplicationController.java
@@ -1,0 +1,25 @@
+package com.kakaotech.team18.backend_server.domain.application.controller;
+
+import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationDetailResponseDto;
+import com.kakaotech.team18.backend_server.domain.application.service.ApplicationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class ApplicationController {
+
+    private final ApplicationService applicationService;
+
+    @GetMapping("/api/clubs/{clubId}/applicants/{applicantId}/application")
+    public ResponseEntity<ApplicationDetailResponseDto> getApplicationDetail(
+            @PathVariable("clubId") Long clubId,
+            @PathVariable("applicantId") Long applicantId
+    ) {
+        ApplicationDetailResponseDto applicationDetail = applicationService.getApplicationDetail(clubId, applicantId);
+        return ResponseEntity.ok(applicationDetail);
+    }
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/application/dto/ApplicationDetailResponseDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/application/dto/ApplicationDetailResponseDto.java
@@ -1,0 +1,27 @@
+package com.kakaotech.team18.backend_server.domain.application.dto;
+
+import java.util.List;
+
+// 지원자가 제출한 지원서의 상세 내용과 관련된 DTO
+public record ApplicationDetailResponseDto(
+    Long applicationId,
+    String status,
+    ApplicantInfo applicantInfo,
+    List<QuestionAndAnswer> questionsAndAnswers
+) {
+    public record ApplicantInfo(
+        Long applicantId,
+        String name,
+        String department,
+        String studentId,
+        String email,
+        String phoneNumber
+    ) {
+    }
+
+    public record QuestionAndAnswer(
+        String question,
+        String answer
+    ) {
+    }
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/application/entity/Application.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/application/entity/Application.java
@@ -15,8 +15,10 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Application extends BaseEntity {

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/application/repository/ApplicationRepository.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/application/repository/ApplicationRepository.java
@@ -1,0 +1,10 @@
+package com.kakaotech.team18.backend_server.domain.application.repository;
+
+import com.kakaotech.team18.backend_server.domain.application.entity.Application;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ApplicationRepository extends JpaRepository<Application, Long> {
+    Optional<Application> findByClub_IdAndUsers_Id(Long clubId, Long userId);
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/application/service/ApplicationService.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/application/service/ApplicationService.java
@@ -1,0 +1,7 @@
+package com.kakaotech.team18.backend_server.domain.application.service;
+
+import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationDetailResponseDto;
+
+public interface ApplicationService {
+    ApplicationDetailResponseDto getApplicationDetail(Long clubId, Long applicantId);
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/application/service/ApplicationServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/application/service/ApplicationServiceImpl.java
@@ -1,0 +1,59 @@
+package com.kakaotech.team18.backend_server.domain.application.service;
+
+import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationDetailResponseDto;
+import com.kakaotech.team18.backend_server.domain.application.entity.Application;
+import com.kakaotech.team18.backend_server.domain.application.repository.ApplicationRepository;
+import com.kakaotech.team18.backend_server.domain.applicationFormAnswer.entity.ApplicationFormAnswer;
+import com.kakaotech.team18.backend_server.domain.applicationFormAnswer.repository.ApplicationFormAnswerRepository;
+import com.kakaotech.team18.backend_server.domain.user.entity.Users;
+import com.kakaotech.team18.backend_server.global.exception.exceptions.ApplicationNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ApplicationServiceImpl implements ApplicationService {
+
+    private final ApplicationRepository applicationRepository;
+    private final ApplicationFormAnswerRepository applicationFormAnswerRepository;
+
+    @Override
+    public ApplicationDetailResponseDto getApplicationDetail(Long clubId, Long applicantId) {
+        // 1. clubId와 applicantId로 지원서 조회 (없으면 ApplicationNotFoundException 예외 발생)
+        Application application = applicationRepository.findByClub_IdAndUsers_Id(clubId, applicantId)
+                .orElseThrow(() -> new ApplicationNotFoundException("clubId=" + clubId + ", applicantId=" + applicantId));
+
+        // 2. 지원자 정보(ApplicantInfo) DTO 생성
+        Users applicant = application.getUsers();
+        ApplicationDetailResponseDto.ApplicantInfo applicantInfo = new ApplicationDetailResponseDto.ApplicantInfo(
+                applicant.getId(),
+                applicant.getName(),
+                applicant.getDepartment(),
+                applicant.getStudentId(),
+                applicant.getEmail(),
+                applicant.getPhoneNumber()
+        );
+
+        // 3. 질문 및 답변(QuestionAndAnswer) DTO 리스트 생성
+        List<ApplicationFormAnswer> answers = applicationFormAnswerRepository.findByApplicationWithFormField(application);
+        List<ApplicationDetailResponseDto.QuestionAndAnswer> questionsAndAnswers = answers.stream()
+                .map(answer -> new ApplicationDetailResponseDto.QuestionAndAnswer(
+                        answer.getApplicationFormField().getQuestion(),
+                        answer.getAnswer()
+                ))
+                .collect(Collectors.toList());
+
+        // 4. 최종 응답 DTO 조립 및 반환
+        return new ApplicationDetailResponseDto(
+                application.getId(),
+                application.getStatus().name(),
+                applicantInfo,
+                questionsAndAnswers
+        );
+    }
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/applicationFormAnswer/entity/ApplicationFormAnswer.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/applicationFormAnswer/entity/ApplicationFormAnswer.java
@@ -12,8 +12,10 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ApplicationFormAnswer extends BaseEntity {

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/applicationFormAnswer/repository/ApplicationFormAnswerRepository.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/applicationFormAnswer/repository/ApplicationFormAnswerRepository.java
@@ -1,0 +1,19 @@
+package com.kakaotech.team18.backend_server.domain.applicationFormAnswer.repository;
+
+import com.kakaotech.team18.backend_server.domain.application.entity.Application;
+import com.kakaotech.team18.backend_server.domain.applicationFormAnswer.entity.ApplicationFormAnswer;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface ApplicationFormAnswerRepository extends JpaRepository<ApplicationFormAnswer, Long> {
+    @Query("""
+           SELECT afa 
+           FROM ApplicationFormAnswer afa 
+           JOIN FETCH afa.applicationFormField 
+           WHERE afa.application = :application
+           """)
+    List<ApplicationFormAnswer> findByApplicationWithFormField(@Param("application") Application application);
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/applicationFormField/entity/ApplicationFormField.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/applicationFormField/entity/ApplicationFormField.java
@@ -13,8 +13,10 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ApplicationFormField extends BaseEntity {

--- a/src/main/java/com/kakaotech/team18/backend_server/global/exception/code/ErrorCode.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/exception/code/ErrorCode.java
@@ -30,6 +30,7 @@ public enum ErrorCode {
     // 404 NOT_FOUND: 리소스를 찾을 수 없음
     USER_NOT_FOUND("해당 유저가 존재하지 않습니다.", HttpStatus.NOT_FOUND),
     CLUB_NOT_FOUND("해당 동아리가 존재하지 않습니다.", HttpStatus.NOT_FOUND),
+    APPLICATION_NOT_FOUND("해당 지원서를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
 
     // 409 CONFLICT: 리소스 충돌
     USER_ALREADY_EXISTS("이미 존재하는 유저입니다.", HttpStatus.CONFLICT),

--- a/src/main/java/com/kakaotech/team18/backend_server/global/exception/exceptions/ApplicationNotFoundException.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/exception/exceptions/ApplicationNotFoundException.java
@@ -1,0 +1,10 @@
+package com.kakaotech.team18.backend_server.global.exception.exceptions;
+
+import com.kakaotech.team18.backend_server.global.exception.code.ErrorCode;
+
+public class ApplicationNotFoundException extends CustomException {
+
+    public ApplicationNotFoundException(String detail) {
+        super(ErrorCode.APPLICATION_NOT_FOUND, detail);
+    }
+}

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/application/controller/ApplicationControllerTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/application/controller/ApplicationControllerTest.java
@@ -1,0 +1,86 @@
+package com.kakaotech.team18.backend_server.domain.application.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationDetailResponseDto;
+import com.kakaotech.team18.backend_server.domain.application.service.ApplicationService;
+import com.kakaotech.team18.backend_server.global.exception.code.ErrorCode;
+import com.kakaotech.team18.backend_server.global.exception.exceptions.ApplicationNotFoundException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.util.Collections;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ApplicationController.class)
+class ApplicationControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private ApplicationService applicationService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("지원서 상세 조회 컨트롤러 - 성공")
+    void getApplicationDetail_success() throws Exception {
+        // given
+        Long clubId = 1L;
+        Long applicantId = 1L;
+
+        ApplicationDetailResponseDto.ApplicantInfo applicantInfo = new ApplicationDetailResponseDto.ApplicantInfo(
+                applicantId, "김지원", "컴퓨터공학과", "20230001", "test@test.com", "010-1234-5678"
+        );
+        ApplicationDetailResponseDto responseDto = new ApplicationDetailResponseDto(
+                100L, "PENDING", applicantInfo, Collections.emptyList()
+        );
+
+        given(applicationService.getApplicationDetail(clubId, applicantId)).willReturn(responseDto);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                get("/api/clubs/{clubId}/applicants/{applicantId}/application", clubId, applicantId)
+                        .accept(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.applicationId").value(100L))
+                .andExpect(jsonPath("$.status").value("PENDING"))
+                .andExpect(jsonPath("$.applicantInfo.name").value("김지원"))
+                .andExpect(jsonPath("$.applicantInfo.department").value("컴퓨터공학과"));
+    }
+
+    @Test
+    @DisplayName("지원서 상세 조회 컨트롤러 - 실패 (지원서 없음)")
+    void getApplicationDetail_fail_applicationNotFound() throws Exception {
+        // given
+        Long clubId = 1L;
+        Long nonExistentApplicantId = 999L;
+
+        given(applicationService.getApplicationDetail(clubId, nonExistentApplicantId))
+                .willThrow(new ApplicationNotFoundException("detail message for test"));
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                get("/api/clubs/{clubId}/applicants/{applicantId}/application", clubId, nonExistentApplicantId)
+                        .accept(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        resultActions.andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error_code").value(ErrorCode.APPLICATION_NOT_FOUND.name()));
+    }
+}

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/application/service/ApplicationServiceImplTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/application/service/ApplicationServiceImplTest.java
@@ -1,0 +1,124 @@
+package com.kakaotech.team18.backend_server.domain.application.service;
+
+import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationDetailResponseDto;
+import com.kakaotech.team18.backend_server.domain.application.entity.Application;
+import com.kakaotech.team18.backend_server.domain.application.entity.Status;
+import com.kakaotech.team18.backend_server.domain.application.repository.ApplicationRepository;
+import com.kakaotech.team18.backend_server.domain.applicationFormAnswer.entity.ApplicationFormAnswer;
+import com.kakaotech.team18.backend_server.domain.applicationFormAnswer.repository.ApplicationFormAnswerRepository;
+import com.kakaotech.team18.backend_server.domain.applicationFormField.entity.ApplicationFormField;
+import com.kakaotech.team18.backend_server.domain.user.entity.Users;
+import com.kakaotech.team18.backend_server.global.exception.exceptions.ApplicationNotFoundException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ApplicationServiceImplTest {
+
+    @InjectMocks
+    private ApplicationServiceImpl applicationService;
+
+    @Mock
+    private ApplicationRepository applicationRepository;
+
+    @Mock
+    private ApplicationFormAnswerRepository applicationFormAnswerRepository;
+
+    @Test
+    @DisplayName("지원서 상세 조회 - 성공")
+    void getApplicationDetail_success() {
+        // given
+        Long clubId = 1L;
+        Long applicantId = 1L;
+
+        // Mock 객체 생성
+        Users mockUser = Users.builder()
+                .name("김지원")
+                .department("컴퓨터공학과")
+                .studentId("20230001")
+                .email("test@test.com")
+                .phoneNumber("010-1234-5678")
+                .build();
+
+        // 리플렉션을 사용해 ID 강제 주입
+        try {
+            java.lang.reflect.Field idField = Users.class.getDeclaredField("id");
+            idField.setAccessible(true);
+            idField.set(mockUser, applicantId);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        Application mockApplication = mock(Application.class);
+        ApplicationFormField mockField1 = mock(ApplicationFormField.class);
+        ApplicationFormField mockField2 = mock(ApplicationFormField.class);
+        ApplicationFormAnswer mockAnswer1 = mock(ApplicationFormAnswer.class);
+        ApplicationFormAnswer mockAnswer2 = mock(ApplicationFormAnswer.class);
+
+        // Repository Mocking 설정
+        when(applicationRepository.findByClub_IdAndUsers_Id(clubId, applicantId)).thenReturn(Optional.of(mockApplication));
+        when(applicationFormAnswerRepository.findByApplicationWithFormField(mockApplication)).thenReturn(List.of(mockAnswer1, mockAnswer2));
+
+        // Application Mocking 설정
+        when(mockApplication.getId()).thenReturn(100L);
+        when(mockApplication.getStatus()).thenReturn(Status.PENDING);
+        when(mockApplication.getUsers()).thenReturn(mockUser);
+
+        // Answer 및 Field Mocking 설정
+        when(mockAnswer1.getApplicationFormField()).thenReturn(mockField1);
+        when(mockField1.getQuestion()).thenReturn("질문 1");
+        when(mockAnswer1.getAnswer()).thenReturn("답변 1");
+
+        when(mockAnswer2.getApplicationFormField()).thenReturn(mockField2);
+        when(mockField2.getQuestion()).thenReturn("질문 2");
+        when(mockAnswer2.getAnswer()).thenReturn("답변 2");
+
+        // when
+        ApplicationDetailResponseDto result = applicationService.getApplicationDetail(clubId, applicantId);
+
+        // then
+        assertNotNull(result);
+        assertEquals(100L, result.applicationId());
+        assertEquals("PENDING", result.status());
+        assertEquals(applicantId, result.applicantInfo().applicantId());
+        assertEquals("김지원", result.applicantInfo().name());
+        assertEquals("컴퓨터공학과", result.applicantInfo().department());
+        assertEquals(2, result.questionsAndAnswers().size());
+        assertEquals("질문 1", result.questionsAndAnswers().get(0).question());
+        assertEquals("답변 1", result.questionsAndAnswers().get(0).answer());
+
+        // verify: 메소드가 정확히 1번씩 호출되었는지 검증
+        verify(applicationRepository, times(1)).findByClub_IdAndUsers_Id(clubId, applicantId);
+        verify(applicationFormAnswerRepository, times(1)).findByApplicationWithFormField(mockApplication);
+    }
+
+    @Test
+    @DisplayName("지원서 상세 조회 - 실패 (지원서 없음)")
+    void getApplicationDetail_fail_applicationNotFound() {
+        // given
+        Long clubId = 1L;
+        Long nonExistentApplicantId = 999L;
+        when(applicationRepository.findByClub_IdAndUsers_Id(clubId, nonExistentApplicantId)).thenReturn(Optional.empty());
+
+        // when & then
+        ApplicationNotFoundException exception = assertThrows(ApplicationNotFoundException.class, () -> {
+            applicationService.getApplicationDetail(clubId, nonExistentApplicantId);
+        });
+        
+        assertEquals("clubId=1, applicantId=999", exception.getDetail());
+
+        // verify
+        verify(applicationRepository, times(1)).findByClub_IdAndUsers_Id(clubId, nonExistentApplicantId);
+        verify(applicationFormAnswerRepository, never()).findByApplicationWithFormField(any(Application.class));
+    }
+}


### PR DESCRIPTION
### **🚀 작업 내용**

**[FEATURE] 지원자 목록에서 특정 지원자 선택 시, 해당 지원서 페이지로 이동 기능 구현**

변경된 API 명세에 따라, 특정 동아리의 특정 지원자에 대한 지원서 상세 정보를 조회하는 기능을 구현했습니다.
변경된 API 명세는 아래 사진으로 첨부했습니다.

- **API 엔드포인트 구현**
    - `GET /api/clubs/{clubId}/applicants/{applicantId}/application`
- **계층별 구현 상세**
    - **Controller**: `ApplicationController`를 생성하여 API 요청을 수신하고 서비스 계층으로 처리를 위임합니다.
    - **Service**: `ApplicationServiceImpl`에서 실제 비즈니스 로직을 처리합니다.
        - Repository에서 데이터를 조회하고, API 응답 형식에 맞게 DTO로 가공합니다.
        - 지원서가 존재하지 않을 경우, 정의된 예외(`ApplicationNotFoundException`)를 발생시킵니다.
    - **Repository**:
        - `ApplicationRepository`: `clubId`와 `applicantId`로 지원서를 조회하는 쿼리 메소드를 추가했습니다.
        - `ApplicationFormAnswerRepository`: N+1 문제 해결을 위해 **JOIN FETCH**를 사용하는 커스텀 쿼리(`@Query`)를 추가했습니다.
    - **DTO**:
        - `ApplicationDetailResponseDto`를 `record`와 중첩 레코드를 사용하여 불변성을 보장하고 가독성을 높였습니다.
    - **Exception**:
        - `ErrorCode`에 `APPLICATION_NOT_FOUND`를 추가하고, 이를 사용하는 `ApplicationNotFoundException`을 구현하여 일관된 예외 처리 기반을 마련했습니다.
    - **Test**:
        - **단위 테스트**: `ApplicationServiceImplTest`에서 Repository를 Mocking하여 서비스 로직의 정확성(데이터 조합, 예외 발생)을 검증했습니다.
        - **통합 테스트**: `ApplicationControllerTest`에서 `MockMvc`를 사용하여 API의 성공(200 OK) 및 실패(404 Not Found) 시나리오를 검증했습니다.

---

## ⏱️ 소요 시간
6h 30m

---

### **🤔 고민했던 내용**

#### **1. N+1 문제 해결**

- 지원서의 답변 목록을 조회한 후, 각 답변에 매핑된 질문을 가져오기 위해 루프를 도는 과정에서 N+1 쿼리 문제가 발생할 수 있었습니다.
- 이를 해결하기 위해 `ApplicationFormAnswerRepository`에 단순 쿼리 메소드 대신, **`JOIN FETCH`** 를 명시한 `@Query`를 사용하여 연관된 `ApplicationFormField`(질문)까지 단 한 번의 쿼리로 함께 조회하도록 개선했습니다. 이를 통해 불필요한 데이터베이스 접근을 최소화하고 성능을 확보했습니다.

#### **2. 일관성 있는 예외 처리 구조 활용**

- 기존 구조에 맞춰 `ErrorCode`에 `APPLICATION_NOT_FOUND`를 추가하고, `CustomException`을 상속받는 `ApplicationNotFoundException`을 구현함으로써, 프로젝트 전체의 예외 처리 일관성을 유지했습니다.

#### **3. 테스트 코드에서 Entity의 id를 다루는 방법**

- 단위 테스트(`ApplicationServiceImplTest`)에서 `id`를 가진 `Users` 목(Mock) 객체를 생성해야 했습니다.
- 하지만 `Users` 엔티티의 `@Builder`는 `id` 필드를 포함하지 않았는데, 이는 `id`가 DB에 의해 자동 생성되는 값이라는 프로덕션 코드의 올바른 설계 의도를 반영한 것이었습니다.
- 프로덕션 코드의 설계를 훼손하지 않으면서 테스트의 목적을 달성하기 위해, **리플렉션(Reflection)**을 사용하여 테스트 코드 내에서만 `private` 필드인 `id`에 값을 강제로 주입하는 방식을 채택했습니다. 이를 통해 테스트의 정확성과 프로덕션 코드의 안정성을 모두 지킬 수 있었습니다.

---

### **💬 리뷰 중점사항**

- **N+1 해결 방식의 적절성**: `ApplicationFormAnswerRepository`에 작성된 `JOIN FETCH` 쿼리가 성능 문제를 효과적으로 해결하는 최적의 방법인지 검토 부탁드립니다.
- **서비스 계층의 역할과 책임**: `ApplicationServiceImpl`이 데이터를 조회하고 DTO로 변환하는 역할에 충실하게 작성되었는지, 로직이 명확하고 간결한지 확인 부탁드립니다.
- **테스트 코드의 신뢰성**:
    - `ApplicationServiceImplTest`에서 리플렉션을 사용한 부분

---

### 🔗관련 이슈
- Close #31
---
<img width="926" height="1320" alt="image" src="https://github.com/user-attachments/assets/04597d44-726e-4dc6-9c4b-5cd86798969a" />
