### PR TITLE
[FEATURE] 지원하기 버튼 클릭부터 지원완료까지

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,29 @@
+language: "ko-KR"
+early_access: false
+
+reviews:
+  profile: "assertive"
+  request_changes_workflow: true
+  high_level_summary: true
+  review_status: true
+  collapse_walkthrough: true
+
+  auto_review:
+    enabled: true
+    drafts: false
+    base_branches: ["develop"]
+
+  path_filters:
+    - "**/src/**"
+    - "pom.xml"
+    - "build.gradle*"
+    - "!**/build/**"
+    - "!**/target/**"
+
+  path_instructions:
+    - path: "src/main/java/**/*.java"
+      instructions: |
+        - import 와일드카드(`import java.util.*`) 사용 금지.
+    - path: "src/test/java/**/*.java"
+      instructions: |
+        - 단위테스트(UnitTest)와 통합테스트(IntegrationTest)를 명확히 분리.

--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,11 @@ dependencies {
     // validation 관련 의존성 추가
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+    // SMTP 전송 (JavaMailSender)
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
+    // Thymeleaf 템플릿 렌더링(나중에 제거할 것)
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+
     // 테스트 코드에서 Lombok 사용을 위한 의존성 추가
     testCompileOnly 'org.projectlombok:lombok'
     testAnnotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/Answer/entity/Answer.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/Answer/entity/Answer.java
@@ -34,4 +34,14 @@ public class Answer extends BaseEntity {
     private FormQuestion formQuestion;
 
     private String answer;
+
+    private Answer(Application application, FormQuestion formQuestion, String answer) {
+        this.application = application;
+        this.formQuestion = formQuestion;
+        this.answer = answer;
+    }
+
+    public static Answer of(Application application, FormQuestion formQuestion, String answer) {
+        return new Answer(application, formQuestion, answer);
+    }
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/Answer/repository/AnswerRepository.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/Answer/repository/AnswerRepository.java
@@ -16,4 +16,6 @@ public interface AnswerRepository extends JpaRepository<Answer, Long> {
            WHERE afa.application = :application
            """)
     List<Answer> findByApplicationWithFormQuestion(@Param("application") Application application);
+
+    void deleteByApplication(Application application);
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/FormQuestion/repository/FormQuestionRepository.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/FormQuestion/repository/FormQuestionRepository.java
@@ -9,4 +9,6 @@ import java.util.List;
 @Repository
 public interface FormQuestionRepository extends JpaRepository<FormQuestion,Long> {
     List<FormQuestion> findByClubApplyFormIdOrderByDisplayOrderAsc(Long clubApplyFormId);
+
+    List<FormQuestion> findByClubApplyFormIdOrderByIdAsc(Long formId);
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/application/controller/ApplicationController.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/application/controller/ApplicationController.java
@@ -1,16 +1,21 @@
 package com.kakaotech.team18.backend_server.domain.application.controller;
 
+import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationApplyRequestDto;
+import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationApplyResponseDto;
 import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationDetailResponseDto;
 import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationStatusUpdateRequestDto;
 import com.kakaotech.team18.backend_server.domain.application.service.ApplicationService;
 import com.kakaotech.team18.backend_server.global.dto.SuccessResponseDto;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -35,5 +40,24 @@ public class ApplicationController {
     ) {
         SuccessResponseDto responseDto = applicationService.updateApplicationStatus(applicationId, requestDto);
         return ResponseEntity.ok(responseDto);
+    }
+
+    @PostMapping("/api/clubs/{clubId}/apply-submit")
+    public ResponseEntity<?> submitApplication(
+            @PathVariable("clubId") Long clubId,
+            @Valid @RequestBody ApplicationApplyRequestDto request,
+            @RequestParam(value = "overwrite", defaultValue = "false" ) boolean confirmOverwrite
+    ){
+        ApplicationApplyResponseDto response = applicationService.submitApplication(
+                clubId,
+                request,
+                confirmOverwrite
+        );
+
+        if(response.requiresConfirmation()){
+            return ResponseEntity.status(HttpStatus.ACCEPTED).body(response);//기존 응답이 있어서 확인
+        } else {
+            return ResponseEntity.status(HttpStatus.CREATED).body(response);//기존 응답이 없어서 바로 제출
+        }
     }
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/application/dto/ApplicationApplyRequestDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/application/dto/ApplicationApplyRequestDto.java
@@ -1,0 +1,28 @@
+package com.kakaotech.team18.backend_server.domain.application.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+import java.util.List;
+
+public record ApplicationApplyRequestDto(
+
+        @NotBlank(message = "학번은 필수입니다.")
+        String studentId,
+
+        @NotBlank(message = "이메일은 필수입니다.")
+        @Email(message = "유효한 이메일 형식이 아닙니다.")
+        String email,
+
+        @NotBlank(message = "이름은 필수입니다.")
+        String name,
+
+        @NotBlank(message = "전화번호는 필수입니다.")
+        String phoneNumber,
+
+        @NotBlank(message = "학과는 필수입니다.")
+        String department,
+
+        List<String> answerList
+) {
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/application/dto/ApplicationApplyResponseDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/application/dto/ApplicationApplyResponseDto.java
@@ -1,0 +1,10 @@
+package com.kakaotech.team18.backend_server.domain.application.dto;
+
+import java.time.LocalDateTime;
+
+public record ApplicationApplyResponseDto(
+        String studentId,
+        LocalDateTime submittedAt,
+        Boolean requiresConfirmation
+) {
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/application/dto/ApplicationApplyResponseDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/application/dto/ApplicationApplyResponseDto.java
@@ -1,7 +1,10 @@
 package com.kakaotech.team18.backend_server.domain.application.dto;
 
+import lombok.Builder;
+
 import java.time.LocalDateTime;
 
+@Builder
 public record ApplicationApplyResponseDto(
         String studentId,
         LocalDateTime submittedAt,

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/application/entity/Application.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/application/entity/Application.java
@@ -51,6 +51,13 @@ public class Application extends BaseEntity {
         this.averageRating = 0.0;
     }
 
+    public Application(User user, ClubApplyForm form) {
+        this.user = user;
+        this.clubApplyForm = form;
+        this.averageRating = 0.0;
+    }
+
+
     /**
      * 지원서의 상태를 변경합니다.
      * 이 메소드는 서비스 계층에서 트랜잭션 내에서 호출되어야 합니다.

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/application/repository/ApplicationRepository.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/application/repository/ApplicationRepository.java
@@ -3,6 +3,10 @@ package com.kakaotech.team18.backend_server.domain.application.repository;
 import com.kakaotech.team18.backend_server.domain.application.entity.Application;
 import com.kakaotech.team18.backend_server.domain.application.entity.Status;
 import java.util.List;
+
+import com.kakaotech.team18.backend_server.domain.clubApplyForm.entity.ClubApplyForm;
+import com.kakaotech.team18.backend_server.domain.user.entity.User;
+import jakarta.validation.constraints.NotBlank;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -18,4 +22,12 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
             where app.clubApplyForm.id = :clubApplyFormId and app.status = :status
             """)
     List<Application> findByClubApplyFormIdAndStatus(Long clubApplyFormId, Status status);
+
+    @Query("""
+            select a 
+            from Application a
+            join a.user u 
+            where u.studentId = :studentId and a.clubApplyForm = :form
+            """)
+    Optional<Application> findByUserAndClubApplyForm(String studentId, ClubApplyForm form);
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/application/service/ApplicationService.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/application/service/ApplicationService.java
@@ -1,11 +1,16 @@
 package com.kakaotech.team18.backend_server.domain.application.service;
 
+import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationApplyRequestDto;
+import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationApplyResponseDto;
 import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationDetailResponseDto;
 import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationStatusUpdateRequestDto;
 import com.kakaotech.team18.backend_server.global.dto.SuccessResponseDto;
+import jakarta.validation.Valid;
 
 public interface ApplicationService {
     ApplicationDetailResponseDto getApplicationDetail(Long clubId, Long applicantId);
 
     SuccessResponseDto updateApplicationStatus(Long applicationId, ApplicationStatusUpdateRequestDto requestDto);
+
+    ApplicationApplyResponseDto submitApplication(Long clubId, @Valid ApplicationApplyRequestDto request, boolean confirmOverwrite);
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/application/service/ApplicationServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/application/service/ApplicationServiceImpl.java
@@ -18,6 +18,7 @@ import com.kakaotech.team18.backend_server.global.dto.SuccessResponseDto;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.ApplicationFormNotFoundException;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.ApplicationNotFoundException;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.ClubApplyFormNotFoundException;
+import com.kakaotech.team18.backend_server.global.exception.exceptions.InvalidAnswerException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/club/entity/Club.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/club/entity/Club.java
@@ -77,5 +77,4 @@ public class Club extends BaseEntity {
             return "모집중";
         }
     }
-
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/entity/ClubApplyForm.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/entity/ClubApplyForm.java
@@ -38,7 +38,7 @@ public class ClubApplyForm extends BaseEntity {
     private boolean isActive;
 
     @Builder
-    private ClubApplyForm(Club club, String title, String description, boolean isActive) {
+    public ClubApplyForm(Club club, String title, String description, boolean isActive) {
         this.club = club;
         this.title = title;
         this.description = description;

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/repository/ClubMemberRepository.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/repository/ClubMemberRepository.java
@@ -1,11 +1,17 @@
 package com.kakaotech.team18.backend_server.domain.clubMember.repository;
 
+import com.kakaotech.team18.backend_server.domain.clubMember.entity.ActiveStatus;
 import com.kakaotech.team18.backend_server.domain.clubMember.entity.ClubMember;
 import com.kakaotech.team18.backend_server.domain.clubMember.entity.Role;
+import com.kakaotech.team18.backend_server.domain.user.entity.User;
+
 import java.util.List;
 import java.util.Optional;
+
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ClubMemberRepository extends JpaRepository<ClubMember, Long> {
 
@@ -24,4 +30,17 @@ public interface ClubMemberRepository extends JpaRepository<ClubMember, Long> {
             where cm.club.id = :clubId and cm.role = :role
             """)
     Optional<ClubMember> findClubAdminByClubIdAndRole(Long clubId, Role role);
+
+    @Query("""
+        select cm.user
+        from ClubMember cm
+        where cm.club.id = :clubId
+          and cm.role = :role
+          and cm.activeStatus = :status
+        """)
+    java.util.Optional<User> findUserByClubIdAndRoleAndStatus(
+            @Param("clubId") Long clubId,
+            @Param("role") Role role,
+            @Param("status") ActiveStatus status
+    );
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/email/connfig/MailConfig.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/email/connfig/MailConfig.java
@@ -21,9 +21,6 @@ public class MailConfig {
         sender.setUsername(username);
         sender.setPassword(password);
 
-        var props = sender.getJavaMailProperties();
-        props.put("mail.smtp.auth", "true");
-        props.put("mail.smtp.starttls.enable", "true");
         return sender;
     }
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/email/connfig/MailConfig.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/email/connfig/MailConfig.java
@@ -1,0 +1,29 @@
+package com.kakaotech.team18.backend_server.domain.email.connfig;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+
+@Configuration
+public class MailConfig {
+
+    @Bean
+    public JavaMailSender javaMailSender(
+            @Value("${spring.mail.host}") String host,
+            @Value("${spring.mail.port}") int port,
+            @Value("${spring.mail.username}") String username,
+            @Value("${spring.mail.password}") String password
+    ) {
+        var sender = new org.springframework.mail.javamail.JavaMailSenderImpl();
+        sender.setHost(host);
+        sender.setPort(port);
+        sender.setUsername(username);
+        sender.setPassword(password);
+
+        var props = sender.getJavaMailProperties();
+        props.put("mail.smtp.auth", "true");
+        props.put("mail.smtp.starttls.enable", "true");
+        return sender;
+    }
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/email/dto/AnswerEmailLine.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/email/dto/AnswerEmailLine.java
@@ -1,0 +1,3 @@
+package com.kakaotech.team18.backend_server.domain.email.dto;
+
+public record AnswerEmailLine(Long questionId, Long displayOrder, String question, String answer) {}

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/email/dto/ApplicationSubmittedEvent.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/email/dto/ApplicationSubmittedEvent.java
@@ -1,0 +1,8 @@
+package com.kakaotech.team18.backend_server.domain.email.dto;
+
+import java.util.List;
+
+public record ApplicationSubmittedEvent(
+        Long applicationId,
+        List<AnswerEmailLine> emailLines
+) {}

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/email/eventListener/ApplicationNotificationListener.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/email/eventListener/ApplicationNotificationListener.java
@@ -1,0 +1,27 @@
+package com.kakaotech.team18.backend_server.domain.email.eventListener;
+
+import com.kakaotech.team18.backend_server.domain.application.entity.Application;
+import com.kakaotech.team18.backend_server.domain.application.repository.ApplicationRepository;
+import com.kakaotech.team18.backend_server.domain.email.dto.ApplicationSubmittedEvent;
+import com.kakaotech.team18.backend_server.domain.email.service.EmailService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class ApplicationNotificationListener {
+
+    private final ApplicationRepository applicationRepository;
+    private final EmailService emailService;
+
+    // 트랜잭션이 커밋된 뒤에만 이 메서드가 호출됨
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onSubmitted(ApplicationSubmittedEvent event) {
+        Application application = applicationRepository.findById(event.applicationId()).orElse(null);
+        if (application == null) return;
+
+        emailService.sendToApplicant(application, event.emailLines());
+    }
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/email/sender/EmailSender.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/email/sender/EmailSender.java
@@ -1,0 +1,8 @@
+package com.kakaotech.team18.backend_server.domain.email.sender;
+
+import java.util.List;
+
+
+public interface EmailSender {
+    void sendHtml(String from, String replyTo, List<String> to, String subject, String htmlBody);
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/email/sender/SmtpEmailSender.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/email/sender/SmtpEmailSender.java
@@ -1,0 +1,36 @@
+package com.kakaotech.team18.backend_server.domain.email.sender;
+
+import java.util.List;
+
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Component;
+
+import jakarta.mail.internet.MimeMessage;
+
+@Component
+public class SmtpEmailSender implements EmailSender {
+
+    private final JavaMailSender mailSender;
+
+    public SmtpEmailSender(JavaMailSender mailSender) {
+        this.mailSender = mailSender;
+    }
+
+    @Override
+    public void sendHtml(String from, String replyTo, List<String> to, String subject, String htmlBody) {
+        try {
+            MimeMessage mime = mailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(mime, true, "UTF-8");
+            helper.setFrom(from);
+            helper.setReplyTo(replyTo);
+            helper.setTo(to.toArray(new String[0]));
+            helper.setSubject(subject);
+            helper.setText(htmlBody, true);
+
+            mailSender.send(mime);
+        } catch (Exception e) {
+            throw new RuntimeException("SMTP send failed", e);
+        }
+    }
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/email/service/EmailService.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/email/service/EmailService.java
@@ -1,0 +1,70 @@
+package com.kakaotech.team18.backend_server.domain.email.service;
+
+import com.kakaotech.team18.backend_server.domain.application.entity.Application;
+import com.kakaotech.team18.backend_server.domain.clubMember.entity.ActiveStatus;
+import com.kakaotech.team18.backend_server.domain.clubMember.entity.Role;
+import com.kakaotech.team18.backend_server.domain.clubMember.repository.ClubMemberRepository;
+import com.kakaotech.team18.backend_server.domain.email.dto.AnswerEmailLine;
+import com.kakaotech.team18.backend_server.domain.email.sender.EmailSender;
+import com.kakaotech.team18.backend_server.domain.email.template.EmailTemplateRenderer;
+
+import com.kakaotech.team18.backend_server.domain.user.entity.User;
+import com.kakaotech.team18.backend_server.global.exception.exceptions.PresidentNotFoundException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+public class EmailService {
+
+    private final EmailTemplateRenderer renderer;
+    private final EmailSender emailSender;
+    private final String from;
+    private final String subjectPrefix;
+    private final ClubMemberRepository  clubMemberRepository;
+
+    public EmailService(
+            EmailTemplateRenderer renderer,
+            EmailSender emailSender,
+            @Value("${email.from}") String from,
+            @Value("${email.subject-prefix}") String subjectPrefix,
+            ClubMemberRepository clubMemberRepository
+    ) {
+        this.renderer = renderer;
+        this.emailSender = emailSender;
+        this.from = from;
+        this.subjectPrefix = subjectPrefix;
+        this.clubMemberRepository = clubMemberRepository;
+    }
+
+    public void sendToApplicant(Application application, List<AnswerEmailLine> emailLines) {
+
+        Map<String, Object> model = new HashMap<>();
+
+        model.put("title", "동아리 지원서");
+        model.put("clubName", application.getClubApplyForm().getClub().getName());
+        model.put("applicantName", application.getUser().getName());
+        model.put("studentId", application.getUser().getStudentId());
+        model.put("department", application.getUser().getDepartment());
+        model.put("phoneNumber", application.getUser().getPhoneNumber());
+        model.put("applicantEmail", application.getUser().getEmail());
+        model.put("answers", emailLines);
+        model.put("submittedAt", application.getLastModifiedAt());
+
+        String html = renderer.render("email-body-applicant", model);
+
+        String subject = subjectPrefix + " "
+                + application.getClubApplyForm().getClub().getName()
+                + " - " + application.getUser().getName();
+
+        User president = clubMemberRepository
+                .findUserByClubIdAndRoleAndStatus(application.getClubApplyForm().getClub().getId(), Role.CLUB_ADMIN, ActiveStatus.ACTIVE)
+                .orElseThrow(() -> new PresidentNotFoundException("clubId:" + application.getClubApplyForm().getClub().getId()));
+        String replyTo = president.getEmail();
+
+        emailSender.sendHtml(from, replyTo,List.of(application.getUser().getEmail()),subject, html);
+    }
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/email/service/EmailService.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/email/service/EmailService.java
@@ -42,6 +42,12 @@ public class EmailService {
 
     public void sendToApplicant(Application application, List<AnswerEmailLine> emailLines) {
 
+        Long clubId = application.getClubApplyForm().getClub().getId();
+        User president = clubMemberRepository
+                .findUserByClubIdAndRoleAndStatus(clubId, Role.CLUB_ADMIN, ActiveStatus.ACTIVE)
+                .orElseThrow(() -> new PresidentNotFoundException("clubId:" + clubId));
+        String replyTo = president.getEmail();
+
         Map<String, Object> model = new HashMap<>();
 
         model.put("title", "동아리 지원서");
@@ -59,11 +65,6 @@ public class EmailService {
         String subject = subjectPrefix + " "
                 + application.getClubApplyForm().getClub().getName()
                 + " - " + application.getUser().getName();
-
-        User president = clubMemberRepository
-                .findUserByClubIdAndRoleAndStatus(application.getClubApplyForm().getClub().getId(), Role.CLUB_ADMIN, ActiveStatus.ACTIVE)
-                .orElseThrow(() -> new PresidentNotFoundException("clubId:" + application.getClubApplyForm().getClub().getId()));
-        String replyTo = president.getEmail();
 
         emailSender.sendHtml(from, replyTo,List.of(application.getUser().getEmail()),subject, html);
     }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/email/service/EmailService.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/email/service/EmailService.java
@@ -29,8 +29,8 @@ public class EmailService {
     public EmailService(
             EmailTemplateRenderer renderer,
             EmailSender emailSender,
-            @Value("${email.from}") String from,
-            @Value("${email.subject-prefix}") String subjectPrefix,
+            @Value("${spring.email.from}") String from,
+            @Value("${spring.email.subject-prefix}") String subjectPrefix,
             ClubMemberRepository clubMemberRepository
     ) {
         this.renderer = renderer;

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/email/template/EmailTemplateRenderer.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/email/template/EmailTemplateRenderer.java
@@ -1,0 +1,22 @@
+package com.kakaotech.team18.backend_server.domain.email.template;
+
+import java.util.Map;
+import org.springframework.stereotype.Component;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
+
+@Component
+public class EmailTemplateRenderer {
+
+    private final TemplateEngine templateEngine;
+
+    public EmailTemplateRenderer(TemplateEngine templateEngine) {
+        this.templateEngine = templateEngine;
+    }
+
+    public String render(String templateName, Map<String, Object> model) {
+        Context ctx = new Context();
+        model.forEach(ctx::setVariable);
+        return templateEngine.process(templateName, ctx);
+    }
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/user/entity/User.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/user/entity/User.java
@@ -23,10 +23,10 @@ public class User extends BaseEntity {
     @Column(name = "user_id")
     private Long id;
 
-    @Column(name = "login_id", nullable = false,  unique = true)
+    @Column(name = "login_id", unique = true)
     private String loginId;
 
-    @Column(name = "password", nullable = false)
+    @Column(name = "password")
     private String password;
 
     @Column(name = "email", nullable = false)

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/user/repository/UserRepository.java
@@ -1,8 +1,12 @@
 package com.kakaotech.team18.backend_server.domain.user.repository;
 
 import com.kakaotech.team18.backend_server.domain.user.entity.User;
+import jakarta.validation.constraints.NotBlank;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
+    Optional<User> findByStudentId(@NotBlank(message = "학번은 필수입니다.") String s);
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/global/exception/code/ErrorCode.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/exception/code/ErrorCode.java
@@ -40,6 +40,7 @@ public enum ErrorCode {
     FORM_NOT_FOUND("지원폼이 존재하지 않습니다", HttpStatus.NOT_FOUND),
     APPLICATION_NOT_FOUND("해당 지원서를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     COMMENT_NOT_FOUND("해당 댓글을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    PRESIDENT_NOT_FOUND("해당 동아리의 회장이 없습니다", HttpStatus.NOT_FOUND),
 
     // 409 CONFLICT: 리소스 충돌
     USER_ALREADY_EXISTS("이미 존재하는 유저입니다.", HttpStatus.CONFLICT),

--- a/src/main/java/com/kakaotech/team18/backend_server/global/exception/code/ErrorCode.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/exception/code/ErrorCode.java
@@ -27,6 +27,7 @@ public enum ErrorCode {
     // 400 BAD_REQUEST: 잘못된 요청
     INVALID_INPUT_VALUE("입력 값이 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
     INVALID_RATING_UNIT("별점은 0.5 단위로만 입력 가능합니다.", HttpStatus.BAD_REQUEST),
+    INVALID_INPUT_ANSWER("잘못된 답안 입력입니다",HttpStatus.BAD_REQUEST),
 
     // 403 FORBIDDEN: 권한 없음
     FORBIDDEN("해당 요청에 대한 권한이 없습니다.", HttpStatus.FORBIDDEN),

--- a/src/main/java/com/kakaotech/team18/backend_server/global/exception/exceptions/InvalidAnswerException.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/exception/exceptions/InvalidAnswerException.java
@@ -1,0 +1,9 @@
+package com.kakaotech.team18.backend_server.global.exception.exceptions;
+
+import com.kakaotech.team18.backend_server.global.exception.code.ErrorCode;
+
+public class InvalidAnswerException extends CustomException {
+    public InvalidAnswerException(String detail) {
+        super(ErrorCode.INVALID_INPUT_ANSWER,detail);
+    }
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/global/exception/exceptions/PresidentNotFoundException.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/exception/exceptions/PresidentNotFoundException.java
@@ -1,0 +1,9 @@
+package com.kakaotech.team18.backend_server.global.exception.exceptions;
+
+import com.kakaotech.team18.backend_server.global.exception.code.ErrorCode;
+
+public class PresidentNotFoundException extends CustomException {
+    public PresidentNotFoundException(String detail) {
+        super(ErrorCode.PRESIDENT_NOT_FOUND, detail);
+    }
+}

--- a/src/main/resources/application-secret.yml
+++ b/src/main/resources/application-secret.yml
@@ -1,0 +1,16 @@
+spring:
+  mail:
+    host: ${SMTP_HOST:smtp.gmail.com}
+    port: ${SMTP_PORT:587}
+    username: ${SMTP_USERNAME:example@gmail.com}
+    password: ${SMTP_PASSWORD:}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+
+  email:
+    from: ${EMAIL_FROM:no-reply@gmail.com}
+    subject-prefix: "[동아리 지원]"

--- a/src/main/resources/templates/email-body-applicant.html
+++ b/src/main/resources/templates/email-body-applicant.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <title th:text="${title}">동아리 지원서</title>
+    <style>
+        body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, 'Apple SD Gothic Neo', 'Noto Sans KR', 'Malgun Gothic', sans-serif; margin: 0; padding: 24px; background: #f7f7f7; }
+        .card { max-width: 760px; margin: 0 auto; background: #fff; border-radius: 16px; padding: 24px; box-shadow: 0 8px 20px rgba(0,0,0,0.06); }
+        h1 { margin: 0 0 8px; font-size: 20px; }
+        h2 { margin: 24px 0 8px; font-size: 16px; }
+        .muted { color: #666; font-size: 13px; }
+        .grid { display: grid; grid-template-columns: 140px 1fr; gap: 8px 16px; }
+        .badge { display: inline-block; padding: 2px 8px; border-radius: 9999px; background: #eef2ff; color: #3730a3; font-size: 12px; }
+        table { width: 100%; border-collapse: collapse; margin-top: 8px; }
+        th, td { text-align: left; padding: 10px 12px; border-bottom: 1px solid #eee; vertical-align: top; }
+        th { width: 30%; color: #374151; background: #fafafa; }
+        .footer { margin-top: 24px; color: #666; font-size: 12px; }
+    </style>
+</head>
+<body>
+<div class="card">
+    <h1>
+        <span class="badge">지원 접수</span>
+        <span th:text="${clubName}">동아리명</span> - <span th:text="${applicantName}">지원자명</span>
+    </h1>
+    <div class="muted" th:text="${#temporals.format(submittedAt, 'yyyy-MM-dd HH:mm')}">2025-09-20 13:00</div>
+
+    <h2>지원자 정보</h2>
+    <div class="grid">
+        <div>이름</div><div th:text="${applicantName}">홍길동</div>
+        <div>학번</div><div th:text="${studentId}">20251234</div>
+        <div>학과</div><div th:text="${department}">컴퓨터정보통신공학과</div>
+        <div>전화번호</div><div th:text="${phoneNumber}">010-0000-0000</div>
+        <div>이메일</div><div th:text="${applicantEmail}">user@example.com</div>
+    </div>
+
+    <h2>지원서 응답</h2>
+    <table>
+        <tbody>
+        <tr th:each="line : ${answers}">
+            <th th:text="${line.question()}">질문</th>
+            <td th:utext="${#strings.escapeXml(line.answer()).replaceAll('\n','<br/>')}">답변</td>
+        </tr>
+        </tbody>
+    </table>
+
+    <div class="footer">
+        본 메일은 지원서 제출 안내용으로 발송되었습니다. 문의는 회장/관리자에게 회신(Reply-To)으로 보내주세요.
+    </div>
+</div>
+</body>
+</html>

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/application/controller/ApplicationControllerTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/application/controller/ApplicationControllerTest.java
@@ -1,6 +1,8 @@
 package com.kakaotech.team18.backend_server.domain.application.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationApplyRequestDto;
+import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationApplyResponseDto;
 import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationDetailResponseDto;
 import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationStatusUpdateRequestDto;
 import com.kakaotech.team18.backend_server.domain.application.entity.Status;
@@ -9,6 +11,7 @@ import com.kakaotech.team18.backend_server.global.dto.SuccessResponseDto;
 import com.kakaotech.team18.backend_server.global.exception.code.ErrorCode;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.ApplicationNotFoundException;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -20,9 +23,17 @@ import org.springframework.test.web.servlet.ResultActions;
 import java.util.Collections;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -149,5 +160,103 @@ class ApplicationControllerTest {
         // then
         resultActions.andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.error_code").value(ErrorCode.INVALID_INPUT_VALUE.name()));
+    }
+
+    @Nested
+    @DisplayName("POST /api/clubs/{clubId}/apply-submit")
+    class SubmitApplicationEndpoint {
+
+        private String validPayloadJson() {
+            return """
+        {
+          "studentId":"20231234",
+          "email":"stud@example.com",
+          "name":"홍길동",
+          "phoneNumber":"010-0000-0000",
+          "department":"컴퓨터공학과",
+          "answerList": ["자기소개입니다","여","A,B"]
+        }
+        """;
+        }
+
+        private String invalidPayloadJson() {
+            // @Valid 위반: studentId 공백, email 형식 아님
+            return """
+        {
+          "studentId":" ",
+          "email":"bad-email",
+          "name":"",
+          "phoneNumber":"",
+          "department":"",
+          "answerList":[]
+        }
+        """;
+        }
+
+        @Test
+        @DisplayName("requiresConfirmation=true → 202 ACCEPTED")
+        void returnsAccepted_whenRequiresConfirmationTrue() throws Exception {
+            long clubId = 1L;
+
+            // overwrite 파라미터 기본값(false)
+            when(applicationService.submitApplication(
+                    eq(clubId),
+                    any(ApplicationApplyRequestDto.class),
+                    eq(false))
+            ).thenReturn(new ApplicationApplyResponseDto(
+                    "20231234", java.time.LocalDateTime.now(), true
+            ));
+
+            mockMvc.perform(post("/api/clubs/{clubId}/apply-submit", clubId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(validPayloadJson()))
+                    .andExpect(status().isAccepted());
+
+            verify(applicationService).submitApplication(
+                    eq(clubId),
+                    any(ApplicationApplyRequestDto.class),
+                    eq(false)
+            );
+        }
+
+        @Test
+        @DisplayName("requiresConfirmation=false → 201 CREATED (overwrite=true)")
+        void returnsCreated_whenRequiresConfirmationFalse() throws Exception {
+            long clubId = 1L;
+
+            when(applicationService.submitApplication(
+                    eq(clubId),
+                    any(ApplicationApplyRequestDto.class),
+                    eq(true))
+            ).thenReturn(new com.kakaotech.team18.backend_server.domain.application.dto.ApplicationApplyResponseDto(
+                    "20231234", java.time.LocalDateTime.now(), false
+            ));
+
+            mockMvc.perform(post("/api/clubs/{clubId}/apply-submit?overwrite=true", clubId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(validPayloadJson()))
+                    .andExpect(status().isCreated());
+
+            verify(applicationService).submitApplication(
+                    eq(clubId),
+                    any(ApplicationApplyRequestDto.class),
+                    eq(true)
+            );
+        }
+
+        @Test
+        @DisplayName("@Valid 위반 → 400 BAD_REQUEST & 서비스 미호출")
+        void returnsBadRequest_whenInvalidBody() throws Exception {
+            mockMvc.perform(post("/api/clubs/{clubId}/apply-submit", 1L)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(invalidPayloadJson()))
+                    .andExpect(status().isBadRequest());
+
+            verify(applicationService, never()).submitApplication(
+                    anyLong(),
+                    any(ApplicationApplyRequestDto.class),
+                    anyBoolean()
+            );
+        }
     }
 }

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/application/service/ApplicationServiceSubmitApplicationTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/application/service/ApplicationServiceSubmitApplicationTest.java
@@ -1,0 +1,264 @@
+package com.kakaotech.team18.backend_server.domain.application.service;
+
+import com.kakaotech.team18.backend_server.domain.Answer.entity.Answer;
+import com.kakaotech.team18.backend_server.domain.Answer.repository.AnswerRepository;
+import com.kakaotech.team18.backend_server.domain.FormQuestion.entity.FieldType;
+import com.kakaotech.team18.backend_server.domain.FormQuestion.entity.FormQuestion;
+import com.kakaotech.team18.backend_server.domain.FormQuestion.repository.FormQuestionRepository;
+import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationApplyRequestDto;
+import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationApplyResponseDto;
+import com.kakaotech.team18.backend_server.domain.application.entity.Application;
+import com.kakaotech.team18.backend_server.domain.application.repository.ApplicationRepository;
+import com.kakaotech.team18.backend_server.domain.club.entity.Club;
+import com.kakaotech.team18.backend_server.domain.clubApplyForm.entity.ClubApplyForm;
+import com.kakaotech.team18.backend_server.domain.clubApplyForm.repository.ClubApplyFormRepository;
+import com.kakaotech.team18.backend_server.domain.email.dto.ApplicationSubmittedEvent;
+import com.kakaotech.team18.backend_server.domain.user.entity.User;
+import com.kakaotech.team18.backend_server.domain.user.repository.UserRepository;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ApplicationServiceSubmitApplicationTest {
+
+    @InjectMocks
+    private ApplicationServiceImpl service;
+
+    @Mock private ApplicationRepository applicationRepository;
+    @Mock private AnswerRepository answerRepository;
+    @Mock private ClubApplyFormRepository clubApplyFormRepository;
+    @Mock private FormQuestionRepository formQuestionRepository;
+    @Mock private UserRepository userRepository;
+    //@Mock private EmailService emailService;
+    @Mock private ApplicationEventPublisher publisher;
+
+    private final User baseUser = User.builder()
+            .studentId("20231234")
+            .email("stud@example.com")
+            .name("홍길동")
+            .phoneNumber("010-0000-0000")
+            .department("컴퓨터공학과")
+            .build();
+
+    private List<FormQuestion> sampleQuestions(ClubApplyForm form) {
+        FormQuestion q1 = new FormQuestion(null, form, "자기소개", FieldType.TEXT, true , 1L, null);
+        FormQuestion q2 = new FormQuestion(null, form, "성별"  , FieldType.RADIO, true , 2L, List.of("남","여"));
+        FormQuestion q3 = new FormQuestion(null, form, "관심사", FieldType.CHECKBOX, false, 3L, List.of("A","B","C"));
+        return List.of(q1, q2, q3);
+    }
+
+    @Nested
+    @DisplayName("submitApplication - 신규 제출")
+    class CreateFlow {
+
+        @Test
+        @DisplayName("기존 지원서가 없으면 저장 후 이벤트 발행")
+        void create_thenPublishEvent() {
+            // given
+            Club club = mock(Club.class);
+            ClubApplyForm form = mock(ClubApplyForm.class);
+            when(form.getId()).thenReturn(11L);
+
+            when(clubApplyFormRepository.findByClubIdAndIsActiveTrue(1L))
+                    .thenReturn(Optional.of(form));
+
+            when(userRepository.findByStudentId("20231234"))
+                    .thenReturn(Optional.empty());
+            when(userRepository.save(any(User.class)))
+                    .thenAnswer(inv -> inv.getArgument(0));
+
+            when(applicationRepository.findByUserAndClubApplyForm(eq("20231234"), eq(form)))
+                    .thenReturn(Optional.empty());
+
+            when(formQuestionRepository.findByClubApplyFormIdOrderByDisplayOrderAsc(11L))
+                    .thenReturn(sampleQuestions(form));
+
+            when(applicationRepository.save(any(Application.class)))
+                    .thenAnswer(inv -> {
+                        Application app = inv.getArgument(0);
+                        ReflectionTestUtils.setField(app, "id", 100L);
+                        ReflectionTestUtils.setField(app, "lastModifiedAt", LocalDateTime.now());
+                        return app;
+                    });
+
+            when(answerRepository.saveAll(anyList()))
+                    .thenAnswer(inv -> inv.getArgument(0));
+
+            ApplicationApplyRequestDto req = new ApplicationApplyRequestDto(
+                    "20231234", "stud@example.com", "홍길동", "010-0000-0000", "컴공",
+                    List.of("안녕하세요", "여", "A,B")
+            );
+
+            // when
+            ApplicationApplyResponseDto res = service.submitApplication(1L, req, false);
+
+            // then
+            assertThat(res).isNotNull();
+            assertThat(res.studentId()).isEqualTo("20231234");
+
+            verify(applicationRepository, times(1)).save(any(Application.class));
+            verify(answerRepository, times(1)).saveAll(anyList());
+            verify(answerRepository, never()).deleteByApplication(any());
+
+            // 이벤트 발행 검증
+            ArgumentCaptor<ApplicationSubmittedEvent> captor =
+                    ArgumentCaptor.forClass(ApplicationSubmittedEvent.class);
+            verify(publisher, times(1)).publishEvent(captor.capture());
+            ApplicationSubmittedEvent event = captor.getValue();
+            assertThat(event.applicationId()).isEqualTo(100L);
+            assertThat(event.emailLines()).hasSize(3);
+        }
+    }
+
+    @Nested
+    @DisplayName("submitApplication - 기존 제출 존재")
+    class UpdateFlow {
+
+        @Test
+        @DisplayName("덮어쓰기 거부(false) → 기존 값 반환, 갱신/이벤트 없음")
+        void existing_noOverwrite() {
+            // given
+            ClubApplyForm form = mock(ClubApplyForm.class);
+            when(clubApplyFormRepository.findByClubIdAndIsActiveTrue(1L))
+                    .thenReturn(Optional.of(form));
+
+            when(userRepository.findByStudentId("20231234"))
+                    .thenReturn(Optional.of(baseUser));
+
+            Application existing = new Application(baseUser, form);
+            ReflectionTestUtils.setField(existing, "id", 200L);
+            ReflectionTestUtils.setField(existing, "lastModifiedAt", LocalDateTime.now());
+
+            when(applicationRepository.findByUserAndClubApplyForm(eq("20231234"), eq(form)))
+                    .thenReturn(Optional.of(existing));
+
+            ApplicationApplyRequestDto req = new ApplicationApplyRequestDto(
+                    "20231234", "stud@example.com", "홍길동", "010-0000-0000", "컴공",
+                    List.of("수정본문", "남", "A")
+            );
+
+            // when
+            ApplicationApplyResponseDto res = service.submitApplication(1L, req, false);
+
+            // then
+            assertThat(res).isNotNull();
+            assertThat(res.studentId()).isEqualTo("20231234");
+
+            verify(answerRepository, never()).deleteByApplication(any());
+            verify(answerRepository, never()).saveAll(anyList());
+            verify(publisher, never()).publishEvent(any());
+        }
+
+        @Test
+        @DisplayName("덮어쓰기 허용(true) → 답변 재저장 + 이벤트 발행")
+        void existing_overwrite() {
+            // given
+            ClubApplyForm form = mock(ClubApplyForm.class);
+            when(form.getId()).thenReturn(11L);
+
+            when(clubApplyFormRepository.findByClubIdAndIsActiveTrue(1L))
+                    .thenReturn(Optional.of(form));
+            when(userRepository.findByStudentId("20231234"))
+                    .thenReturn(Optional.of(baseUser));
+
+            Application existing = new Application(baseUser, form);
+            ReflectionTestUtils.setField(existing, "id", 201L);
+            ReflectionTestUtils.setField(existing, "lastModifiedAt", LocalDateTime.now());
+
+            when(applicationRepository.findByUserAndClubApplyForm(eq("20231234"), eq(form)))
+                    .thenReturn(Optional.of(existing));
+
+            when(formQuestionRepository.findByClubApplyFormIdOrderByDisplayOrderAsc(11L))
+                    .thenReturn(sampleQuestions(form));
+
+            when(answerRepository.saveAll(anyList()))
+                    .thenAnswer(inv -> inv.getArgument(0));
+
+            ApplicationApplyRequestDto req = new ApplicationApplyRequestDto(
+                    "20231234", "stud@example.com", "홍길동", "010-0000-0000", "컴공",
+                    List.of("수정본문", "여", "B")
+            );
+
+            // when
+            ApplicationApplyResponseDto res = service.submitApplication(1L, req, true);
+
+            // then
+            assertThat(res).isNotNull();
+            assertThat(res.studentId()).isEqualTo("20231234");
+
+            verify(answerRepository, times(1)).deleteByApplication(eq(existing));
+            verify(answerRepository, times(1)).saveAll(anyList());
+
+            ArgumentCaptor<ApplicationSubmittedEvent> captor =
+                    ArgumentCaptor.forClass(ApplicationSubmittedEvent.class);
+            verify(publisher, times(1)).publishEvent(captor.capture());
+            assertThat(captor.getValue().applicationId()).isEqualTo(201L);
+        }
+    }
+
+    @Nested
+    @DisplayName("saveApplicationAnswers 동작")
+    class SaveAnswers {
+
+        @SuppressWarnings("unchecked")
+        @Test
+        @DisplayName("체크박스(비필수) 미응답 → Answer.answer=null & 이메일 '(미입력)'")
+        void checkbox_optional_blankSavedAsNull() {
+            // given
+            ClubApplyForm form = mock(ClubApplyForm.class);
+            when(form.getId()).thenReturn(11L);
+
+            Application app = new Application(baseUser, form);
+            ReflectionTestUtils.setField(app, "id", 300L);
+
+            when(formQuestionRepository.findByClubApplyFormIdOrderByDisplayOrderAsc(11L))
+                    .thenReturn(sampleQuestions(form));
+
+            when(answerRepository.saveAll(anyList()))
+                    .thenAnswer(inv -> inv.getArgument(0));
+
+            // TEXT 값, RADIO 값, CHECKBOX 공란
+            var answers = List.of("자소서", "남", "");
+
+            // when
+            var emailLines = service.saveApplicationAnswers(app, answers);
+
+            // then
+            assertThat(emailLines).hasSize(3);
+            assertThat(emailLines.get(2).question()).isEqualTo("관심사");
+            assertThat(emailLines.get(2).answer()).isEqualTo("(미입력)");
+
+            // 저장 리스트 검증
+            ArgumentCaptor<List> cap = ArgumentCaptor.forClass(List.class);
+            verify(answerRepository, times(1)).saveAll(cap.capture());
+            List saved = cap.getValue();
+            assertThat(saved).hasSize(3);
+            Answer last = (Answer) saved.get(2);
+            assertThat(last.getFormQuestion().getQuestion()).isEqualTo("관심사");
+            assertThat(last.getAnswer()).isNull();
+        }
+    }
+}

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/email/service/EmailServiceTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/email/service/EmailServiceTest.java
@@ -1,0 +1,161 @@
+package com.kakaotech.team18.backend_server.domain.email.service;
+
+import com.kakaotech.team18.backend_server.domain.application.entity.Application;
+import com.kakaotech.team18.backend_server.domain.club.entity.Club;
+import com.kakaotech.team18.backend_server.domain.clubApplyForm.entity.ClubApplyForm;
+import com.kakaotech.team18.backend_server.domain.clubMember.entity.ActiveStatus;
+import com.kakaotech.team18.backend_server.domain.clubMember.entity.Role;
+import com.kakaotech.team18.backend_server.domain.clubMember.repository.ClubMemberRepository;
+import com.kakaotech.team18.backend_server.domain.email.dto.AnswerEmailLine;
+import com.kakaotech.team18.backend_server.domain.email.sender.EmailSender;
+import com.kakaotech.team18.backend_server.domain.email.template.EmailTemplateRenderer;
+import com.kakaotech.team18.backend_server.domain.user.entity.User;
+import com.kakaotech.team18.backend_server.global.exception.exceptions.PresidentNotFoundException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+
+@ExtendWith(MockitoExtension.class)
+class EmailServiceTest {
+
+    @Mock
+    EmailTemplateRenderer renderer;
+    @Mock
+    EmailSender emailSender;
+    @Mock
+    ClubMemberRepository clubMemberRepository;
+
+    @Mock
+    Application application;
+    @Mock
+    ClubApplyForm clubApplyForm;
+    @Mock
+    Club club;
+    @Mock
+    User applicant;
+    @Mock
+    User president;
+
+    @Captor
+    ArgumentCaptor<Map<String,Object>> modelCaptor;
+    @Captor
+    ArgumentCaptor<List<String>> toCaptor;
+
+    EmailService service;
+
+    final String from = "no-reply@clubhub.example";
+    final String subjectPrefix = "[동아리 지원서]";
+
+    @BeforeEach
+    void setUp() {
+        service = new EmailService(renderer, emailSender, from, subjectPrefix, clubMemberRepository);
+    }
+
+    private void stubHappyPath() {
+        when(application.getLastModifiedAt()).thenReturn(LocalDateTime.of(2025,9,20,13,0));
+        when(application.getUser()).thenReturn(applicant);
+        when(applicant.getName()).thenReturn("홍길동");
+        when(applicant.getStudentId()).thenReturn("20251234");
+        when(applicant.getDepartment()).thenReturn("인공지능학과");
+        when(applicant.getPhoneNumber()).thenReturn("010-1111-2222");
+        when(applicant.getEmail()).thenReturn("applicant@example.com");
+
+        when(application.getClubApplyForm()).thenReturn(clubApplyForm);
+        when(clubApplyForm.getClub()).thenReturn(club);
+        when(club.getId()).thenReturn(77L);
+        when(club.getName()).thenReturn("카카오테크 동아리");
+
+        when(clubMemberRepository.findUserByClubIdAndRoleAndStatus(77L, Role.CLUB_ADMIN, ActiveStatus.ACTIVE))
+                .thenReturn(Optional.of(president));
+        when(president.getEmail()).thenReturn("president@example.com");
+
+        when(renderer.render(eq("email-body-applicant"), anyMap())).thenReturn("<html>OK</html>");
+    }
+
+    @Test
+    @DisplayName("단위: 메일 전송 성공")
+    void unit_success_sendMail() {
+        stubHappyPath();
+        List<AnswerEmailLine> lines = List.of(
+                new AnswerEmailLine(2L, 1L, "자기소개", "안녕하세요"),
+                new AnswerEmailLine(1L, 2L, "지원 동기", "함께 성장하고 싶습니다")
+        );
+
+        service.sendToApplicant(application, lines);
+
+        // 템플릿 렌더링 모델 검증
+        verify(renderer).render(eq("email-body-applicant"), modelCaptor.capture());
+        Map<String,Object> model = modelCaptor.getValue();
+        assertThat(model).containsKeys("title","clubName","applicantName","studentId","department",
+                "phoneNumber","applicantEmail","answers","submittedAt");
+        assertThat(model.get("clubName")).isEqualTo("카카오테크 동아리");
+        assertThat(model.get("applicantName")).isEqualTo("홍길동");
+        assertThat(model.get("answers")).isEqualTo(lines);
+
+        // 메일 전송 인자 검증
+        verify(emailSender).sendHtml(
+                eq(from),
+                eq("president@example.com"),
+                toCaptor.capture(),
+                eq(subjectPrefix + " " + "카카오테크 동아리" + " - " + "홍길동"),
+                eq("<html>OK</html>")
+        );
+        assertThat(toCaptor.getValue()).containsExactly("applicant@example.com");
+    }
+
+    @Test
+    @DisplayName("단위: 메일 전송 실패 - EmailSender에서 예외 → 그대로 전파")
+    void unit_fail_sendMailThrows() {
+        stubHappyPath();
+        doThrow(new RuntimeException("SMTP send failed"))
+                .when(emailSender)
+                .sendHtml(anyString(), anyString(), anyList(), anyString(), anyString());
+
+        assertThatThrownBy(() -> service.sendToApplicant(application, List.of()))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("SMTP send failed");
+
+        // 실패 시에도 renderer는 호출돼서 html 생성까지 시도했는지
+        verify(renderer).render(eq("email-body-applicant"), anyMap());
+    }
+
+    @Test
+    @DisplayName("단위: 회장 조회 실패 - PresidentNotFoundException")
+    void unit_fail_noPresident() {
+        when(application.getClubApplyForm()).thenReturn(clubApplyForm);
+        when(clubApplyForm.getClub()).thenReturn(club);
+        when(club.getId()).thenReturn(77L);
+        when(clubMemberRepository.findUserByClubIdAndRoleAndStatus(77L, Role.CLUB_ADMIN, ActiveStatus.ACTIVE))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.sendToApplicant(application, List.of()))
+                .isInstanceOf(PresidentNotFoundException.class)
+                .hasMessageContaining("해당 동아리의 회장이 없습니다");
+
+        verify(emailSender, never()).sendHtml(anyString(), anyString(), anyList(), anyString(), anyString());
+    }
+}


### PR DESCRIPTION
## 🚀 작업 내용

지원하기 버튼을 누르면 일어나는 작업을 했습니다. 학번에 따라 지원기록을 확인하고, 기존에 지원한 지원자면 덮어쓰기를 할지, 아니면 취소할지를 선택합니다. 지원 내역이 없는 지원자면 새로운 지원내역을 만들어줍니다. 새로운 지원내역이 생기면 이메일로 지원내용을 발송해줍니다. 

* ApplicaitonController에 submitApplication는 ConfirmOverwrite에 따라 다른 응답을 보냅니다. 지원하기를 눌렀다면 기본 false인 상태에서 응답을 받고 true로 바뀝니다
*  ApplicationService에 submitApplication는 신규가입자인지 판단, 신규 지원자인지 판단, 새로운 확정된 지원내역을 이메일로 전송합니다

* Email
    * MailConfig는 application-secret.yml에 작성된 내용을 사용할 수 있게 해줍니다
    * sender는 작성된 내용을 JavaMailSender에 매핑해 보내줍니다
    * EmailService는 List<AnswerEmailLine> emailLine이 가지고있는 내용과 함께 email template에 매핑해줍니다
    * eventListener는 commit이 된 이후에 이메일 발송을 보장해줍니다. 롤백이 일어나 데이터베이스에 반영이 안되었는데 접수확인 메일이 전송되는 문제를 막아줍니다. 
 

## ⏱️ 소요 시간
20h 이상으로 추정

## 🤔 고민했던 내용

email폼을 어떻게 할지 고민했습니다. 프론트에서 내용을 받아서 이메일폼에 매핑시켜서 받아와서 전송할지, 아니면 폼을 백에서 가지고 전송할지 고민했습니다. 사용자와 상호작용이 필요없는 부분이라 굳이 프론트에서 처리할 필요가 없을 것 같아서 백에서 폼을 만들어두긴 했습니다.
이 부분에 대해서는 다른 이슈로 만들어서 수정해야할 것 같습니다. 이미 이 티켓이 너무 커져버려서 읽기 힘드실 것 같아요

## 💬 리뷰 중점사항

email 관련하여 고려하지 못한 사항에 대해 지적 부탁드립니다. 


## 🔗관련 이슈
- Close #49 