### PR TITLE
[fix] changed unmatching request names

### DIFF
--- a/src/main/java/com/kakaotech/team18/backend_server/domain/FormQuestion/dto/FormQuestionUpdateDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/FormQuestion/dto/FormQuestionUpdateDto.java
@@ -12,7 +12,7 @@ import java.util.List;
 @Schema(description = "지원서 양식 개별 질문 수정 정보")
 public record FormQuestionUpdateDto(
         @Schema(description = "질문 ID", example = "1")
-        Long questionId,
+        Long questionNum,
 
         @Schema(description = "질문 내용", example = "가장 자신 있는 프로그래밍 언어는 무엇인가요?")
         @NotBlank(message = "질문은 필수 입니다.")

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/application/dto/ApplicationApplyRequestDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/application/dto/ApplicationApplyRequestDto.java
@@ -24,11 +24,11 @@ public record ApplicationApplyRequestDto(
         @NotBlank(message = "학과는 필수입니다.")
         String department,
 
-        List<AnswerDto> answerList
+        List<AnswerDto> answers
 ) {
         public record AnswerDto(
-                Long questionId,
+                Long questionNum,
                 String question,
-                String answerContent
+                String answer
         ) {}
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/service/ClubApplyFormServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/service/ClubApplyFormServiceImpl.java
@@ -100,10 +100,10 @@ public class ClubApplyFormServiceImpl implements ClubApplyFormService {
             ClubApplyForm findClubApplyForm
     ) {
         for (FormQuestionUpdateDto dto : request.formQuestions()) {
-            if (dto.questionId() != null && existingMap.containsKey(dto.questionId())) {
-                existingMap.get(dto.questionId()).updateFrom(dto);
-                log.info("Updated FormQuestionId: {}", dto.questionId());
-                incomingIds.add(dto.questionId());
+            if (dto.questionNum() != null && existingMap.containsKey(dto.questionNum())) {
+                existingMap.get(dto.questionNum()).updateFrom(dto);
+                log.info("Updated FormQuestionNum: {}", dto.questionNum());
+                incomingIds.add(dto.questionNum());
             } else {
                 FormQuestion newQuestion = createFormQuestion(dto, findClubApplyForm);
                 FormQuestion savedFormQuestion = formQuestionRepository.save(newQuestion);

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/email/dto/AnswerEmailLine.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/email/dto/AnswerEmailLine.java
@@ -1,3 +1,7 @@
 package com.kakaotech.team18.backend_server.domain.email.dto;
 
-public record AnswerEmailLine(Long questionId, Long displayOrder, String question, String answer) {}
+public record AnswerEmailLine(
+        Long questionNum,
+        Long displayOrder,
+        String question,
+        String answer) {}

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/application/controller/ApplicationControllerTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/application/controller/ApplicationControllerTest.java
@@ -187,10 +187,10 @@ class ApplicationControllerTest {
           "name":"홍길동",
           "phoneNumber":"010-0000-0000",
           "department":"컴퓨터공학과",
-          "answerList": [
-          {"questionId":1,"answerContent":"자기소개입니다"},
-          {"questionId":2,"answerContent":"여"},
-          {"questionId":3,"answerContent":"A,B"}
+          "answers": [
+          {"questionNum":1,"question":"q","answer":"자기소개입니다"},
+          {"questionNum":2,"question":"q","answer":"여"},
+          {"questionNum":3,"question":"q","answer":"A,B"}
           ]
         }
         """;
@@ -205,7 +205,7 @@ class ApplicationControllerTest {
           "name":"",
           "phoneNumber":"",
           "department":"",
-          "answerList":[]
+          "answers":[]
         }
         """;
         }


### PR DESCRIPTION
## 🚀 작업 내용
answerList->answers
questionId->questionNum
answerContent->answer

## ⏱️ 소요 시간
10m

## 🤔 고민했던 내용


## 💬 리뷰 중점사항


## 🔗관련 이슈
- Close #이슈번호

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - 지원서 제출 API 필드명 정비: answerList → answers, questionId → questionNum, answerContent → answer로 변경해 용어 일관성 강화.
  - 폼 질문 식별 기준을 questionId에서 questionNum으로 통일하고 관련 검증/에러 메시지 표현을 업데이트.

- Tests
  - 컨트롤러 테스트를 새로운 요청 스키마(answers 배열, 각 항목의 questionNum/answer)에 맞게 수정하여 유효/무효 페이로드 검증을 최신화.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->