### PR TITLE
[FIX] CD 워크플로우의 빌드 실패 문제 해결

### DIFF
--- a/.github/workflows/deploy-with-docker.yml
+++ b/.github/workflows/deploy-with-docker.yml
@@ -42,7 +42,12 @@ jobs:
           printf "%s" "${{ secrets.APPLICATION_YML }}" > ./src/main/resources/application.yml
 
       - name: Build (Gradle)
-        run: ./gradlew clean build
+        env:
+          KAKAO_CLIENT_ID: ${{ secrets.KAKAO_CLIENT_ID }}
+          KAKAO_CLIENT_SECRET: ${{ secrets.KAKAO_CLIENT_SECRET }}
+          JWT_SECRET: ${{ secrets.JWT_SECRET }}
+          KAKAO_REDIRECT_URI_TEST: ${{ secrets.KAKAO_REDIRECT_URI_TEST }}
+        run: SPRING_PROFILES_ACTIVE=test ./gradlew clean build
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -144,12 +149,16 @@ jobs:
 
             # .env 생성 (printf로 안전하게 생성)
             tmp_env="$(mktemp)"
-            printf 'DB_NAME=%s\nDB_USER=%s\nDB_PASSWORD=%s\nDB_ROOT_PASSWORD=%s\nECR_REGISTRY=%s\n' \
+            printf 'DB_NAME=%s\nDB_USER=%s\nDB_PASSWORD=%s\nDB_ROOT_PASSWORD=%s\nECR_REGISTRY=%s\nKAKAO_CLIENT_ID=%s\nKAKAO_CLIENT_SECRET=%s\nJWT_SECRET=%s\nKAKAO_REDIRECT_URI_PROD=%s\n' \
             '${{ secrets.DB_NAME }}' \
             '${{ secrets.DB_USER }}' \
             '${{ secrets.DB_PASSWORD }}' \
             '${{ secrets.DB_ROOT_PASSWORD }}' \
-            "$REG" > "$tmp_env"
+            "$REG" \
+            '${{ secrets.KAKAO_CLIENT_ID }}' \
+            '${{ secrets.KAKAO_CLIENT_SECRET }}' \
+            '${{ secrets.JWT_SECRET }}' \
+            '${{ secrets.KAKAO_REDIRECT_URI_PROD }}' > "$tmp_env"
             install -m 600 "$tmp_env" ${{ env.REMOTE_DIR }}/shared/.env
             rm -f "$tmp_env"
             ln -sf ${{ env.REMOTE_DIR }}/shared/.env ${{ env.REMOTE_DIR }}/current/.env


### PR DESCRIPTION
## 🚀 작업 내용
`deploy-with-docker.yml`의 `Build (Gradle)` 스텝에서,
테스트 실행 시 필요한 `test` 프로파일 활성화 및 환경 변수 주입이
누락되어 `ApplicationContext` 로딩에 실패하던 문제를 해결합니다.

- `Build (Gradle)` 스텝에 `SPRING_PROFILES_ACTIVE=test`를 추가하고,
- `env` 블록을 통해 테스트에 필요한 모든 Secret을 환경 변수로 주입하도록 수정했습니다.
- 또한, `Deploy on EC2` 스텝의 `.env` 파일 생성 스크립트에 실행 환경에 필요한 모든 Secret을 추가하여, 배포 후 애플리케이션이 정상적으로 구동되도록 수정했습니다.


## ⏱️ 소요 시간
30m

