### PR TITLE
[FEATURE] pass or fail 결과반영, 메세지 전송

### DIFF
--- a/src/main/java/com/kakaotech/team18/backend_server/domain/application/controller/ApplicationController.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/application/controller/ApplicationController.java
@@ -2,6 +2,7 @@ package com.kakaotech.team18.backend_server.domain.application.controller;
 
 import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationApplyRequestDto;
 import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationApplyResponseDto;
+import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationApprovedRequestDto;
 import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationDetailResponseDto;
 import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationStatusUpdateRequestDto;
 import com.kakaotech.team18.backend_server.domain.application.service.ApplicationService;
@@ -75,5 +76,14 @@ public class ApplicationController {
         } else {
             return ResponseEntity.status(HttpStatus.CREATED).body(response);//기존 응답이 없어서 바로 제출
         }
+    }
+
+    @PatchMapping("/api/clubs/{clubId}/application-form")
+    public ResponseEntity<SuccessResponseDto> sendPassFailMessage(
+            @PathVariable("clubId") Long clubId,
+            @RequestBody ApplicationApprovedRequestDto requestDto
+    ){
+        SuccessResponseDto responseDto = applicationService.sendPassFailMessage(clubId, requestDto);
+        return ResponseEntity.ok(responseDto);
     }
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/application/controller/ApplicationController.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/application/controller/ApplicationController.java
@@ -78,12 +78,13 @@ public class ApplicationController {
         }
     }
 
-    @PatchMapping("/api/clubs/{clubId}/application-form")
+    @PatchMapping("/api/clubs/{clubId}/application-form/result")
     public ResponseEntity<SuccessResponseDto> sendPassFailMessage(
             @PathVariable("clubId") Long clubId,
-            @RequestBody ApplicationApprovedRequestDto requestDto
+            @RequestBody ApplicationApprovedRequestDto requestDto,
+            @RequestParam(value = "stage") String stage
     ){
-        SuccessResponseDto responseDto = applicationService.sendPassFailMessage(clubId, requestDto);
+        SuccessResponseDto responseDto = applicationService.sendPassFailMessage(clubId, requestDto, stage);
         return ResponseEntity.ok(responseDto);
     }
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/application/controller/ApplicationController.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/application/controller/ApplicationController.java
@@ -5,6 +5,7 @@ import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationApp
 import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationApprovedRequestDto;
 import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationDetailResponseDto;
 import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationStatusUpdateRequestDto;
+import com.kakaotech.team18.backend_server.domain.application.entity.Stage;
 import com.kakaotech.team18.backend_server.domain.application.service.ApplicationService;
 import com.kakaotech.team18.backend_server.global.dto.SuccessResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
@@ -82,7 +83,7 @@ public class ApplicationController {
     public ResponseEntity<SuccessResponseDto> sendPassFailMessage(
             @PathVariable("clubId") Long clubId,
             @RequestBody ApplicationApprovedRequestDto requestDto,
-            @RequestParam(value = "stage") String stage
+            @RequestParam(value = "stage") Stage stage
     ){
         SuccessResponseDto responseDto = applicationService.sendPassFailMessage(clubId, requestDto, stage);
         return ResponseEntity.ok(responseDto);

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/application/dto/ApplicationApprovedRequestDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/application/dto/ApplicationApprovedRequestDto.java
@@ -1,6 +1,7 @@
 package com.kakaotech.team18.backend_server.domain.application.dto;
 
-public class ApplicationApprovedRequestDto {
-    String message;
+public record ApplicationApprovedRequestDto(
+        String message
+) {
 }
 

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/application/dto/ApplicationApprovedRequestDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/application/dto/ApplicationApprovedRequestDto.java
@@ -1,0 +1,6 @@
+package com.kakaotech.team18.backend_server.domain.application.dto;
+
+public class ApplicationApprovedRequestDto {
+    String message;
+}
+

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/application/entity/Application.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/application/entity/Application.java
@@ -40,7 +40,8 @@ public class Application extends BaseEntity {
     @Column(name = "status",  nullable = false)
     private Status status = Status.PENDING;
 
-    private String stage;
+    @Enumerated(EnumType.STRING)
+    private Stage stage;
 
     @Column(nullable = false)
     private Double averageRating = 0.0;
@@ -60,6 +61,10 @@ public class Application extends BaseEntity {
      */
     public void updateStatus(Status newStatus) {
         this.status = newStatus;
+    }
+
+    public void updateStage(Stage newStage) {
+        this.stage = newStage;
     }
 
     public void updateAverageRating(Double averageRating) {

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/application/entity/Application.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/application/entity/Application.java
@@ -40,6 +40,8 @@ public class Application extends BaseEntity {
     @Column(name = "status",  nullable = false)
     private Status status = Status.PENDING;
 
+    private String stage;
+
     @Column(nullable = false)
     private Double averageRating = 0.0;
 

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/application/entity/Stage.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/application/entity/Stage.java
@@ -1,0 +1,14 @@
+package com.kakaotech.team18.backend_server.domain.application.entity;
+
+public enum Stage {
+    INTERVIEW, FINAL;
+
+    public static Stage fromRaw(String raw) {
+        if (raw == null) throw new IllegalArgumentException("stage is required");
+        try {
+            return Stage.valueOf(raw.trim().toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Unsupported stage: " + raw);
+        }
+    }
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/application/repository/ApplicationRepository.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/application/repository/ApplicationRepository.java
@@ -1,6 +1,7 @@
 package com.kakaotech.team18.backend_server.domain.application.repository;
 
 import com.kakaotech.team18.backend_server.domain.application.entity.Application;
+import com.kakaotech.team18.backend_server.domain.application.entity.Stage;
 import com.kakaotech.team18.backend_server.domain.application.entity.Status;
 import java.util.List;
 
@@ -31,4 +32,6 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
             where u.studentId = :studentId and a.clubApplyForm = :form
             """)
     Optional<Application> findByStudentIdAndClubApplyForm(String studentId, ClubApplyForm form);
+
+    List<Application> findByClubApplyForm_Club_IdAndStage(Long clubId, Stage stage);
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/application/service/ApplicationService.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/application/service/ApplicationService.java
@@ -2,9 +2,13 @@ package com.kakaotech.team18.backend_server.domain.application.service;
 
 import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationApplyRequestDto;
 import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationApplyResponseDto;
+import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationApprovedRequestDto;
 import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationDetailResponseDto;
 import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationStatusUpdateRequestDto;
+import com.kakaotech.team18.backend_server.domain.email.dto.AnswerEmailLine;
 import com.kakaotech.team18.backend_server.global.dto.SuccessResponseDto;
+
+import java.util.List;
 
 public interface ApplicationService {
     ApplicationDetailResponseDto getApplicationDetail(Long clubId, Long applicantId);
@@ -12,4 +16,8 @@ public interface ApplicationService {
     SuccessResponseDto updateApplicationStatus(Long applicationId, ApplicationStatusUpdateRequestDto requestDto);
 
     ApplicationApplyResponseDto submitApplication(Long clubId, ApplicationApplyRequestDto request, boolean confirmOverwrite);
+
+    SuccessResponseDto sendPassFailMessage(Long clubId, ApplicationApprovedRequestDto requestDto);
+
+    SuccessResponseDto sendPassFailMessage(long clubId, List<AnswerEmailLine> emailLines);
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/application/service/ApplicationService.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/application/service/ApplicationService.java
@@ -17,7 +17,5 @@ public interface ApplicationService {
 
     ApplicationApplyResponseDto submitApplication(Long clubId, ApplicationApplyRequestDto request, boolean confirmOverwrite);
 
-    SuccessResponseDto sendPassFailMessage(Long clubId, ApplicationApprovedRequestDto requestDto);
-
-    SuccessResponseDto sendPassFailMessage(long clubId, List<AnswerEmailLine> emailLines);
+    SuccessResponseDto sendPassFailMessage(Long clubId, ApplicationApprovedRequestDto requestDto, String stage);
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/application/service/ApplicationService.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/application/service/ApplicationService.java
@@ -6,10 +6,7 @@ import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationApp
 import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationDetailResponseDto;
 import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationStatusUpdateRequestDto;
 import com.kakaotech.team18.backend_server.domain.application.entity.Stage;
-import com.kakaotech.team18.backend_server.domain.email.dto.AnswerEmailLine;
 import com.kakaotech.team18.backend_server.global.dto.SuccessResponseDto;
-
-import java.util.List;
 
 public interface ApplicationService {
     ApplicationDetailResponseDto getApplicationDetail(Long clubId, Long applicantId);

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/application/service/ApplicationService.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/application/service/ApplicationService.java
@@ -5,6 +5,7 @@ import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationApp
 import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationApprovedRequestDto;
 import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationDetailResponseDto;
 import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationStatusUpdateRequestDto;
+import com.kakaotech.team18.backend_server.domain.application.entity.Stage;
 import com.kakaotech.team18.backend_server.domain.email.dto.AnswerEmailLine;
 import com.kakaotech.team18.backend_server.global.dto.SuccessResponseDto;
 
@@ -17,5 +18,5 @@ public interface ApplicationService {
 
     ApplicationApplyResponseDto submitApplication(Long clubId, ApplicationApplyRequestDto request, boolean confirmOverwrite);
 
-    SuccessResponseDto sendPassFailMessage(Long clubId, ApplicationApprovedRequestDto requestDto, String stage);
+    SuccessResponseDto sendPassFailMessage(Long clubId, ApplicationApprovedRequestDto requestDto, Stage stage);
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/application/service/ApplicationServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/application/service/ApplicationServiceImpl.java
@@ -158,11 +158,6 @@ public class ApplicationServiceImpl implements ApplicationService {
         }
     }
 
-    @Override
-    public SuccessResponseDto sendPassFailMessage(Long clubId, ApplicationApprovedRequestDto requestDto) {
-        return null;
-    }
-
     private ApplicationApplyResponseDto updateApplication(
             Application application,
             ApplicationApplyRequestDto request
@@ -270,7 +265,8 @@ public class ApplicationServiceImpl implements ApplicationService {
     }
 
     @Override
-    public SuccessResponseDto sendPassFailMessage(long clubId, List<AnswerEmailLine> emailLines) {
+    public SuccessResponseDto sendPassFailMessage(Long clubId, ApplicationApprovedRequestDto requestDto, String stage) {
+        
         return null;
     }
 

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/application/service/ApplicationServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/application/service/ApplicationServiceImpl.java
@@ -276,7 +276,10 @@ public class ApplicationServiceImpl implements ApplicationService {
 
         List<Application> apps = applicationRepository.findByClubApplyForm_Club_IdAndStage(clubId, stage);
 
+        ClubApplyForm form =clubApplyFormRepository.findByClub_Id(clubId);
+
         if(stage == Stage.INTERVIEW) {
+            form.updateInterviewMessage(requestDto.message());
             List<Application> approved = apps.stream()
                     .filter(a -> a.getStatus() == Status.APPROVED)
                     .toList();
@@ -303,6 +306,7 @@ public class ApplicationServiceImpl implements ApplicationService {
             }
         }
         if(stage == Stage.FINAL) {
+            form.updateFinalMessage(requestDto.message());
             List<Application> approved = apps.stream()
                     .filter(a -> a.getStatus() == Status.APPROVED)
                     .toList();

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/application/service/ApplicationServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/application/service/ApplicationServiceImpl.java
@@ -270,6 +270,7 @@ public class ApplicationServiceImpl implements ApplicationService {
         return emailLines;
     }
 
+    @Transactional
     @Override
     public SuccessResponseDto sendPassFailMessage(Long clubId, ApplicationApprovedRequestDto requestDto, Stage stage) {
 
@@ -289,8 +290,8 @@ public class ApplicationServiceImpl implements ApplicationService {
                 a.updateStage(Stage.FINAL);
                 publisher.publishEvent(new InterviewApprovedEvent(
                         a.getId(),
-                        requestDto.message(),
                         a.getUser().getEmail(),
+                        requestDto.message(),
                         a.getStage()));
             }
             for(Application a : rejected) {
@@ -314,8 +315,8 @@ public class ApplicationServiceImpl implements ApplicationService {
             for(Application a : approved) {
                 publisher.publishEvent(new FinalApprovedEvent(
                         a.getId(),
-                        requestDto.message(),
                         a.getUser().getEmail(),
+                        requestDto.message(),
                         a.getStage()));
             }
             for(Application a : rejected) {
@@ -326,8 +327,7 @@ public class ApplicationServiceImpl implements ApplicationService {
                         a.getStage()));
             }
         }
-
-        return null;
+        return new SuccessResponseDto(true);
     }
 
     //helper methods

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/application/service/ApplicationServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/application/service/ApplicationServiceImpl.java
@@ -7,6 +7,7 @@ import com.kakaotech.team18.backend_server.domain.FormQuestion.repository.FormQu
 import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationApplyRequestDto;
 import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationApplyRequestDto.AnswerDto;
 import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationApplyResponseDto;
+import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationApprovedRequestDto;
 import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationDetailResponseDto;
 import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationStatusUpdateRequestDto;
 import com.kakaotech.team18.backend_server.domain.application.entity.Application;
@@ -157,6 +158,11 @@ public class ApplicationServiceImpl implements ApplicationService {
         }
     }
 
+    @Override
+    public SuccessResponseDto sendPassFailMessage(Long clubId, ApplicationApprovedRequestDto requestDto) {
+        return null;
+    }
+
     private ApplicationApplyResponseDto updateApplication(
             Application application,
             ApplicationApplyRequestDto request
@@ -261,6 +267,11 @@ public class ApplicationServiceImpl implements ApplicationService {
         // 4) 일괄 저장
         answerRepository.saveAll(toSave);
         return emailLines;
+    }
+
+    @Override
+    public SuccessResponseDto sendPassFailMessage(long clubId, List<AnswerEmailLine> emailLines) {
+        return null;
     }
 
     //helper methods

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/entity/ClubApplyForm.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/entity/ClubApplyForm.java
@@ -39,6 +39,9 @@ public class ClubApplyForm extends BaseEntity {
     @Column(nullable = false)
     private boolean isActive;
 
+    private String interviewMessage;
+    private String finalMessage;
+
     @Builder
     private ClubApplyForm(Club club, String title, String description, boolean isActive) {
         this.club = club;
@@ -50,5 +53,11 @@ public class ClubApplyForm extends BaseEntity {
     public void update(String title, String description) {
         this.title = title;
         this.description = description;
+    }
+    public void updateInterviewMessage(String message){
+        this.interviewMessage = message;
+    }
+    public void updateFinalMessage(String message){
+        this.finalMessage = message;
     }
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/repository/ClubApplyFormRepository.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/repository/ClubApplyFormRepository.java
@@ -13,4 +13,6 @@ public interface ClubApplyFormRepository extends JpaRepository<ClubApplyForm,Lon
     Optional<ClubApplyForm> getByClub(Club club);
 
     Optional<ClubApplyForm> findByClubId(Long clubId);
+
+    ClubApplyForm findByClub_Id(Long clubId);
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/email/dto/AnswerEmailLine.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/email/dto/AnswerEmailLine.java
@@ -1,3 +1,8 @@
 package com.kakaotech.team18.backend_server.domain.email.dto;
 
-public record AnswerEmailLine(Long questionId, Long displayOrder, String question, String answer) {}
+public record AnswerEmailLine(
+        Long questionId,
+        Long displayOrder,
+        String question,
+        String answer
+) {}

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/email/dto/FinalApprovedEvent.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/email/dto/FinalApprovedEvent.java
@@ -1,0 +1,10 @@
+package com.kakaotech.team18.backend_server.domain.email.dto;
+
+import com.kakaotech.team18.backend_server.domain.application.entity.Stage;
+
+public record FinalApprovedEvent(
+        Long applicationId,
+        String email,
+        String message,
+        Stage stage
+) {}

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/email/dto/FinalRejectedEvent.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/email/dto/FinalRejectedEvent.java
@@ -1,0 +1,9 @@
+package com.kakaotech.team18.backend_server.domain.email.dto;
+
+import com.kakaotech.team18.backend_server.domain.application.entity.Stage;
+
+public record FinalRejectedEvent(
+        Long applicationId,
+        String email,
+        Stage stage
+) {}

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/email/dto/InterviewApprovedEvent.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/email/dto/InterviewApprovedEvent.java
@@ -4,7 +4,7 @@ import com.kakaotech.team18.backend_server.domain.application.entity.Stage;
 
 public record InterviewApprovedEvent(
         Long applicationId,
-        String message,
         String email,
+        String message,
         Stage stage
 ) {}

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/email/dto/InterviewApprovedEvent.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/email/dto/InterviewApprovedEvent.java
@@ -1,0 +1,10 @@
+package com.kakaotech.team18.backend_server.domain.email.dto;
+
+import com.kakaotech.team18.backend_server.domain.application.entity.Stage;
+
+public record InterviewApprovedEvent(
+        Long applicationId,
+        String message,
+        String email,
+        Stage stage
+) {}

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/email/dto/InterviewRejectedEvent.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/email/dto/InterviewRejectedEvent.java
@@ -1,0 +1,9 @@
+package com.kakaotech.team18.backend_server.domain.email.dto;
+
+import com.kakaotech.team18.backend_server.domain.application.entity.Stage;
+
+public record InterviewRejectedEvent(
+        Long applicationId,
+        String email,
+        Stage stage
+){}

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/email/eventListener/ApplicationNotificationListener.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/email/eventListener/ApplicationNotificationListener.java
@@ -3,9 +3,12 @@ package com.kakaotech.team18.backend_server.domain.email.eventListener;
 import com.kakaotech.team18.backend_server.domain.application.entity.Application;
 import com.kakaotech.team18.backend_server.domain.application.repository.ApplicationRepository;
 import com.kakaotech.team18.backend_server.domain.email.dto.ApplicationSubmittedEvent;
+import com.kakaotech.team18.backend_server.domain.email.dto.FinalApprovedEvent;
+import com.kakaotech.team18.backend_server.domain.email.dto.FinalRejectedEvent;
+import com.kakaotech.team18.backend_server.domain.email.dto.InterviewApprovedEvent;
+import com.kakaotech.team18.backend_server.domain.email.dto.InterviewRejectedEvent;
 import com.kakaotech.team18.backend_server.domain.email.service.EmailService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -17,12 +20,40 @@ public class ApplicationNotificationListener {
     private final ApplicationRepository applicationRepository;
     private final EmailService emailService;
 
-    // 트랜잭션이 커밋된 뒤에만 이 메서드가 호출됨
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void onSubmitted(ApplicationSubmittedEvent event) {
         Application application = applicationRepository.findById(event.applicationId()).orElse(null);
         if (application == null) return;
 
         emailService.sendToApplicant(application, event.emailLines());
+    }
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onInterviewApproved(InterviewApprovedEvent event) {
+        Application application = applicationRepository.findById(event.applicationId()).orElse(null);
+        if (application == null) return;
+
+        emailService.sendInterviewApprovedResultToApplicant(application, event.message());
+    }
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onInterviewRejected(InterviewRejectedEvent event) {
+        Application application = applicationRepository.findById(event.applicationId()).orElse(null);
+        if (application == null) return;
+
+        emailService.sendInterviewRejectedResultToApplicant(application);
+    }
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onFinalApproved(FinalApprovedEvent event) {
+        Application application = applicationRepository.findById(event.applicationId()).orElse(null);
+        if (application == null) return;
+
+        emailService.sendFinalApprovedResultToApplicant(application, event.message());
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onFinalRejected(FinalRejectedEvent event) {
+        Application application = applicationRepository.findById(event.applicationId()).orElse(null);
+        if (application == null) return;
+
+        emailService.sendFinalRejectedResultToApplicant(application);
     }
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/email/eventListener/ApplicationNotificationListener.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/email/eventListener/ApplicationNotificationListener.java
@@ -9,6 +9,7 @@ import com.kakaotech.team18.backend_server.domain.email.dto.InterviewApprovedEve
 import com.kakaotech.team18.backend_server.domain.email.dto.InterviewRejectedEvent;
 import com.kakaotech.team18.backend_server.domain.email.service.EmailService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -20,6 +21,7 @@ public class ApplicationNotificationListener {
     private final ApplicationRepository applicationRepository;
     private final EmailService emailService;
 
+    @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void onSubmitted(ApplicationSubmittedEvent event) {
         Application application = applicationRepository.findById(event.applicationId()).orElse(null);
@@ -27,6 +29,8 @@ public class ApplicationNotificationListener {
 
         emailService.sendToApplicant(application, event.emailLines());
     }
+
+    @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void onInterviewApproved(InterviewApprovedEvent event) {
         Application application = applicationRepository.findById(event.applicationId()).orElse(null);
@@ -34,6 +38,8 @@ public class ApplicationNotificationListener {
 
         emailService.sendInterviewApprovedResultToApplicant(application, event.message());
     }
+
+    @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void onInterviewRejected(InterviewRejectedEvent event) {
         Application application = applicationRepository.findById(event.applicationId()).orElse(null);
@@ -41,6 +47,8 @@ public class ApplicationNotificationListener {
 
         emailService.sendInterviewRejectedResultToApplicant(application);
     }
+
+    @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void onFinalApproved(FinalApprovedEvent event) {
         Application application = applicationRepository.findById(event.applicationId()).orElse(null);
@@ -49,6 +57,7 @@ public class ApplicationNotificationListener {
         emailService.sendFinalApprovedResultToApplicant(application, event.message());
     }
 
+    @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void onFinalRejected(FinalRejectedEvent event) {
         Application application = applicationRepository.findById(event.applicationId()).orElse(null);

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/email/service/EmailService.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/email/service/EmailService.java
@@ -20,23 +20,22 @@ import java.util.Map;
 @Service
 public class EmailService {
 
+    private static final String SUBJECT_PREFIX = "[동아리 지원]";
+
     private final EmailTemplateRenderer renderer;
     private final EmailSender emailSender;
     private final String from;
-    private final String subjectPrefix;
     private final ClubMemberRepository  clubMemberRepository;
 
     public EmailService(
             EmailTemplateRenderer renderer,
             EmailSender emailSender,
             @Value("${spring.email.from}") String from,
-            @Value("${spring.email.subject-prefix}") String subjectPrefix,
             ClubMemberRepository clubMemberRepository
     ) {
         this.renderer = renderer;
         this.emailSender = emailSender;
         this.from = from;
-        this.subjectPrefix = subjectPrefix;
         this.clubMemberRepository = clubMemberRepository;
     }
 
@@ -62,6 +61,121 @@ public class EmailService {
 
         String html = renderer.render("email-body-applicant", model);
 
+        final String subjectPrefix = "[동아리 지원]";
+        String subject = subjectPrefix + " "
+                + application.getClubApplyForm().getClub().getName()
+                + " - " + application.getUser().getName();
+
+        emailSender.sendHtml(from, replyTo,List.of(application.getUser().getEmail()),subject, html);
+    }
+
+    public void sendInterviewApprovedResultToApplicant(Application application, String message) {
+        Long clubId = application.getClubApplyForm().getClub().getId();
+        User president = clubMemberRepository
+                .findUserByClubIdAndRoleAndStatus(clubId, Role.CLUB_ADMIN, ActiveStatus.ACTIVE)
+                .orElseThrow(() -> new PresidentNotFoundException("clubId:" + clubId));
+        String replyTo = president.getEmail();
+
+        Map<String, Object> model = new HashMap<>();
+
+        model.put("title", "동아리 면접 합격을 축하드립니다");
+        model.put("clubName", application.getClubApplyForm().getClub().getName());
+        model.put("applicantName", application.getUser().getName());
+        model.put("studentId", application.getUser().getStudentId());
+        model.put("department", application.getUser().getDepartment());
+        model.put("phoneNumber", application.getUser().getPhoneNumber());
+        model.put("applicantEmail", application.getUser().getEmail());
+        model.put("message", message);
+        model.put("submittedAt", application.getLastModifiedAt());
+
+        String html = renderer.render("email-body-applicant-InterviewApproved", model);
+
+        final String subjectPrefix = "[동아리 지원]";
+        String subject = subjectPrefix + " "
+                + application.getClubApplyForm().getClub().getName()
+                + " - " + application.getUser().getName();
+
+        emailSender.sendHtml(from, replyTo,List.of(application.getUser().getEmail()),subject, html);
+    }
+
+    public void sendInterviewRejectedResultToApplicant(Application application) {
+        Long clubId = application.getClubApplyForm().getClub().getId();
+        User president = clubMemberRepository
+                .findUserByClubIdAndRoleAndStatus(clubId, Role.CLUB_ADMIN, ActiveStatus.ACTIVE)
+                .orElseThrow(() -> new PresidentNotFoundException("clubId:" + clubId));
+        String replyTo = president.getEmail();
+
+        Map<String, Object> model = new HashMap<>();
+
+        model.put("title", "동아리 면접 결과");
+        model.put("clubName", application.getClubApplyForm().getClub().getName());
+        model.put("applicantName", application.getUser().getName());
+        model.put("studentId", application.getUser().getStudentId());
+        model.put("department", application.getUser().getDepartment());
+        model.put("phoneNumber", application.getUser().getPhoneNumber());
+        model.put("applicantEmail", application.getUser().getEmail());
+        model.put("submittedAt", application.getLastModifiedAt());
+
+        String html = renderer.render("email-body-applicant-InterviewApproved", model);
+
+        final String subjectPrefix = "[동아리 지원]";
+        String subject = subjectPrefix + " "
+                + application.getClubApplyForm().getClub().getName()
+                + " - " + application.getUser().getName();
+
+        emailSender.sendHtml(from, replyTo,List.of(application.getUser().getEmail()),subject, html);
+    }
+
+    public void sendFinalApprovedResultToApplicant(Application application, String message) {
+        Long clubId = application.getClubApplyForm().getClub().getId();
+        User president = clubMemberRepository
+                .findUserByClubIdAndRoleAndStatus(clubId, Role.CLUB_ADMIN, ActiveStatus.ACTIVE)
+                .orElseThrow(() -> new PresidentNotFoundException("clubId:" + clubId));
+        String replyTo = president.getEmail();
+
+        Map<String, Object> model = new HashMap<>();
+
+        model.put("title", "동아리 최종 합격을 축하드립니다");
+        model.put("clubName", application.getClubApplyForm().getClub().getName());
+        model.put("applicantName", application.getUser().getName());
+        model.put("studentId", application.getUser().getStudentId());
+        model.put("department", application.getUser().getDepartment());
+        model.put("phoneNumber", application.getUser().getPhoneNumber());
+        model.put("applicantEmail", application.getUser().getEmail());
+        model.put("message", message);
+        model.put("submittedAt", application.getLastModifiedAt());
+
+        String html = renderer.render("email-body-applicant-InterviewApproved", model);
+
+        final String subjectPrefix = "[동아리 지원]";
+        String subject = subjectPrefix + " "
+                + application.getClubApplyForm().getClub().getName()
+                + " - " + application.getUser().getName();
+
+        emailSender.sendHtml(from, replyTo,List.of(application.getUser().getEmail()),subject, html);
+    }
+
+    public void sendFinalRejectedResultToApplicant(Application application) {
+        Long clubId = application.getClubApplyForm().getClub().getId();
+        User president = clubMemberRepository
+                .findUserByClubIdAndRoleAndStatus(clubId, Role.CLUB_ADMIN, ActiveStatus.ACTIVE)
+                .orElseThrow(() -> new PresidentNotFoundException("clubId:" + clubId));
+        String replyTo = president.getEmail();
+
+        Map<String, Object> model = new HashMap<>();
+
+        model.put("title", "동아리 최종 결과");
+        model.put("clubName", application.getClubApplyForm().getClub().getName());
+        model.put("applicantName", application.getUser().getName());
+        model.put("studentId", application.getUser().getStudentId());
+        model.put("department", application.getUser().getDepartment());
+        model.put("phoneNumber", application.getUser().getPhoneNumber());
+        model.put("applicantEmail", application.getUser().getEmail());
+        model.put("submittedAt", application.getLastModifiedAt());
+
+        String html = renderer.render("email-body-applicant-InterviewApproved", model);
+
+        final String subjectPrefix = "[동아리 지원]";
         String subject = subjectPrefix + " "
                 + application.getClubApplyForm().getClub().getName()
                 + " - " + application.getUser().getName();

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/email/service/EmailService.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/email/service/EmailService.java
@@ -20,8 +20,6 @@ import java.util.Map;
 @Service
 public class EmailService {
 
-    private static final String SUBJECT_PREFIX = "[동아리 지원]";
-
     private final EmailTemplateRenderer renderer;
     private final EmailSender emailSender;
     private final String from;
@@ -113,10 +111,6 @@ public class EmailService {
         model.put("applicantEmail", application.getUser().getEmail());
         model.put("submittedAt", application.getLastModifiedAt());
         return model;
-    }
-
-    private String subjectFor(Application application) {
-
     }
 
     private boolean isApproved(ResultType type) {

--- a/src/main/resources/templates/email-body-applicant-FinalApproved.html
+++ b/src/main/resources/templates/email-body-applicant-FinalApproved.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8"/>
+    <meta name="viewport" content="width=device-width"/>
+    <title th:text="${title}">동아리 최종 합격 안내</title>
+    <style>
+        body { font-family: system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif; margin:0; padding:0; background:#f6f7f9; }
+        .container { max-width:640px; margin:24px auto; background:#fff; border-radius:12px; padding:24px; border:1px solid #e9eef3; }
+        h1 { font-size:20px; margin:0 0 12px; }
+        .meta { color:#6b7280; font-size:13px; margin-bottom:16px; }
+        .card { background:#f9fafb; border:1px solid #eef2f7; border-radius:10px; padding:16px; margin:12px 0; }
+        pre { white-space:pre-wrap; word-break:break-word; font-family:inherit; font-size:14px; }
+        .footer { color:#9aa4af; font-size:12px; margin-top:20px; }
+    </style>
+</head>
+<body>
+<div class="container">
+    <h1 th:text="${title}">동아리 최종 합격을 축하드립니다</h1>
+    <div class="meta">
+        <span th:text="'동아리: ' + ${clubName}">동아리명</span> ·
+        <span th:text="${#temporals.format(submittedAt, 'yyyy-MM-dd HH:mm')}">2025-10-04 10:00</span>
+    </div>
+
+    <div class="card">
+        <strong th:text="${applicantName}">홍길동</strong> 님, 최종 합격을 진심으로 축하드립니다!<br/>
+        아래 공지사항을 확인해 주시고 일정 및 준비물을 참고해 주세요.
+    </div>
+
+    <div class="card">
+        <div style="font-weight:600; margin-bottom:8px;">안내 메시지</div>
+        <pre th:text="${message}">OT는 10/7(화) 19:00, 장소는 공대 1호관 101호…</pre>
+    </div>
+
+    <div class="card">
+        <div style="font-weight:600; margin-bottom:8px;">지원자 정보</div>
+        <div>이름: <span th:text="${applicantName}">홍길동</span></div>
+        <div>학번: <span th:text="${studentId}">20231234</span></div>
+        <div>학과: <span th:text="${department}">컴퓨터정보통신공학과</span></div>
+        <div>연락처: <span th:text="${phoneNumber}">010-1234-5678</span></div>
+        <div>이메일: <span th:text="${applicantEmail}">user@example.com</span></div>
+    </div>
+
+    <div class="footer">
+        본 메일은 회신 시 동아리 회장(Reply-To)에게 전달됩니다.<br/>
+        © <span th:text="${clubName}">동아리명</span>
+    </div>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/email-body-applicant-FinalRejected.html
+++ b/src/main/resources/templates/email-body-applicant-FinalRejected.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8"/>
+    <meta name="viewport" content="width=device-width"/>
+    <title th:text="${title}">동아리 최종 결과 안내</title>
+    <style>
+        body { font-family: system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif; margin:0; padding:0; background:#f6f7f9; }
+        .container { max-width:640px; margin:24px auto; background:#fff; border-radius:12px; padding:24px; border:1px solid #e9eef3; }
+        h1 { font-size:20px; margin:0 0 12px; }
+        .meta { color:#6b7280; font-size:13px; margin-bottom:16px; }
+        .card { background:#f9fafb; border:1px solid #eef2f7; border-radius:10px; padding:16px; margin:12px 0; }
+        .footer { color:#9aa4af; font-size:12px; margin-top:20px; }
+    </style>
+</head>
+<body>
+<div class="container">
+    <h1 th:text="${title}">동아리 최종 결과 안내</h1>
+    <div class="meta">
+        <span th:text="'동아리: ' + ${clubName}">동아리명</span> ·
+        <span th:text="${#temporals.format(submittedAt, 'yyyy-MM-dd HH:mm')}">2025-10-04 10:00</span>
+    </div>
+
+    <div class="card">
+        <strong th:text="${applicantName}">홍길동</strong> 님, 관심을 갖고 지원해 주셔서 진심으로 감사드립니다.<br/>
+        심사 결과, 이번 모집에서는 함께하지 못하게 되었음을 안내드립니다.
+    </div>
+
+    <div class="card">
+        지원서에 담아 주신 관심과 시간에 깊이 감사드리며, 다음 기회에 더 좋은 인연으로 만나 뵙기를 바랍니다.
+    </div>
+
+    <div class="card">
+        <div style="font-weight:600; margin-bottom:8px;">지원자 정보</div>
+        <div>이름: <span th:text="${applicantName}">홍길동</span></div>
+        <div>학번: <span th:text="${studentId}">20231234</span></div>
+        <div>학과: <span th:text="${department}">컴퓨터정보통신공학과</span></div>
+        <div>연락처: <span th:text="${phoneNumber}">010-1234-5678</span></div>
+        <div>이메일: <span th:text="${applicantEmail}">user@example.com</span></div>
+    </div>
+
+    <div class="footer">
+        본 메일은 회신 시 동아리 회장(Reply-To)에게 전달됩니다.<br/>
+        © <span th:text="${clubName}">동아리명</span>
+    </div>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/email-body-applicant-InterviewApproved.html
+++ b/src/main/resources/templates/email-body-applicant-InterviewApproved.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8"/>
+  <meta name="viewport" content="width=device-width"/>
+  <title th:text="${title}">동아리 면접 합격 안내</title>
+  <style>
+    body { font-family: system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif; margin:0; padding:0; background:#f6f7f9; }
+    .container { max-width:640px; margin:24px auto; background:#fff; border-radius:12px; padding:24px; border:1px solid #e9eef3; }
+    h1 { font-size:20px; margin:0 0 12px; }
+    .meta { color:#6b7280; font-size:13px; margin-bottom:16px; }
+    .card { background:#f9fafb; border:1px solid #eef2f7; border-radius:10px; padding:16px; margin:12px 0; }
+    pre { white-space:pre-wrap; word-break:break-word; font-family:inherit; font-size:14px; }
+    .footer { color:#9aa4af; font-size:12px; margin-top:20px; }
+  </style>
+</head>
+<body>
+<div class="container">
+  <h1 th:text="${title}">동아리 면접 합격을 축하드립니다</h1>
+  <div class="meta">
+    <span th:text="'동아리: ' + ${clubName}">동아리명</span> ·
+    <span th:text="${#temporals.format(submittedAt, 'yyyy-MM-dd HH:mm')}">2025-10-04 10:00</span>
+  </div>
+
+  <div class="card">
+    <strong th:text="${applicantName}">홍길동</strong> 님, 면접 합격을 진심으로 축하드립니다!<br/>
+    아래 안내 메시지를 확인해 주세요.
+  </div>
+
+  <div class="card">
+    <div style="font-weight:600; margin-bottom:8px;">안내 메시지</div>
+    <!-- 사용자가 입력한 메시지: 개행 유지 -->
+    <pre th:text="${message}">OT는 10/7(화) 19:00입니다…</pre>
+  </div>
+
+  <div class="card">
+    <div style="font-weight:600; margin-bottom:8px;">지원자 정보</div>
+    <div>이름: <span th:text="${applicantName}">홍길동</span></div>
+    <div>학번: <span th:text="${studentId}">20231234</span></div>
+    <div>학과: <span th:text="${department}">컴퓨터정보통신공학과</span></div>
+    <div>연락처: <span th:text="${phoneNumber}">010-1234-5678</span></div>
+    <div>이메일: <span th:text="${applicantEmail}">user@example.com</span></div>
+  </div>
+
+  <div class="footer">
+    본 메일은 회신 시 동아리 회장(Reply-To)에게 전달됩니다.<br/>
+    © <span th:text="${clubName}">동아리명</span>
+  </div>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/email=body-applicant-InterviewRejected.html
+++ b/src/main/resources/templates/email=body-applicant-InterviewRejected.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8"/>
+    <meta name="viewport" content="width=device-width"/>
+    <title th:text="${title}">동아리 면접 결과 안내</title>
+    <style>
+        body { font-family: system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif; margin:0; padding:0; background:#f6f7f9; }
+        .container { max-width:640px; margin:24px auto; background:#fff; border-radius:12px; padding:24px; border:1px solid #e9eef3; }
+        h1 { font-size:20px; margin:0 0 12px; }
+        .meta { color:#6b7280; font-size:13px; margin-bottom:16px; }
+        .card { background:#f9fafb; border:1px solid #eef2f7; border-radius:10px; padding:16px; margin:12px 0; }
+        .footer { color:#9aa4af; font-size:12px; margin-top:20px; }
+    </style>
+</head>
+<body>
+<div class="container">
+    <h1 th:text="${title}">동아리 면접 결과 안내</h1>
+    <div class="meta">
+        <span th:text="'동아리: ' + ${clubName}">동아리명</span> ·
+        <span th:text="${#temporals.format(submittedAt, 'yyyy-MM-dd HH:mm')}">2025-10-04 10:00</span>
+    </div>
+
+    <div class="card">
+        <strong th:text="${applicantName}">홍길동</strong> 님, 지원해 주셔서 진심으로 감사합니다.<br/>
+        심사 결과, 이번 면접에서는 함께하지 못하게 되었음을 안내드립니다.
+    </div>
+
+    <div class="card">
+        앞으로 더 좋은 인연으로 만나 뵙길 바랍니다. 귀중한 시간 내어 주셔서 감사합니다.
+    </div>
+
+    <div class="card">
+        <div style="font-weight:600; margin-bottom:8px;">지원자 정보</div>
+        <div>이름: <span th:text="${applicantName}">홍길동</span></div>
+        <div>학번: <span th:text="${studentId}">20231234</span></div>
+        <div>학과: <span th:text="${department}">컴퓨터정보통신공학과</span></div>
+        <div>연락처: <span th:text="${phoneNumber}">010-1234-5678</span></div>
+        <div>이메일: <span th:text="${applicantEmail}">user@example.com</span></div>
+    </div>
+
+    <div class="footer">
+        본 메일은 회신 시 동아리 회장(Reply-To)에게 전달됩니다.<br/>
+        © <span th:text="${clubName}">동아리명</span>
+    </div>
+</div>
+</body>
+</html>

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/service/ClubApplyFormServiceImplTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/service/ClubApplyFormServiceImplTest.java
@@ -50,7 +50,7 @@ class ClubApplyFormServiceImplTest {
 
     @BeforeEach
     void setUp() {
-        clubApplyForm = new ClubApplyForm(100L, mockClub, "카카오 동아리 지원서", "함께 성장할 팀원을 찾습니다.", true);
+        clubApplyForm = new ClubApplyForm(100L, mockClub, "카카오 동아리 지원서", "함께 성장할 팀원을 찾습니다.", true, null, null);
         FormQuestion textQuestion = FormQuestion.builder()
                 .clubApplyForm(mockClubApplyForm)
                 .question("이름")

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/email/service/EmailServiceUnitTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/email/service/EmailServiceUnitTest.java
@@ -1,15 +1,25 @@
 package com.kakaotech.team18.backend_server.domain.email.service;
 
+import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationApprovedRequestDto;
 import com.kakaotech.team18.backend_server.domain.application.entity.Application;
+import com.kakaotech.team18.backend_server.domain.application.entity.Stage;
+import com.kakaotech.team18.backend_server.domain.application.entity.Status;
+import com.kakaotech.team18.backend_server.domain.application.repository.ApplicationRepository;
+import com.kakaotech.team18.backend_server.domain.application.service.ApplicationServiceImpl;
 import com.kakaotech.team18.backend_server.domain.club.entity.Club;
 import com.kakaotech.team18.backend_server.domain.clubApplyForm.entity.ClubApplyForm;
 import com.kakaotech.team18.backend_server.domain.clubMember.entity.ActiveStatus;
 import com.kakaotech.team18.backend_server.domain.clubMember.entity.Role;
 import com.kakaotech.team18.backend_server.domain.clubMember.repository.ClubMemberRepository;
 import com.kakaotech.team18.backend_server.domain.email.dto.AnswerEmailLine;
+import com.kakaotech.team18.backend_server.domain.email.dto.FinalApprovedEvent;
+import com.kakaotech.team18.backend_server.domain.email.dto.FinalRejectedEvent;
+import com.kakaotech.team18.backend_server.domain.email.dto.InterviewApprovedEvent;
+import com.kakaotech.team18.backend_server.domain.email.dto.InterviewRejectedEvent;
 import com.kakaotech.team18.backend_server.domain.email.sender.EmailSender;
 import com.kakaotech.team18.backend_server.domain.email.template.EmailTemplateRenderer;
 import com.kakaotech.team18.backend_server.domain.user.entity.User;
+import com.kakaotech.team18.backend_server.global.dto.SuccessResponseDto;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.PresidentNotFoundException;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -19,8 +29,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -29,12 +41,16 @@ import java.util.Optional;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -48,6 +64,10 @@ class EmailServiceUnitTest {
     EmailSender emailSender;
     @Mock
     ClubMemberRepository clubMemberRepository;
+    @Mock
+    ApplicationRepository applicationRepository;
+    @Mock
+    ApplicationEventPublisher publisher;
 
     @Mock
     Application application;
@@ -64,11 +84,16 @@ class EmailServiceUnitTest {
     ArgumentCaptor<Map<String,Object>> modelCaptor;
     @Captor
     ArgumentCaptor<List<String>> toCaptor;
+    @Captor
+    ArgumentCaptor<Object> eventCaptor;
 
+    @InjectMocks
+    ApplicationServiceImpl serviceImpl;
+    @InjectMocks
     EmailService service;
 
     final String from = "no-reply@clubhub.example";
-    final String subjectPrefix = "[동아리 지원서]";
+    final String subjectPrefix = "[동아리 지원]";
 
     @BeforeEach
     void setUp() {
@@ -157,5 +182,151 @@ class EmailServiceUnitTest {
                 .hasMessageContaining("해당 동아리의 회장이 없습니다");
 
         verify(emailSender, never()).sendHtml(anyString(), anyString(), anyList(), anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("INTERVIEW 단계: APPROVED→승격(FINAL)+합격 이벤트, REJECTED→삭제+불합격 이벤트, PENDING→무시")
+    void interview_flow() {
+        // given
+        Application appApproved = mock(Application.class);
+        Application appRejected = mock(Application.class);
+        Application appPending  = mock(Application.class);
+
+        // 공통: stage 초기값은 INTERVIEW
+        final Stage[] approvedStageRef = { Stage.INTERVIEW }; // updateStage 호출 시 바뀌게 함
+        when(appApproved.getStage()).thenAnswer(inv -> approvedStageRef[0]);
+        doAnswer(inv -> { approvedStageRef[0] = inv.getArgument(0, Stage.class); return null; })
+                .when(appApproved).updateStage(any(Stage.class));
+
+        when(appRejected.getStage()).thenReturn(Stage.INTERVIEW);
+
+        // status
+        when(appApproved.getStatus()).thenReturn(Status.APPROVED);
+        when(appRejected.getStatus()).thenReturn(Status.REJECTED);
+        when(appPending.getStatus()).thenReturn(Status.PENDING);
+
+        // ids
+        when(appApproved.getId()).thenReturn(101L);
+        when(appRejected.getId()).thenReturn(102L);
+
+        // emails
+        User userApproved = mock(User.class);
+        User userRejected = mock(User.class);
+        when(userApproved.getEmail()).thenReturn("approved@ex.com");
+        when(userRejected.getEmail()).thenReturn("rejected@ex.com");
+        when(appApproved.getUser()).thenReturn(userApproved);
+        when(appRejected.getUser()).thenReturn(userRejected);;
+
+        when(applicationRepository.findByClubApplyForm_Club_IdAndStage(77L, Stage.INTERVIEW))
+                .thenReturn(List.of(appApproved, appRejected, appPending));
+
+        ApplicationApprovedRequestDto req = new ApplicationApprovedRequestDto("면접 합격 안내 메시지");
+
+        // when
+        SuccessResponseDto resp = serviceImpl.sendPassFailMessage(77L, req, Stage.INTERVIEW);
+
+        //then
+        assertThat(resp).isNotNull();
+
+        // 승격 호출 확인
+        verify(appApproved).updateStage(Stage.FINAL);
+        verify(appRejected, never()).updateStage(any());
+        verify(appPending,  never()).updateStage(any());
+
+        // 삭제 호출 확인 (REJECTED만)
+        verify(applicationRepository, times(1)).deleteById(102L);
+        verify(applicationRepository, never()).deleteById(101L);
+        verify(applicationRepository, never()).deleteById(103L);
+
+        // 이벤트 캡처
+        verify(publisher, times(2)).publishEvent(eventCaptor.capture());
+        List<Object> events = eventCaptor.getAllValues();
+
+        // InterviewApprovedEvent
+        InterviewApprovedEvent approvedEvt = events.stream()
+                .filter(e -> e instanceof InterviewApprovedEvent)
+                .map(e -> (InterviewApprovedEvent) e)
+                .findFirst().orElseThrow();
+        assertThat(approvedEvt.applicationId()).isEqualTo(101L);
+        assertThat(approvedEvt.email()).isEqualTo("approved@ex.com");
+        assertThat(approvedEvt.message()).isEqualTo("면접 합격 안내 메시지");
+        assertThat(approvedEvt.stage()).isEqualTo(Stage.FINAL);
+
+        // InterviewRejectedEvent
+        InterviewRejectedEvent rejectedEvt = events.stream()
+                .filter(e -> e instanceof InterviewRejectedEvent)
+                .map(e -> (InterviewRejectedEvent) e)
+                .findFirst().orElseThrow();
+        assertThat(rejectedEvt.applicationId()).isEqualTo(102L);
+        assertThat(rejectedEvt.email()).isEqualTo("rejected@ex.com");
+        assertThat(rejectedEvt.stage()).isEqualTo(Stage.INTERVIEW);
+    }
+
+    @Test
+    @DisplayName("FINAL 단계: APPROVED→최종 합격 이벤트, REJECTED→삭제+최종 불합격 이벤트, PENDING→무시")
+    void final_flow() {
+        //given
+        Application appApproved = mock(Application.class);
+        Application appRejected = mock(Application.class);
+        Application appPending  = mock(Application.class);
+
+        when(appApproved.getStage()).thenReturn(Stage.FINAL);
+        when(appRejected.getStage()).thenReturn(Stage.FINAL);
+
+        when(appApproved.getStatus()).thenReturn(Status.APPROVED);
+        when(appRejected.getStatus()).thenReturn(Status.REJECTED);
+        when(appPending.getStatus()).thenReturn(Status.PENDING);
+
+        when(appApproved.getId()).thenReturn(201L);
+        when(appRejected.getId()).thenReturn(202L);
+
+        User userApproved = mock(User.class);
+        User userRejected = mock(User.class);
+        when(userApproved.getEmail()).thenReturn("final-approved@ex.com");
+        when(userRejected.getEmail()).thenReturn("final-rejected@ex.com");
+        when(appApproved.getUser()).thenReturn(userApproved);
+        when(appRejected.getUser()).thenReturn(userRejected);
+
+        when(applicationRepository.findByClubApplyForm_Club_IdAndStage(88L, Stage.FINAL))
+                .thenReturn(List.of(appApproved, appRejected, appPending));
+
+        ApplicationApprovedRequestDto req = new ApplicationApprovedRequestDto("최종 합격 안내 메시지");
+
+        //when
+        SuccessResponseDto resp = serviceImpl.sendPassFailMessage(88L, req, Stage.FINAL);
+
+        //then
+        assertThat(resp).isNotNull();
+
+        // FINAL 단계에서는 승격 호출 없음
+        verify(appApproved, never()).updateStage(any());
+        verify(appRejected, never()).updateStage(any());
+        verify(appPending,  never()).updateStage(any());
+
+        // 삭제 호출 확인 (REJECTED만)
+        verify(applicationRepository, times(1)).deleteById(202L);
+        verify(applicationRepository, never()).deleteById(201L);
+        verify(applicationRepository, never()).deleteById(203L);
+
+        // 이벤트 캡처 (approved 1, rejected 1)
+        verify(publisher, times(2)).publishEvent(eventCaptor.capture());
+        List<Object> events = eventCaptor.getAllValues();
+
+        FinalApprovedEvent approvedEvt = events.stream()
+                .filter(e -> e instanceof FinalApprovedEvent)
+                .map(e -> (FinalApprovedEvent) e)
+                .findFirst().orElseThrow();
+        assertThat(approvedEvt.applicationId()).isEqualTo(201L);
+        assertThat(approvedEvt.email()).isEqualTo("final-approved@ex.com");
+        assertThat(approvedEvt.message()).isEqualTo("최종 합격 안내 메시지");
+        assertThat(approvedEvt.stage()).isEqualTo(Stage.FINAL);
+
+        FinalRejectedEvent rejectedEvt = events.stream()
+                .filter(e -> e instanceof FinalRejectedEvent)
+                .map(e -> (FinalRejectedEvent) e)
+                .findFirst().orElseThrow();
+        assertThat(rejectedEvt.applicationId()).isEqualTo(202L);
+        assertThat(rejectedEvt.email()).isEqualTo("final-rejected@ex.com");
+        assertThat(rejectedEvt.stage()).isEqualTo(Stage.FINAL);
     }
 }

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/email/service/EmailServiceUnitTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/email/service/EmailServiceUnitTest.java
@@ -8,6 +8,7 @@ import com.kakaotech.team18.backend_server.domain.application.repository.Applica
 import com.kakaotech.team18.backend_server.domain.application.service.ApplicationServiceImpl;
 import com.kakaotech.team18.backend_server.domain.club.entity.Club;
 import com.kakaotech.team18.backend_server.domain.clubApplyForm.entity.ClubApplyForm;
+import com.kakaotech.team18.backend_server.domain.clubApplyForm.repository.ClubApplyFormRepository;
 import com.kakaotech.team18.backend_server.domain.clubMember.entity.ActiveStatus;
 import com.kakaotech.team18.backend_server.domain.clubMember.entity.Role;
 import com.kakaotech.team18.backend_server.domain.clubMember.repository.ClubMemberRepository;
@@ -73,6 +74,8 @@ class EmailServiceUnitTest {
     Application application;
     @Mock
     ClubApplyForm clubApplyForm;
+    @Mock
+    ClubApplyFormRepository clubApplyFormRepository;
     @Mock
     Club club;
     @Mock
@@ -192,6 +195,8 @@ class EmailServiceUnitTest {
         Application appRejected = mock(Application.class);
         Application appPending  = mock(Application.class);
 
+        when(clubApplyFormRepository.findByClub_Id(77L)).thenReturn(clubApplyForm);
+
         // 공통: stage 초기값은 INTERVIEW
         final Stage[] approvedStageRef = { Stage.INTERVIEW }; // updateStage 호출 시 바뀌게 함
         when(appApproved.getStage()).thenAnswer(inv -> approvedStageRef[0]);
@@ -227,6 +232,9 @@ class EmailServiceUnitTest {
 
         //then
         assertThat(resp).isNotNull();
+
+        verify(clubApplyFormRepository).findByClub_Id(77L);
+        verify(clubApplyForm).updateInterviewMessage("면접 합격 안내 메시지");
 
         // 승격 호출 확인
         verify(appApproved).updateStage(Stage.FINAL);
@@ -270,6 +278,8 @@ class EmailServiceUnitTest {
         Application appRejected = mock(Application.class);
         Application appPending  = mock(Application.class);
 
+        when(clubApplyFormRepository.findByClub_Id(88L)).thenReturn(clubApplyForm);
+
         when(appApproved.getStage()).thenReturn(Stage.FINAL);
         when(appRejected.getStage()).thenReturn(Stage.FINAL);
 
@@ -297,6 +307,9 @@ class EmailServiceUnitTest {
 
         //then
         assertThat(resp).isNotNull();
+
+        verify(clubApplyFormRepository).findByClub_Id(88L);
+        verify(clubApplyForm).updateFinalMessage("최종 합격 안내 메시지");
 
         // FINAL 단계에서는 승격 호출 없음
         verify(appApproved, never()).updateStage(any());

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/email/service/EmailServiceUnitTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/email/service/EmailServiceUnitTest.java
@@ -72,7 +72,7 @@ class EmailServiceUnitTest {
 
     @BeforeEach
     void setUp() {
-        service = new EmailService(renderer, emailSender, from, subjectPrefix, clubMemberRepository);
+        service = new EmailService(renderer, emailSender, from, clubMemberRepository);
     }
 
     private void stubHappyPath() {


### PR DESCRIPTION
## 🚀 작업 내용
지원자 관리창에서 결과 일괄전송에 대한 작업을 했습니다. 

* controller
PATCH /api/clubs/{clubId}/application-form/result?stage=INTERVIEW|FINAL

* service
stage=INTERVIEW이면 interviewMessage에 메세지 저장, approved는 FINAL로 승격, REJECTED는 삭제, PENDING은 무시
stage=FINAL이면 finalMessage에 메세지 저장, REJECTED는 삭제, PENDING은 무시
이메일은 approved와 rejected에게만 갑니다

* email
4가지의 전송을 위해 event를 4가지 생성하고, 각각에 맞는 form을 넣었습니다.


## ⏱️ 소요 시간
5h

## 🤔 고민했던 내용
메세지를 어디에 저장할지 고민했습니다. 
club vs clubApplyForm
새로운 form을 만들 때 마다 필요하다고 생각해서 form에 넣었습니다 

## 💬 리뷰 중점사항


## 🔗관련 이슈
- Close #82 