### PR TITLE
[REFACTOR] club

### DIFF
--- a/src/main/java/com/kakaotech/team18/backend_server/domain/club/controller/ClubController.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/club/controller/ClubController.java
@@ -32,8 +32,8 @@ public class ClubController{
     @Operation(summary = "전체 동아리 목록 조회", description = "모집 상태와 함께 전체 동아리 목록을 조회합니다.")
     @ApiResponse(responseCode = "200", description = "조회 성공")
     @GetMapping
-    public ResponseEntity<List<ClubListResponseDto>> getAllClubs() {
-        List<ClubListResponseDto> response = clubService.getAllClubs();
+    public ResponseEntity<ClubListResponseDto> getAllClubs() {
+        ClubListResponseDto response = clubService.getAllClubs();
         return ResponseEntity.ok(response);
     }
 
@@ -53,11 +53,10 @@ public class ClubController{
     @Operation(summary = "카테고리별 동아리 목록 조회", description = "특정 카테고리에 속한 동아리 목록을 조회합니다.")
     @ApiResponse(responseCode = "200", description = "조회 성공")
     @GetMapping("/search/category")
-    public ResponseEntity<List<ClubListResponseDto>> listClubsByCategory(
+    public ResponseEntity<ClubListResponseDto> listClubsByCategory(
             @Parameter(description = "조회할 동아리 카테고리", required = true, example = "SPORTS") @RequestParam String category
     ){
-        //List<ClubListResponseDto> response = clubService.getClubByCategory(Category.valueOf(category));
-        List<ClubListResponseDto> response = clubService.getClubByCategory(category);
+        ClubListResponseDto response = clubService.getClubByCategory(category);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/club/service/ClubService.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/club/service/ClubService.java
@@ -10,11 +10,11 @@ import java.util.List;
 
 public interface ClubService {
 
-    List<ClubListResponseDto> getClubByCategory(String category);
+    ClubListResponseDto getClubByCategory(String category);
 
-    List<ClubListResponseDto> getClubByName(String name);
+    ClubListResponseDto getClubByName(String name);
 
-    List<ClubListResponseDto> getAllClubs();
+    ClubListResponseDto getAllClubs();
 
     ClubDetailResponseDto getClubDetail(Long clubId);
 

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/club/service/ClubServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/club/service/ClubServiceImpl.java
@@ -41,7 +41,7 @@ public class ClubServiceImpl implements ClubService {
 
 
     @Override
-    public List<ClubListResponseDto> getClubByCategory(String category) {
+    public ClubListResponseDto getClubByCategory(String category) {
         if (category.equals("ALL")) {
             return mapToResponse(clubRepository.findAllProjectedBy());
         }
@@ -49,7 +49,7 @@ public class ClubServiceImpl implements ClubService {
     }
 
     @Override
-    public List<ClubListResponseDto> getClubByName(String name) {
+    public ClubListResponseDto getClubByName(String name) {
         if (name == null || name.isBlank()) {
             return mapToResponse(clubRepository.findAllProjectedBy());
         }
@@ -57,7 +57,7 @@ public class ClubServiceImpl implements ClubService {
     }
 
     @Override
-    public List<ClubListResponseDto> getAllClubs() {
+    public ClubListResponseDto getAllClubs() {
         return mapToResponse(clubRepository.findAllProjectedBy());
     }
 
@@ -87,9 +87,9 @@ public class ClubServiceImpl implements ClubService {
                 });
         ClubApplyForm clubApplyForm = clubApplyFormRepository
                 .findByClubId(club.getId()).orElseThrow(() -> {
-            log.warn("ClubApplyForm not found for id={}", clubId);
-            return new ClubApplyFormNotFoundException("clubId = " + clubId);
-        });
+                    log.warn("ClubApplyForm not found for id={}", clubId);
+                    return new ClubApplyFormNotFoundException("clubId = " + clubId);
+                });
         List<ClubMember> applicantList = clubMemberRepository.findByClubIdAndRole(clubId, Role.APPLICANT);
         List<Application> pendingApplication = applicationRepository.findByClubApplyFormIdAndStatus(clubApplyForm.getId(), Status.PENDING);
         log.info("동아리 대쉬보드를 조회합니다 clubId={}, applicantList={}", clubId, applicantList);
@@ -120,16 +120,15 @@ public class ClubServiceImpl implements ClubService {
         }
     }
 
-
     // ---- private helpers ----
-    private List<ClubListResponseDto> mapToResponse(List<ClubSummary> summaries) {
+    private ClubListResponseDto mapToResponse(List<ClubSummary> summaries) {
         List<ClubListResponseDto.ClubsInfo> clubs = summaries.stream()
-                .map(s -> ClubListResponseDto.from(
-                        s,
-                        RecruitStatusCalculator.calculate(s.getRecruitStart(), s.getRecruitEnd()).getDisplayName()
+                .map(summary -> ClubListResponseDto.from(
+                        summary,
+                        RecruitStatusCalculator.calculate(summary.getRecruitStart(), summary.getRecruitEnd()).getDisplayName()
                 ))
                 .toList();
 
-        return Collections.singletonList(new ClubListResponseDto(clubs));
+        return new ClubListResponseDto(clubs);
     }
 }

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/club/controller/ClubControllerIntegrationTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/club/controller/ClubControllerIntegrationTest.java
@@ -108,14 +108,13 @@ class ClubControllerIntegrationTest {
 
         // then
         resultActions.andExpect(status().isOk())
-                .andExpect(jsonPath("$.size()").value(1))
-                .andExpect(jsonPath("$[0].clubs.size()").value(2))
-                .andExpect(jsonPath("$[0].clubs[0].id").value(1))
-                .andExpect(jsonPath("$[0].clubs[0].name").value("동아리1"))
-                .andExpect(jsonPath("$[0].clubs[0].category").value("STUDY"))
-                .andExpect(jsonPath("$[0].clubs[1].id").value(2))
-                .andExpect(jsonPath("$[0].clubs[1].name").value("동아리2"))
-                .andExpect(jsonPath("$[0].clubs[1].category").value("SPORTS"))
+                .andExpect(jsonPath("$.clubs.size()").value(2))
+                .andExpect(jsonPath("$.clubs[0].id").value(1))
+                .andExpect(jsonPath("$.clubs[0].name").value("동아리1"))
+                .andExpect(jsonPath("$.clubs[0].category").value("STUDY"))
+                .andExpect(jsonPath("$.clubs[1].id").value(2))
+                .andExpect(jsonPath("$.clubs[1].name").value("동아리2"))
+                .andExpect(jsonPath("$.clubs[1].category").value("SPORTS"))
                 .andDo(print());
     }
 }

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/club/controller/ClubControllerTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/club/controller/ClubControllerTest.java
@@ -70,18 +70,17 @@ class ClubControllerTest {
         );
 
         ClubListResponseDto mockResponse = new ClubListResponseDto(List.of(club1, club2));
-        List<ClubListResponseDto> mockList = List.of(mockResponse);
 
-        when(clubService.getAllClubs()).thenReturn(mockList);
+        when(clubService.getAllClubs()).thenReturn(mockResponse);
 
         // when
         ResultActions resultActions = mockMvc.perform(get("/api/clubs"));
 
         // then
         resultActions.andExpect(status().isOk())
-                .andExpect(jsonPath("$[0].clubs.size()").value(2))
-                .andExpect(jsonPath("$[0].clubs[0].name").value("동아리1"))
-                .andExpect(jsonPath("$[0].clubs[1].recruitStatus").value("모집 종료"))
+                .andExpect(jsonPath("$.clubs.size()").value(2))
+                .andExpect(jsonPath("$.clubs[0].name").value("동아리1"))
+                .andExpect(jsonPath("$.clubs[1].recruitStatus").value("모집 종료"))
                 .andDo(print());
     }
     @DisplayName("동아리 상세 페이지를 조회한다.")

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/club/service/ClubServiceImplTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/club/service/ClubServiceImplTest.java
@@ -80,13 +80,12 @@ class ClubServiceImplTest {
                 when(clubRepository.findAllProjectedBy()).thenReturn(List.of(summary));
 
                 //when
-                List<ClubListResponseDto> result = clubService.getAllClubs();
+                ClubListResponseDto result = clubService.getAllClubs();
 
                 //then
-                assertThat(result).hasSize(1);
-                ClubListResponseDto wrapper = result.get(0);
-                assertThat(wrapper.clubs()).hasSize(1);
-                assertThat(wrapper.clubs().get(0).recruitStatus()).isEqualTo(DUMMY_STATUS_ENUM.getDisplayName());
+                assertThat(result.clubs()).hasSize(1);
+                assertThat(result.clubs().get(0).recruitStatus()).isEqualTo(DUMMY_STATUS_ENUM.getDisplayName());
+
                 verify(clubRepository, times(1)).findAllProjectedBy();
                 verifyNoMoreInteractions(clubRepository);
             }
@@ -102,10 +101,9 @@ class ClubServiceImplTest {
         void nullCategoryUsesAll() {
             when(clubRepository.findAllProjectedBy()).thenReturn(List.of());
 
-            List<ClubListResponseDto> result = clubService.getClubByCategory("ALL");
+            ClubListResponseDto result = clubService.getClubByCategory("ALL");
 
-            assertThat(result).hasSize(1);
-            assertThat(result.get(0).clubs()).isEmpty();
+            assertThat(result.clubs()).isEmpty();
             verify(clubRepository, times(1)).findAllProjectedBy();
             verify(clubRepository, never()).findSummariesByCategory(ArgumentMatchers.any());
         }
@@ -113,16 +111,14 @@ class ClubServiceImplTest {
         @Test
         @DisplayName("category 가 주어지면 카테고리 요약을 조회한다")
         void givenCategoryUsesByCategory() {
-            when(clubRepository.findSummariesByCategory(Category.SPORTS)).thenReturn(List.of(
-                    new TestClubSummary(10L, "Run Club", Category.SPORTS, "run", null, null)
-            ));
+            when(clubRepository.findSummariesByCategory(Category.SPORTS)).thenReturn(
+                    List.of(new TestClubSummary(10L, "Run Club", Category.SPORTS, "run", null, null))
+            );
 
-            List<ClubListResponseDto> result = clubService.getClubByCategory(String.valueOf(Category.SPORTS));
+            ClubListResponseDto result = clubService.getClubByCategory(String.valueOf(Category.SPORTS));
 
-            assertThat(result).hasSize(1);
-            ClubListResponseDto wrapper = result.get(0);
-            assertThat(wrapper.clubs()).hasSize(1);
-            assertThat(wrapper.clubs().get(0).name()).isEqualTo("Run Club");
+            assertThat(result.clubs()).hasSize(1);
+            assertThat(result.clubs().get(0).name()).isEqualTo("Run Club");
 
             verify(clubRepository, times(1)).findSummariesByCategory(Category.SPORTS);
             verify(clubRepository, never()).findAllProjectedBy();
@@ -138,20 +134,15 @@ class ClubServiceImplTest {
         void blankUsesAll() {
             when(clubRepository.findAllProjectedBy()).thenReturn(List.of());
 
-            List<ClubListResponseDto> r1 = clubService.getClubByName(null);
-            List<ClubListResponseDto> r2 = clubService.getClubByName("");
-            List<ClubListResponseDto> r3 = clubService.getClubByName("   ");
+            ClubListResponseDto r1 = clubService.getClubByName(null);
+            ClubListResponseDto r2 = clubService.getClubByName("");
+            ClubListResponseDto r3 = clubService.getClubByName("   ");
 
-            assertThat(r1).hasSize(1);
-            assertThat(r1.get(0).clubs()).isEmpty();
+            assertThat(r1.clubs()).isEmpty();
+            assertThat(r2.clubs()).isEmpty();
+            assertThat(r3.clubs()).isEmpty();
 
-            assertThat(r2).hasSize(1);
-            assertThat(r2.get(0).clubs()).isEmpty();
-
-            assertThat(r3).hasSize(1);
-            assertThat(r3.get(0).clubs()).isEmpty();
-
-            verify(clubRepository, times(3)).findAllProjectedBy(); // 세 번 호출
+            verify(clubRepository, times(3)).findAllProjectedBy();
             verify(clubRepository, never()).findSummariesByNameContaining(anyString());
         }
 
@@ -161,12 +152,10 @@ class ClubServiceImplTest {
             when(clubRepository.findSummariesByNameContaining("Inter"))
                     .thenReturn(List.of(new TestClubSummary(7L, "InterX", Category.STUDY, "si", null, null)));
 
-            List<ClubListResponseDto> result = clubService.getClubByName("Inter");
+            ClubListResponseDto result = clubService.getClubByName("Inter");
 
-            assertThat(result).hasSize(1);
-            ClubListResponseDto wrapper = result.get(0);
-            assertThat(wrapper.clubs()).hasSize(1);
-            assertThat(wrapper.clubs().get(0).name()).isEqualTo("InterX");
+            assertThat(result.clubs()).hasSize(1);
+            assertThat(result.clubs().get(0).name()).isEqualTo("InterX");
 
             verify(clubRepository, times(1)).findSummariesByNameContaining("Inter");
             verify(clubRepository, never()).findAllProjectedBy();


### PR DESCRIPTION
## 🚀 작업 내용
club response refactor

## ⏱️ 소요 시간
20m

## 🤔 고민했던 내용


## 💬 리뷰 중점사항


## 🔗관련 이슈
- Close #이슈번호

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - 클럽 목록 관련 API 응답을 단일 루트 객체로 통일했습니다. 전체 조회, 카테고리별 조회, 이름 검색 모두 루트에 clubs 배열이 포함된 객체를 반환합니다.
  - 기존에 최상위 배열을 기대하던 클라이언트는 파싱 로직을 루트 객체의 clubs 배열 기준으로 업데이트해야 합니다.
  - 화면 기능과 데이터 필드 구성은 동일하며, 응답 구조만 간소화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->