### PR TITLE
[FIX] @WebMvcTest의 ApplicationContext 로드 실패 문제 해결

### DIFF
--- a/src/test/java/com/kakaotech/team18/backend_server/domain/application/controller/ApplicationControllerTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/application/controller/ApplicationControllerTest.java
@@ -7,6 +7,7 @@ import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationDet
 import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationStatusUpdateRequestDto;
 import com.kakaotech.team18.backend_server.domain.application.entity.Status;
 import com.kakaotech.team18.backend_server.domain.application.service.ApplicationService;
+import com.kakaotech.team18.backend_server.global.config.SecurityConfig;
 import com.kakaotech.team18.backend_server.global.config.TestSecurityConfig;
 import com.kakaotech.team18.backend_server.global.dto.SuccessResponseDto;
 import com.kakaotech.team18.backend_server.global.exception.code.ErrorCode;
@@ -45,7 +46,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest(
         controllers = ApplicationController.class,
-        excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JwtAuthenticationFilter.class)
+        excludeFilters = {
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = SecurityConfig.class),
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JwtAuthenticationFilter.class)
+        }
 )
 @Import(TestSecurityConfig.class)
 class ApplicationControllerTest {

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/club/controller/ClubControllerTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/club/controller/ClubControllerTest.java
@@ -1,5 +1,6 @@
 package com.kakaotech.team18.backend_server.domain.club.controller;
 
+import com.kakaotech.team18.backend_server.global.config.SecurityConfig;
 import com.kakaotech.team18.backend_server.global.config.TestSecurityConfig;
 import com.kakaotech.team18.backend_server.domain.application.entity.Status;
 import com.kakaotech.team18.backend_server.domain.club.dto.ClubDashBoardResponseDto;
@@ -33,7 +34,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest(
         controllers = ClubController.class,
-        excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JwtAuthenticationFilter.class)
+        excludeFilters = {
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = SecurityConfig.class),
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JwtAuthenticationFilter.class)
+        }
 )
 @Import(TestSecurityConfig.class)
 class ClubControllerTest {

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/controller/ClubApplyFormControllerTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/controller/ClubApplyFormControllerTest.java
@@ -22,6 +22,7 @@ import com.kakaotech.team18.backend_server.domain.clubApplyForm.dto.ClubApplyFor
 import com.kakaotech.team18.backend_server.domain.clubApplyForm.dto.ClubApplyFormResponseDto;
 import com.kakaotech.team18.backend_server.domain.clubApplyForm.dto.ClubApplyFormUpdateDto;
 import com.kakaotech.team18.backend_server.domain.clubApplyForm.service.ClubApplyFormService;
+import com.kakaotech.team18.backend_server.global.config.SecurityConfig;
 import com.kakaotech.team18.backend_server.global.config.TestSecurityConfig;
 import com.kakaotech.team18.backend_server.global.security.JwtAuthenticationFilter;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.ClubApplyFormNotFoundException;
@@ -40,9 +41,10 @@ import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(
     controllers = ClubApplyFormController.class,
-    excludeFilters = @ComponentScan.Filter(
-        type = FilterType.ASSIGNABLE_TYPE, classes = JwtAuthenticationFilter.class
-    )
+        excludeFilters = {
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = SecurityConfig.class),
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JwtAuthenticationFilter.class)
+        }
 )
 @Import(TestSecurityConfig.class)
 class ClubApplyFormControllerTest {

--- a/src/test/java/com/kakaotech/team18/backend_server/global/exception/handler/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/global/exception/handler/GlobalExceptionHandlerTest.java
@@ -1,6 +1,7 @@
 package com.kakaotech.team18.backend_server.global.exception.handler;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kakaotech.team18.backend_server.global.config.SecurityConfig;
 import com.kakaotech.team18.backend_server.global.config.TestSecurityConfig;
 import com.kakaotech.team18.backend_server.global.exception.code.ErrorCode;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.CustomException;
@@ -32,7 +33,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest(
         controllers = GlobalExceptionHandlerTest.TestController.class,
-        excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JwtAuthenticationFilter.class)
+        excludeFilters = {
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = SecurityConfig.class),
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JwtAuthenticationFilter.class)
+        }
 )
 @Import({TestSecurityConfig.class, GlobalExceptionHandler.class, GlobalExceptionHandlerTest.TestController.class})
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)


### PR DESCRIPTION
## 🚀 작업 내용
@WebMvcTest를 사용하는 모든 컨트롤러 테스트 클래스들이,
CD 환경에서 ApplicationContext 로딩에 실패하던 문제를 해결합니다.

1. 문제 원인
- @WebMvcTest는 Web 계층 테스트를 위해 @Configuration 클래스를 스캔하면서, 테스트에 불필요한 실제 SecurityConfig를 로드하려고 시도했습니다.
- 이로 인해, SecurityConfig에 명시된 @EnableConfigurationProperties가 동작하고, OAuth2ClientAutoConfiguration 등 거대한 자동 설정이 활성화되면서, 가벼운 테스트 환경에는 없는 Bean들을 요구하여 의존성 주입 실패(UnsatisfiedDependencyException, IllegalStateException)가 발생했습니다.
- 이 문제는 캐시가 없는 깨끗한 CI/CD 환경에서만 재현되고, 로컬에서는 캐시의 영향으로 우연히 성공하는 경우가 있어 원인 파악이 어려웠습니다.

2. 해결 방안
- **excludeFilters 적용**: 문제가 발생하는 모든 @WebMvcTest 클래스에 excludeFilters 속성을 추가하여, 컴포넌트 스캔 과정에서 SecurityConfig.class와 JwtAuthenticationFilter.class를 명시적으로 제외하도록 수정했습니다.
- **@Import(TestSecurityConfig) 유지**: 제외된 실제 보안 설정 대신, 아무런 의존성 없는 최소한의 가짜 보안 설정(TestSecurityConfig)이 주입되도록 하여, 테스트가 정상적으로 실행될 수 있는 최소한의 보안 환경을 구성했습니다.

## ⏱️ 소요 시간
1h

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - 컨트롤러 및 예외 처리 테스트의 보안 설정을 정비해 테스트 슬라이스에서 불필요한 컴포넌트 로딩을 제외했습니다.
  - 테스트 컨텍스트 초기화 속도와 격리성을 개선하여 안정성을 높였습니다.
  - 테스트 설정을 전반적으로 일관화해 플래키(간헐적 실패) 가능성을 줄였습니다.

- Chores
  - 테스트 구성 업데이트로 유지보수성과 가독성을 향상했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->