### PR TITLE
[REFACTOR] GitHub Actions 파이프라인 CI/CD 별로 분리 (#21)

### DIFF
--- a/.github/workflows/GithubPrNotification.yml
+++ b/.github/workflows/GithubPrNotification.yml
@@ -1,7 +1,7 @@
 name: Pull Request Discord Notification
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, closed]
 
 jobs:

--- a/.github/workflows/cd-on-merge.yml
+++ b/.github/workflows/cd-on-merge.yml
@@ -1,24 +1,40 @@
-name: Deploy To Ec2 when Merge to Develop Branch
+name: CD on Merge to develop
 
 on:
   push:
     branches: [develop]
+  workflow_dispatch: {}
+
+concurrency:
+  group: cd-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    steps:
-      - name: Github Repository 파일 불러오기
-        uses: actions/checkout@v4
 
-      - name: JDK 21버전 설치
-        uses: actions/setup-java@v4
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: 21
 
-      - name: application.yml 파일 만들기
-        run: echo "${{ secrets.APPLICATION_YML }}" > ./src/main/resources/application.yml
+      - name: application.yml from secret
+        run: |
+          mkdir -p ./src/main/resources
+          cat > ./src/main/resources/application.yml <<'YAML'
+          ${{ secrets.APPLICATION_YML }}
+          YAML
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: ${{ runner.os }}-gradle-
 
       - name: 테스트 및 빌드하기
         run: ./gradlew clean build

--- a/.github/workflows/ci-on-pr.yml
+++ b/.github/workflows/ci-on-pr.yml
@@ -1,0 +1,52 @@
+name: CI on PR (build & test)
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [develop]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    # 위에 synchronize가 pr에 commit이 추가될 때마다 돌아간다는 의미인데, job이 동시에 동작하지 않도록 함
+    concurrency:
+      group: ci-${{ github.event.pull_request.head.sha }}
+      # 마지막 커밋 기준으로 작동
+      cancel-in-progress: true
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+
+      # 캐시를 사용해 이전 Gradle 의존성을 다시 사용하도록 함 (속도 향상을 위함)
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: ${{ runner.os }}-gradle-
+
+      # 테스트용 yml을 임시 생성(H2)
+      - name: application-test.yml (temp)
+        run: |
+          mkdir -p ./src/main/resources
+          cat > ./src/main/resources/application-test.yml <<'YAML'
+          spring:
+            datasource:
+              url: jdbc:h2:mem:testdb;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+              driver-class-name: org.h2.Driver
+              username: sa
+              password:
+            jpa:
+              hibernate.ddl-auto: create
+              properties.hibernate.format_sql: true
+          YAML
+
+      # 테스트 프로필로 빌드/테스트
+      - name: Build & Test
+        run: SPRING_PROFILES_ACTIVE=test ./gradlew clean build


### PR DESCRIPTION
## 🚀 작업 내용
PR 이후에야 테스트가 통과하는지 알 수 있어 불편을 겪는 것 같아 CI 파이프라인과 CD 파이프라인을 분리했습니다. 

- develop 브랜치에 PR을 하면 ci-on-pr.yml 파이프라인이 동작합니다.
-  PR이 머지돼 push가 일어나면 cd-on-merge.yml 파이프라인이 동작합니다.
- 이슈는 따로 등록하지 않았는데 등록하는게 좋을까요? 

## ⏱️ 소요 시간
15분

## 🤔 고민했던 내용
CI 파이프라인 작동시 테스트를 진행해야 하는데 GPT가 application.yml 파일을 테스트 전용으로 GitHub Actions 내부에 스크립트로 작성하는 것을 추천해줘 해당 방법을 사용해봤습니다. 

merge 됐을 때는 기존 처럼 prod 프로필이 작동됩니다. 


## 💬 리뷰 중점사항


## 🔗관련 이슈
- Close #21 