### PR TITLE
bug: fixed ClubController

### DIFF
--- a/src/main/java/com/kakaotech/team18/backend_server/domain/club/controller/ClubController.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/club/controller/ClubController.java
@@ -52,7 +52,7 @@ public class ClubController{
 
     @Operation(summary = "카테고리별 동아리 목록 조회", description = "특정 카테고리에 속한 동아리 목록을 조회합니다.")
     @ApiResponse(responseCode = "200", description = "조회 성공")
-    @GetMapping("/search/category")
+    @GetMapping("/search/{category}")
     public ResponseEntity<List<ClubListResponseDto>> listClubsByCategory(
             @Parameter(description = "조회할 동아리 카테고리", required = true, example = "SPORTS") @RequestParam String category
     ){


### PR DESCRIPTION
category -> {category}

## 🚀 작업 내용
수정

## ⏱️ 소요 시간
5m

## 🤔 고민했던 내용


## 💬 리뷰 중점사항


## 🔗관련 이슈
- Close #이슈번호

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * 카테고리별 클럽 조회 API의 URL 구조를 단순화했습니다: /search/category에서 /search/{category}로 변경되어 카테고리를 경로 변수로 명시합니다.
  * 영향: 기존 경로를 사용 중인 클라이언트는 새 경로로 요청을 업데이트해야 합니다. 이외 동작과 응답 형식은 동일합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->