### PR TITLE
[REFACTOR] 동아리 한줄 소개 추가 및 동아리 모집 일정 모집폼에서 등록 (#132)

### DIFF
--- a/src/main/java/com/kakaotech/team18/backend_server/domain/club/dto/ClubDetailRequestDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/club/dto/ClubDetailRequestDto.java
@@ -57,5 +57,5 @@ public record ClubDetailRequestDto(
 
         @Schema(description = "등록/수정할 동아리 지원 유의사항", example = "지원 시 유의사항을 반드시 확인해주세요.")
         @NotBlank(message = "지원 유의사항은 필수입니다.")
-        String applicationNotices
+        String applicationNotice
 ) {}

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/club/dto/ClubDetailRequestDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/club/dto/ClubDetailRequestDto.java
@@ -10,29 +10,58 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 @Builder
-@Schema(description = "동아리 상세 정보 요청 데이터")
+@Schema(description = "동아리 상세 정보 등록/수정 요청 데이터")
 public record ClubDetailRequestDto(
+        @Schema(description = "등록/수정할 동아리 ID", example = "1")
+        @NotNull(message = "동아리 ID는 필수입니다.")
         Long  clubId,
 
-        @NotBlank
+        @Schema(description = "등록/수정할 동아리 이름", example = "개발하는 사람들")
+        @NotBlank(message = "동아리 이름은 필수입니다.")
         String clubName,
 
+        @Schema(description = "등록/수정할 주요 활동 장소", example = "학생회관 101호")
+        @NotBlank(message = "활동 장소는 필수입니다.")
         String location,
 
-        @NotNull
+        @Schema(description = "등록/수정할 동아리 카테고리", example = "STUDY")
+        @NotNull(message = "카테고리는 필수입니다.")
         Category category,
 
+        @Schema(description = "등록/수정할 동아리 한 줄 소개", example = "함께 성장하는 개발 동아리입니다.")
+        @NotBlank(message = "한 줄 소개는 필수입니다.")
         String shortIntroduction,
 
+        @Schema(description = "등록/수정할 동아리 소개 이미지 URL 목록")
         List<String> introductionImages,
 
+        @Schema(description = "등록/수정할 동아리 소개 (개요)", example = "저희는 스프링부트와 리액트를 공부하는 스터디 동아리입니다...")
+        @NotBlank(message = "소개 개요는 필수입니다.")
         String introductionOverview,
 
+        @Schema(description = "등록/수정할 동아리 소개 (활동 내용)", example = "매주 월요일 정기 스터디, 분기별 해커톤 진행")
+        @NotBlank(message = "소개 활동 내용은 필수입니다.")
         String introductionActivity,
 
+        @Schema(description = "등록/수정할 동아리 소개 (인재상)", example = "개발에 대한 열정이 넘치는 분")
+        @NotBlank(message = "소개 인재상은 필수입니다.")
         String introductionIdeal,
 
+        @Schema(description = "등록/수정할 정기 모임 정보", example = "매주 월요일 18시")
+        @NotBlank(message = "정기 모임 정보는 필수입니다.")
         String regularMeetingInfo,
+
+        @Schema(description = "등록/수정할 동아리 지원 유의사항", example = "지원 시 유의사항을 반드시 확인해주세요.")
+        @NotBlank(message = "지원 유의사항은 필수입니다.")
+        String caution,
+
+        @Schema(description = "모집 시작일")
+        @NotNull(message = "모집 시작일은 필수입니다.")
+        LocalDateTime recruitStart,
+
+        @Schema(description = "모집 마감일")
+        @NotNull(message = "모집 마감일은 필수입니다.")
+        LocalDateTime recruitEnd,
 
         String recruitStatus,
 
@@ -40,9 +69,7 @@ public record ClubDetailRequestDto(
 
         String presidentPhoneNumber,
 
-        LocalDateTime recruitStart,
-
-        LocalDateTime recruitEnd,
-
+        @Schema(description = "등록/수정할 동아리 지원 유의사항", example = "지원 시 유의사항을 반드시 확인해주세요.")
+        @NotBlank(message = "지원 유의사항은 필수입니다.")
         String applicationNotices
 ) {}

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/club/dto/ClubDetailRequestDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/club/dto/ClubDetailRequestDto.java
@@ -49,10 +49,6 @@ public record ClubDetailRequestDto(
         @NotBlank(message = "정기 모임 정보는 필수입니다.")
         String regularMeetingInfo,
 
-        @Schema(description = "등록/수정할 동아리 지원 유의사항", example = "지원 시 유의사항을 반드시 확인해주세요.")
-        @NotBlank(message = "지원 유의사항은 필수입니다.")
-        String caution,
-
         String recruitStatus,
 
         String presidentName,

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/club/dto/ClubDetailRequestDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/club/dto/ClubDetailRequestDto.java
@@ -4,10 +4,8 @@ import com.kakaotech.team18.backend_server.domain.club.entity.Category;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import lombok.Builder;
-
-import java.time.LocalDateTime;
 import java.util.List;
+import lombok.Builder;
 
 @Builder
 @Schema(description = "동아리 상세 정보 등록/수정 요청 데이터")
@@ -54,14 +52,6 @@ public record ClubDetailRequestDto(
         @Schema(description = "등록/수정할 동아리 지원 유의사항", example = "지원 시 유의사항을 반드시 확인해주세요.")
         @NotBlank(message = "지원 유의사항은 필수입니다.")
         String caution,
-
-        @Schema(description = "모집 시작일")
-        @NotNull(message = "모집 시작일은 필수입니다.")
-        LocalDateTime recruitStart,
-
-        @Schema(description = "모집 마감일")
-        @NotNull(message = "모집 마감일은 필수입니다.")
-        LocalDateTime recruitEnd,
 
         String recruitStatus,
 

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/club/dto/ClubDetailResponseDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/club/dto/ClubDetailResponseDto.java
@@ -31,7 +31,7 @@ public record ClubDetailResponseDto(
         @Schema(description = "동아리 회장 연락처", example = "010-1234-5678") String presidentPhoneNumber,
         @Schema(description = "모집 시작일") LocalDateTime recruitStart,
         @Schema(description = "모집 마감일") LocalDateTime recruitEnd,
-        @Schema(description = "동아리 지원 유의사항 목록") String applicationNotices
+        @Schema(description = "동아리 지원 유의사항 목록") String applicationNotice
 ) {
 
     public static ClubDetailResponseDto from(Club club, User user) {
@@ -57,7 +57,7 @@ public record ClubDetailResponseDto(
                 presidentPhoneNumber(user.getPhoneNumber()).
                 recruitStart(club.getRecruitStart()).
                 recruitEnd(club.getRecruitEnd()).
-                applicationNotices(club.getCaution()).
+                applicationNotice(club.getCaution()).
                 build();
     }
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/club/entity/Club.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/club/entity/Club.java
@@ -82,7 +82,7 @@ public class Club extends BaseEntity {
         this.category = dto.category();
         this.location = dto.location();
         this.shortIntroduction = dto.shortIntroduction();
-        this.caution = dto.applicationNotices();
+        this.caution = dto.applicationNotice();
         this.regularMeetingInfo = dto.regularMeetingInfo();
         this.introduction = buildNewIntroduction(dto);
     }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/club/entity/Club.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/club/entity/Club.java
@@ -18,10 +18,12 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Slf4j
 public class Club extends BaseEntity {
 
     @Id
@@ -81,10 +83,14 @@ public class Club extends BaseEntity {
         this.location = dto.location();
         this.shortIntroduction = dto.shortIntroduction();
         this.caution = dto.applicationNotices();
-        this.recruitStart = dto.recruitStart();
-        this.recruitEnd = dto.recruitEnd();
         this.regularMeetingInfo = dto.regularMeetingInfo();
         this.introduction = buildNewIntroduction(dto);
+    }
+
+    public void updateRecruitDate(LocalDateTime recruitStart, LocalDateTime recruitEnd) {
+        this.recruitStart = recruitStart;
+        this.recruitEnd = recruitEnd;
+        log.info("Updated recruit date for clubId: {} to start: {} end: {}", this.id, recruitStart, recruitEnd);
     }
 
     private ClubIntroduction buildNewIntroduction(ClubDetailRequestDto dto) {
@@ -104,5 +110,4 @@ public class Club extends BaseEntity {
         }
         return newIntro;
     }
-
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/club/service/ClubServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/club/service/ClubServiceImpl.java
@@ -1,8 +1,8 @@
 package com.kakaotech.team18.backend_server.domain.club.service;
 
 import com.kakaotech.team18.backend_server.domain.application.entity.Application;
-import com.kakaotech.team18.backend_server.domain.application.entity.Status;
 import com.kakaotech.team18.backend_server.domain.application.entity.Stage;
+import com.kakaotech.team18.backend_server.domain.application.entity.Status;
 import com.kakaotech.team18.backend_server.domain.application.repository.ApplicationRepository;
 import com.kakaotech.team18.backend_server.domain.club.dto.ClubDashBoardResponseDto;
 import com.kakaotech.team18.backend_server.domain.club.dto.ClubDashboardApplicantResponseDto;
@@ -24,10 +24,7 @@ import com.kakaotech.team18.backend_server.global.dto.SuccessResponseDto;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.ClubApplyFormNotFoundException;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.ClubMemberNotFoudException;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.ClubNotFoundException;
-
-import java.util.Collections;
 import java.util.List;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/dto/ClubApplyFormRequestDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/dto/ClubApplyFormRequestDto.java
@@ -3,6 +3,7 @@ package com.kakaotech.team18.backend_server.domain.clubApplyForm.dto;
 import com.kakaotech.team18.backend_server.domain.formQuestion.dto.FormQuestionRequestDto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
@@ -32,5 +33,8 @@ public record ClubApplyFormRequestDto(
         @Valid
         List<@Valid FormQuestionRequestDto> formQuestions
 ) {
-
+        @AssertTrue(message = "모집 마감일은 시작일과 같거나 이후여야 합니다.")
+        public boolean isRecruitPeriodValid() {
+                return recruitStart == null || recruitEnd == null || !recruitEnd.isBefore(recruitStart);
+        }
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/dto/ClubApplyFormRequestDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/dto/ClubApplyFormRequestDto.java
@@ -5,6 +5,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Schema(description = "지원서 양식 등록 정보")
@@ -16,6 +18,14 @@ public record ClubApplyFormRequestDto(
         @Schema(description = "지원서 설명", example = "카카오테크 캠퍼스 12기 모집을 위한 지원서입니다.")
         @NotBlank(message = "설명은 필수 값입니다.")
         String description,
+
+        @Schema(description = "모집 시작일")
+        @NotNull(message = "모집 시작일은 필수입니다.")
+        LocalDateTime recruitStart,
+
+        @Schema(description = "모집 마감일")
+        @NotNull(message = "모집 마감일은 필수입니다.")
+        LocalDateTime recruitEnd,
 
         @Schema(description = "질문 목록")
         @NotEmpty(message = "질문 목록은 최소 1개 이상이어야 합니다.")

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/dto/ClubApplyFormUpdateDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/dto/ClubApplyFormUpdateDto.java
@@ -5,6 +5,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Schema(description = "지원서 양식 수정 정보")
@@ -16,6 +18,14 @@ public record ClubApplyFormUpdateDto(
         @Schema(description = "지원서 설명", example = "카카오테크 캠퍼스 12기 모집을 위한 지원서입니다.")
         @NotBlank(message = "설명은 필수 값입니다.")
         String description,
+
+        @Schema(description = "모집 시작일")
+        @NotNull(message = "모집 시작일은 필수입니다.")
+        LocalDateTime recruitStart,
+
+        @Schema(description = "모집 마감일")
+        @NotNull(message = "모집 마감일은 필수입니다.")
+        LocalDateTime recruitEnd,
 
         @Schema(description = "질문 목록")
         @NotEmpty(message = "질문 목록은 최소 1개 이상이어야 합니다.")

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/dto/ClubApplyFormUpdateDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/dto/ClubApplyFormUpdateDto.java
@@ -3,6 +3,7 @@ package com.kakaotech.team18.backend_server.domain.clubApplyForm.dto;
 import com.kakaotech.team18.backend_server.domain.formQuestion.dto.FormQuestionUpdateDto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
@@ -32,5 +33,8 @@ public record ClubApplyFormUpdateDto(
         @Valid
         List<@Valid FormQuestionUpdateDto> formQuestions
 ) {
-
+        @AssertTrue(message = "모집 마감일은 시작일과 같거나 이후여야 합니다.")
+        public boolean isRecruitPeriodValid() {
+                return recruitStart == null || recruitEnd == null || !recruitEnd.isBefore(recruitStart);
+        }
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/service/ClubApplyFormServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/service/ClubApplyFormServiceImpl.java
@@ -65,6 +65,8 @@ public class ClubApplyFormServiceImpl implements ClubApplyFormService {
         ClubApplyForm savedClubApplyForm = clubApplyFormRepository.save(clubApplyForm);
         log.info("Saved ClubApplyFormId: {}", savedClubApplyForm.getId());
 
+        findClub.updateRecruitDate(request.recruitStart(), request.recruitEnd());
+
         request.formQuestions().forEach(formQuestionRequestDto -> {
             FormQuestion formQuestion = createFormQuestion(formQuestionRequestDto, savedClubApplyForm);
             formQuestionRepository.save(formQuestion);
@@ -75,13 +77,14 @@ public class ClubApplyFormServiceImpl implements ClubApplyFormService {
     @Override
     @Transactional
     public void updateClubApplyForm(Long clubId, ClubApplyFormUpdateDto request) {
-        Club club = findClub(clubId);
-        ClubApplyForm findClubApplyForm = clubApplyFormRepository.findByClubId(club.getId())
+        Club findClub = findClub(clubId);
+        ClubApplyForm findClubApplyForm = clubApplyFormRepository.findByClubId(findClub.getId())
                 .orElseThrow(() -> {
                     log.warn("ClubApplyForm not found for clubId: {}", clubId);
-                    return new ClubApplyFormNotFoundException("clubId = " + club.getId());
+                    return new ClubApplyFormNotFoundException("clubId = " + findClub.getId());
                 });
 
+        findClub.updateRecruitDate(request.recruitStart(), request.recruitEnd());
         findClubApplyForm.update(request.title(), request.description());
         //기존 FormQuestion 찾아서 Map에 등록
         Map<Long, FormQuestion> existingMap = formQuestionRepository.findByClubApplyForm(

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/club/controller/ClubControllerTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/club/controller/ClubControllerTest.java
@@ -144,7 +144,7 @@ class ClubControllerTest {
                 .presidentPhoneNumber("010-1234-5678")
                 .recruitStart(LocalDateTime.of(2025, 9, 3, 0, 0))
                 .recruitEnd(LocalDateTime.of(2025, 9, 20, 23, 59))
-                .applicationNotices("주의사항")
+                .applicationNotice("주의사항")
                 .build();
 
         when(clubService.getClubDetail(clubId)).thenReturn(expected);

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/club/service/ClubServiceMockTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/club/service/ClubServiceMockTest.java
@@ -269,7 +269,7 @@ public class ClubServiceMockTest {
                 .introductionActivity("new activity")
                 .introductionIdeal("new ideal")
                 .introductionImages(List.of("n1.png", "n2.png", "n1.png"))
-                .applicationNotices("주의사항")
+                .applicationNotice("주의사항")
                 .regularMeetingInfo("매주 수 18:00")
                 .build();
 

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/club/service/ClubServiceMockTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/club/service/ClubServiceMockTest.java
@@ -270,8 +270,6 @@ public class ClubServiceMockTest {
                 .introductionIdeal("new ideal")
                 .introductionImages(List.of("n1.png", "n2.png", "n1.png"))
                 .applicationNotices("주의사항")
-                .recruitStart(LocalDateTime.of(2025, 10, 1, 0, 0))
-                .recruitEnd(LocalDateTime.of(2025, 10, 31, 23, 59))
                 .regularMeetingInfo("매주 수 18:00")
                 .build();
 
@@ -286,8 +284,6 @@ public class ClubServiceMockTest {
         assertThat(club.getLocation()).isEqualTo("인문대 2호관");
         assertThat(club.getShortIntroduction()).isEqualTo("new short");
         assertThat(club.getCaution()).isEqualTo("주의사항");
-        assertThat(club.getRecruitStart()).isEqualTo(LocalDateTime.of(2025, 10, 1, 0, 0));
-        assertThat(club.getRecruitEnd()).isEqualTo(LocalDateTime.of(2025, 10, 31, 23, 59));
         assertThat(club.getRegularMeetingInfo()).isEqualTo("매주 수 18:00");
 
         // introduction 교체 확인

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/controller/ClubApplyFormControllerTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/controller/ClubApplyFormControllerTest.java
@@ -242,6 +242,27 @@ class ClubApplyFormControllerTest {
                 .andExpect(jsonPath("$.message").exists());
     }
 
+    @DisplayName("동아리 지원서 저장 API 호출 - 실패(동아리 시작일이 마감일보다 이전인 경우 400 응답)")
+    @Test
+    void timeSlotQuestionWithWrongClubPeriod() throws Exception {
+        Long clubId = 1L;
+        ClubApplyFormRequestDto invalidRequestDto = new ClubApplyFormRequestDto(
+                "테스트 지원서",
+                "설명",
+                LocalDateTime.of(2025, 10, 31, 0, 0),
+                LocalDateTime.of(2025, 10, 1, 23, 59),
+                List.of(new FormQuestionRequestDto("면접 가능한 시간대를 선택해 주세요.", FieldType.TEXT, true, 1L, null, null))
+        );
+
+        mockMvc.perform(post("/api/clubs/{clubId}/dashboard/apply-form", clubId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(invalidRequestDto))
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").exists());
+    }
+
     @DisplayName("동아리 지원서 수정 API 호출 - 성공")
     @Test
     void updateClubApplyForm() throws Exception {

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/controller/ClubApplyFormControllerTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/controller/ClubApplyFormControllerTest.java
@@ -242,9 +242,9 @@ class ClubApplyFormControllerTest {
                 .andExpect(jsonPath("$.message").exists());
     }
 
-    @DisplayName("동아리 지원서 저장 API 호출 - 실패(동아리 시작일이 마감일보다 이전인 경우 400 응답)")
+    @DisplayName("동아리 지원서 저장 API 호출 - 실패(동아리 마감일이 시작일보다 이전인 경우 400 응답)")
     @Test
-    void timeSlotQuestionWithWrongClubPeriod() throws Exception {
+    void createClubApplyForm_invalidRecruitmentPeriod() throws Exception {
         Long clubId = 1L;
         ClubApplyFormRequestDto invalidRequestDto = new ClubApplyFormRequestDto(
                 "테스트 지원서",

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/controller/ClubApplyFormControllerTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/controller/ClubApplyFormControllerTest.java
@@ -27,6 +27,7 @@ import com.kakaotech.team18.backend_server.global.config.TestSecurityConfig;
 import com.kakaotech.team18.backend_server.global.security.JwtAuthenticationFilter;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.ClubApplyFormNotFoundException;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.ClubNotFoundException;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -152,8 +153,10 @@ class ClubApplyFormControllerTest {
         ClubApplyFormRequestDto clubApplyFormRequestDto = new ClubApplyFormRequestDto(
                 "테스트 지원서",
                 "테스트 설명",
-                List.of(new FormQuestionRequestDto("질문 1", FieldType.TEXT, true, 1L, null, null)
-                ));
+                LocalDateTime.of(2025, 10, 1, 0, 0),
+                LocalDateTime.of(2025, 10, 31, 23, 59),
+                List.of(new FormQuestionRequestDto("질문 1", FieldType.TEXT, true, 1L, null, null))
+                );
 
         doNothing().when(clubApplyFormService).createClubApplyForm(clubId, clubApplyFormRequestDto);
 
@@ -177,8 +180,10 @@ class ClubApplyFormControllerTest {
         ClubApplyFormRequestDto clubApplyFormRequestDto = new ClubApplyFormRequestDto(
                 "테스트 지원서",
                 "테스트 설명",
-                List.of(new FormQuestionRequestDto("질문 1", FieldType.TEXT, true, 1L, null, null)
-                ));
+                LocalDateTime.of(2025, 10, 1, 0, 0),
+                LocalDateTime.of(2025, 10, 31, 23, 59),
+                List.of(new FormQuestionRequestDto("질문 1", FieldType.TEXT, true, 1L, null, null))
+        );
 
         doThrow(new ClubNotFoundException("clubId")).when(clubApplyFormService).createClubApplyForm(clubId, clubApplyFormRequestDto);
 
@@ -200,6 +205,8 @@ class ClubApplyFormControllerTest {
         Long clubId = 1L;
         // question 필드가 blank인 경우
         ClubApplyFormRequestDto clubApplyFormRequestDto = new ClubApplyFormRequestDto("테스트 지원서", "테스트 설명",
+                LocalDateTime.of(2025, 10, 1, 0, 0),
+                LocalDateTime.of(2025, 10, 31, 23, 59),
                 List.of(new FormQuestionRequestDto("", FieldType.TEXT, true, 1L, null, null)));
 
         //when & then
@@ -221,6 +228,8 @@ class ClubApplyFormControllerTest {
         ClubApplyFormRequestDto invalidRequestDto = new ClubApplyFormRequestDto(
                 "테스트 지원서",
                 "설명",
+                LocalDateTime.of(2025, 10, 1, 0, 0),
+                LocalDateTime.of(2025, 10, 31, 23, 59),
                 List.of(new FormQuestionRequestDto("면접 가능한 시간대를 선택해 주세요.", FieldType.TIME_SLOT, true, 1L, null, null))
         );
 
@@ -241,6 +250,8 @@ class ClubApplyFormControllerTest {
         ClubApplyFormUpdateDto clubApplyFormUpdateDto = new ClubApplyFormUpdateDto(
                 "테스트 지원서",
                 "테스트 설명",
+                LocalDateTime.of(2025, 10, 1, 0, 0),
+                LocalDateTime.of(2025, 10, 31, 23, 59),
                 List.of(new FormQuestionUpdateDto(1L, "질문 1", FieldType.TEXT, true, 1L, null, null)
                 ));
 
@@ -265,6 +276,8 @@ class ClubApplyFormControllerTest {
         ClubApplyFormUpdateDto clubApplyFormUpdateDto = new ClubApplyFormUpdateDto(
                 "테스트 지원서",
                 "테스트 설명",
+                LocalDateTime.of(2025, 10, 1, 0, 0),
+                LocalDateTime.of(2025, 10, 31, 23, 59),
                 List.of(new FormQuestionUpdateDto(1L, "질문 1", FieldType.TEXT, true, 1L, null, null)
                 ));
 
@@ -287,7 +300,11 @@ class ClubApplyFormControllerTest {
         //given
         Long clubId = 1L;
         // question 필드가 blank인 경우
-        ClubApplyFormUpdateDto clubApplyFormUpdateDto = new ClubApplyFormUpdateDto("테스트 지원서", "테스트 설명",
+        ClubApplyFormUpdateDto clubApplyFormUpdateDto = new ClubApplyFormUpdateDto(
+                "테스트 지원서",
+                "테스트 설명",
+                LocalDateTime.of(2025, 10, 1, 0, 0),
+                LocalDateTime.of(2025, 10, 31, 23, 59),
                 List.of(new FormQuestionUpdateDto(1L, "", FieldType.TEXT, true, 1L, null, null)));
 
         //when & then
@@ -309,6 +326,8 @@ class ClubApplyFormControllerTest {
         ClubApplyFormUpdateDto invalidRequestDto = new ClubApplyFormUpdateDto(
                 "테스트 지원서",
                 "설명",
+                LocalDateTime.of(2025, 10, 1, 0, 0),
+                LocalDateTime.of(2025, 10, 31, 23, 59),
                 List.of(new FormQuestionUpdateDto(1L, "면접 가능한 시간대를 선택해 주세요.", FieldType.TIME_SLOT, true, 1L, null, null))
         );
 

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/service/ClubApplyFormServiceImplMockTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/service/ClubApplyFormServiceImplMockTest.java
@@ -27,6 +27,7 @@ import com.kakaotech.team18.backend_server.domain.clubApplyForm.repository.ClubA
 import com.kakaotech.team18.backend_server.global.exception.exceptions.ClubApplyFormNotFoundException;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.ClubNotFoundException;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.assertj.core.api.Assertions;
@@ -116,7 +117,11 @@ class ClubApplyFormServiceImplMockTest {
                 false, 2L, List.of("옵션 1", "옵션 2"),
                 List.of(new TimeSlotOptionRequestDto("2025-09-24", new TimeSlotOptionRequestDto.TimeRange("10:00", "21:00")))
         );
-        ClubApplyFormRequestDto requestDto = new ClubApplyFormRequestDto("테스트 지원서", "테스트 설명", List.of(question1, question2));
+        ClubApplyFormRequestDto requestDto = new ClubApplyFormRequestDto("테스트 지원서",
+                "테스트 설명",
+                LocalDateTime.of(2025, 10, 1, 0, 0),
+                LocalDateTime.of(2025, 10, 31, 23, 59),
+                List.of(question1, question2));
 
         ClubApplyForm clubApplyForm = ClubApplyForm.builder()
                 .club(club)
@@ -147,7 +152,11 @@ class ClubApplyFormServiceImplMockTest {
         //given
         Long clubId = 1L;
         FormQuestionRequestDto question1 = new FormQuestionRequestDto("질문 1", FieldType.TEXT, true, 1L, null, null);
-        ClubApplyFormRequestDto requestDto = new ClubApplyFormRequestDto("테스트 지원서", "테스트 설명", List.of(question1));
+        ClubApplyFormRequestDto requestDto = new ClubApplyFormRequestDto("테스트 지원서",
+                "테스트 설명",
+                LocalDateTime.of(2025, 10, 1, 0, 0),
+                LocalDateTime.of(2025, 10, 31, 23, 59),
+                List.of(question1));
 
         given(clubRepository.findById(clubId)).willReturn(Optional.empty());
 
@@ -192,8 +201,10 @@ class ClubApplyFormServiceImplMockTest {
         ClubApplyFormUpdateDto requestDto = new ClubApplyFormUpdateDto(
                 "수정된 지원서 제목",
                 "수정된 지원서 설명",
+                LocalDateTime.of(2025, 10, 1, 0, 0),
+                LocalDateTime.of(2025, 10, 31, 23, 59),
                 List.of(
-                        new com.kakaotech.team18.backend_server.domain.formQuestion.dto.FormQuestionUpdateDto(
+                        new FormQuestionUpdateDto(
                                 1L,
                                 "수정된 질문 1",
                                 FieldType.TEXT,
@@ -202,7 +213,7 @@ class ClubApplyFormServiceImplMockTest {
                                 null,
                                 null
                         ),
-                        new com.kakaotech.team18.backend_server.domain.formQuestion.dto.FormQuestionUpdateDto(
+                        new FormQuestionUpdateDto(
                                 null,
                                 "새로운 질문 3",
                                 FieldType.CHECKBOX,
@@ -233,7 +244,12 @@ class ClubApplyFormServiceImplMockTest {
         Club club = mock(Club.class);
         ReflectionTestUtils.setField(club, "id", 1L);
         FormQuestionUpdateDto question1 = new FormQuestionUpdateDto(1L, "질문 1", FieldType.TEXT, true, 1L, null, null);
-        ClubApplyFormUpdateDto requestDto = new ClubApplyFormUpdateDto("테스트 지원서", "테스트 설명", List.of(question1));
+        ClubApplyFormUpdateDto requestDto = new ClubApplyFormUpdateDto(
+                "테스트 지원서",
+                "테스트 설명",
+                LocalDateTime.of(2025, 10, 1, 0, 0),
+                LocalDateTime.of(2025, 10, 31, 23, 59),
+                List.of(question1));
 
         given(club.getId()).willReturn(1L);
         given(clubRepository.findById(clubId)).willReturn(Optional.of(club));
@@ -247,7 +263,8 @@ class ClubApplyFormServiceImplMockTest {
         then(clubRepository).should(times(1)).findById(clubId);
         then(clubApplyFormRepository).should(times(1)).findByClubId(clubId);
         then(clubApplyFormRepository).should(never()).save(any(ClubApplyForm.class));
-        then(formQuestionRepository).should(never()).save(any(FormQuestion.class));    }
+        then(formQuestionRepository).should(never()).save(any(FormQuestion.class));
+    }
 
 
     private ClubApplyForm createClubApplyForm(Club findClub) {


### PR DESCRIPTION
## 🚀 작업 내용
동아리 한줄 소개는 이미 shortIntroduction으로 존재해서 구현 안했습니다. 
모집 일정을 동아리 상세페이지가 아니라 모집 폼에서 등록/수정하도록 변경했습니다. 

## ⏱️ 소요 시간
30분 

## 🤔 고민했던 내용
기존 코드가 유지되도록 노력했습니다. 

## 💬 리뷰 중점사항
코드를 작성하다보니 DB에 뭐가 먼저 들어가야하는지 좀 애매하다고 느꼈습니다. 

지금 ClubDetail은 등록이 아니라 수정하는 기능만 수행하는 것 같은데 (club을 save하는 곳이 없고, `updateClubDetail`만 존재함)
이렇게 되면 

Club 을 우리가 DB로 직접 등록해주고 -> 사용자가 클럽 상세 페이지 수정 -> 이때는 지원 일정이 null -> 그리고 지원폼 등록할 때 지원 일정이 등록됨 

이런 순서로 진행될 것 같은데 괜찮아 보이나요? 

그리고 동아리 상세페이지가 등록이 없고 수정만 있으면 제 셍각에는 Controller의 updateClub이라는 API의 POST 메서드는 PATCH로 변경되어야 할 것 같아요. 의견 주세요!


## 🔗관련 이슈
- Close #132 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신기능**
  - 지원서 생성/수정에 모집 시작·마감일 필드를 추가하고, 저장/수정 시 동아리의 모집 기간이 함께 갱신됩니다.
- **문서**
  - 동아리 상세 및 지원서 요청 항목에 설명과 예시를 보강해 API 문서 가독성 향상.
- **기타**
  - 요청 페이로드에 필수/비어있음 검증 추가 및 모집 기간 유효성(마감일 ≥ 시작일) 검사 도입.
- **변경**
  - 동아리 상세의 지원 유의사항 필드명을 단수화(applicationNotices → applicationNotice)하고 시간 관련 필드 구조 조정.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->