### PR TITLE
[REFACTOR]지민 5차 코드리뷰 피드백 반영 (#140)

### DIFF
--- a/.github/workflows/deploy-with-docker.yml
+++ b/.github/workflows/deploy-with-docker.yml
@@ -99,11 +99,6 @@ jobs:
           source: "docker-compose.yml"
           target: "${{ env.REMOTE_DIR }}/current"
 
-      - name: Debug Secrets (TEMPORARY)
-        run: |
-          echo "KAKAO_CLIENT_ID = ${{ secrets.KAKAO_CLIENT_ID }}"
-          echo "JWT_SECRET = ${{ secrets.JWT_SECRET }}"
-
       - name: Deploy on EC2 (create .env, set credHelpers, compose up)
         uses: appleboy/ssh-action@v1.0.3
         with:

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/application/dto/ApplicationApplyRequestDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/application/dto/ApplicationApplyRequestDto.java
@@ -1,8 +1,11 @@
 package com.kakaotech.team18.backend_server.domain.application.dto;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.kakaotech.team18.backend_server.global.annotation.NoSpecialChar;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 
 import java.util.List;
 
@@ -13,12 +16,16 @@ public record ApplicationApplyRequestDto(
         String email,
 
         @NotBlank(message = "이름은 필수입니다.")
+        @NoSpecialChar
         String name,
 
         @NotBlank(message = "학번은 필수입니다.")
+        @Pattern(regexp = "\\d{6}", message = "학번은 6자리 숫자여야 합니다.")
+        @NoSpecialChar
         String studentId,
 
-        @NotBlank(message = "전화번호는 필수입니다.")
+        @Schema(description = "전화번호 (하이픈(-) 제외)", example = "01012345678")
+        @Pattern(regexp = "^\\d{10,11}$", message = "올바른 전화번호 형식이 아닙니다.")
         String phoneNumber,
 
         @NotBlank(message = "학과는 필수입니다.")

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/auth/dto/RegisterRequestDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/auth/dto/RegisterRequestDto.java
@@ -1,5 +1,6 @@
 package com.kakaotech.team18.backend_server.domain.auth.dto;
 
+import com.kakaotech.team18.backend_server.global.annotation.NoSpecialChar;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotEmpty;
@@ -9,6 +10,7 @@ import jakarta.validation.constraints.Pattern;
 public record RegisterRequestDto(
     @Schema(description = "이름(실명)", requiredMode = Schema.RequiredMode.REQUIRED, example = "김지원")
     @NotEmpty(message = "이름은 비어 있을 수 없습니다.")
+    @NoSpecialChar
     String name,
 
     @Schema(description = "이메일", requiredMode = Schema.RequiredMode.REQUIRED, example = "user@example.com")
@@ -18,6 +20,8 @@ public record RegisterRequestDto(
 
     @Schema(description = "학번", requiredMode = Schema.RequiredMode.REQUIRED, example = "213456")
     @NotEmpty(message = "학번은 비어 있을 수 없습니다.")
+    @Pattern(regexp = "\\d{6}", message = "학번은 6자리 숫자여야 합니다.")
+    @NoSpecialChar
     String studentId,
 
     @Schema(description = "학과", requiredMode = Schema.RequiredMode.REQUIRED, example = "컴퓨터공학과")

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/club/service/ClubServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/club/service/ClubServiceImpl.java
@@ -22,8 +22,9 @@ import com.kakaotech.team18.backend_server.domain.clubMember.entity.Role;
 import com.kakaotech.team18.backend_server.domain.clubMember.repository.ClubMemberRepository;
 import com.kakaotech.team18.backend_server.global.dto.SuccessResponseDto;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.ClubApplyFormNotFoundException;
-import com.kakaotech.team18.backend_server.global.exception.exceptions.ClubMemberNotFoudException;
+import com.kakaotech.team18.backend_server.global.exception.exceptions.ClubMemberNotFoundException;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.ClubNotFoundException;
+
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -75,7 +76,7 @@ public class ClubServiceImpl implements ClubService {
         ClubMember clubAdmin = clubMemberRepository.findClubAdminByClubIdAndRole(findClub.getId(), Role.CLUB_ADMIN)
                 .orElseThrow(() -> {
                     log.warn("ClubAdmin not found for id={}", findClub.getId());
-                    return new ClubMemberNotFoudException("해당 동아리의 동아리 회장을 찾을 수 없습니다 clubId = " + findClub.getId());
+                    return new ClubMemberNotFoundException("해당 동아리의 동아리 회장을 찾을 수 없습니다 clubId = " + findClub.getId());
                 });
         return ClubDetailResponseDto.from(findClub, clubAdmin.getUser());
     }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/dto/ClubApplyFormRequestDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/dto/ClubApplyFormRequestDto.java
@@ -8,16 +8,19 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
+import jakarta.validation.constraints.Size;
 import java.util.List;
 
 @Schema(description = "지원서 양식 등록 정보")
 public record ClubApplyFormRequestDto(
         @Schema(description = "지원서 제목", example = "카태켐 12기 지원서")
         @NotBlank(message = "제목은 필수 값입니다.")
+        @Size(max = 50, message = "제목은 50자 이내로 입력해주세요.")
         String title,
 
         @Schema(description = "지원서 설명", example = "카카오테크 캠퍼스 12기 모집을 위한 지원서입니다.")
         @NotBlank(message = "설명은 필수 값입니다.")
+        @Size(max = 100, message = "설명은 100자 이내로 입력해주세요.")
         String description,
 
         @Schema(description = "모집 시작일")

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/dto/ClubApplyFormUpdateDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/dto/ClubApplyFormUpdateDto.java
@@ -8,16 +8,19 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
+import jakarta.validation.constraints.Size;
 import java.util.List;
 
 @Schema(description = "지원서 양식 수정 정보")
 public record ClubApplyFormUpdateDto(
         @Schema(description = "지원서 제목", example = "카태켐 12기 지원서")
         @NotBlank(message = "제목은 필수 값입니다.")
+        @Size(max = 50, message = "제목은 50자 이내로 입력해주세요.")
         String title,
 
         @Schema(description = "지원서 설명", example = "카카오테크 캠퍼스 12기 모집을 위한 지원서입니다.")
         @NotBlank(message = "설명은 필수 값입니다.")
+        @Size(max = 100, message = "설명은 100자 이내로 입력해주세요.")
         String description,
 
         @Schema(description = "모집 시작일")

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/service/ClubApplyFormServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/service/ClubApplyFormServiceImpl.java
@@ -153,7 +153,7 @@ public class ClubApplyFormServiceImpl implements ClubApplyFormService {
             builder.timeSlotOptions(timeSlots != null
                     ? timeSlots.stream()
                     .map(tsoDto -> new TimeSlotOption(
-                            LocalDate.parse(tsoDto.date()),
+                            tsoDto.date(),
                             new TimeSlotOption.TimeRange(
                                     tsoDto.availableTime().start(),
                                     tsoDto.availableTime().end()

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/formQuestion/dto/FormQuestionRequestDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/formQuestion/dto/FormQuestionRequestDto.java
@@ -7,6 +7,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
 import java.util.List;
 
 @ValidFormQuestionRequest
@@ -14,6 +15,7 @@ import java.util.List;
 public record FormQuestionRequestDto(
         @Schema(description = "질문 내용", example = "가장 자신 있는 프로그래밍 언어는 무엇인가요?")
         @NotBlank(message = "질문은 필수 입니다.")
+        @Size(max = 100, message = "질문은 100자 이내로 입력해주세요.")
         String question,
 
         @Schema(description = "질문 유형", example = "[TEXT, RADIO, CHECKBOX, TIME_SLOT 중 하나 입력 가능]")

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/formQuestion/dto/FormQuestionUpdateDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/formQuestion/dto/FormQuestionUpdateDto.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
 import java.util.List;
 
 @ValidFormQuestionRequest
@@ -16,6 +17,7 @@ public record FormQuestionUpdateDto(
 
         @Schema(description = "질문 내용", example = "가장 자신 있는 프로그래밍 언어는 무엇인가요?")
         @NotBlank(message = "질문은 필수 입니다.")
+        @Size(max = 100, message = "질문은 100자 이내로 입력해주세요.")
         String question,
 
         @Schema(description = "질문 유형", example = "[TEXT, RADIO, CHECKBOX, TIME_SLOT 중 하나 입력 가능]")

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/formQuestion/dto/TimeSlotOptionRequestDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/formQuestion/dto/TimeSlotOptionRequestDto.java
@@ -22,7 +22,7 @@ public record TimeSlotOptionRequestDto(
             @NotBlank(message = "면접 시작 시간은 필수 입니다.")
             String start,
 
-            @Schema(description = "면점 마감 시간", example = "21:00")
+            @Schema(description = "면접 마감 시간", example = "21:00")
             @NotBlank(message = "면접 마감 시간은 필수 입니다.")
             String end
     ) {}

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/formQuestion/dto/TimeSlotOptionRequestDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/formQuestion/dto/TimeSlotOptionRequestDto.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import java.time.LocalTime;
 
 @Schema(description = "동아리의 면접 가능 날짜")
 public record TimeSlotOptionRequestDto(
@@ -20,11 +21,11 @@ public record TimeSlotOptionRequestDto(
     public record TimeRange(
             @Schema(description = "면접 시작 시간", example = "10:00")
             @NotBlank(message = "면접 시작 시간은 필수 입니다.")
-            String start,
+            LocalTime start,
 
             @Schema(description = "면접 마감 시간", example = "21:00")
             @NotBlank(message = "면접 마감 시간은 필수 입니다.")
-            String end
+            LocalTime end
     ) {}
 }
 

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/formQuestion/dto/TimeSlotOptionRequestDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/formQuestion/dto/TimeSlotOptionRequestDto.java
@@ -2,15 +2,15 @@ package com.kakaotech.team18.backend_server.domain.formQuestion.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
 import java.time.LocalTime;
 
 @Schema(description = "동아리의 면접 가능 날짜")
 public record TimeSlotOptionRequestDto(
         @Schema(description = "면접 날짜", example = "2025-09-24")
-        @NotBlank
-        String date,
+        @NotNull(message = "면접 날짜는 필수 입니다.")
+        LocalDate date,
 
         @Schema(description = "가능한 면접 시간")
         @Valid
@@ -20,11 +20,11 @@ public record TimeSlotOptionRequestDto(
     @Schema(description = "동아리의 면접 가능 시간")
     public record TimeRange(
             @Schema(description = "면접 시작 시간", example = "10:00")
-            @NotBlank(message = "면접 시작 시간은 필수 입니다.")
+            @NotNull(message = "면접 시작 시간은 필수 입니다.")
             LocalTime start,
 
             @Schema(description = "면접 마감 시간", example = "21:00")
-            @NotBlank(message = "면접 마감 시간은 필수 입니다.")
+            @NotNull(message = "면접 마감 시간은 필수 입니다.")
             LocalTime end
     ) {}
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/formQuestion/entity/FormQuestion.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/formQuestion/entity/FormQuestion.java
@@ -87,7 +87,7 @@ public class FormQuestion extends BaseEntity {
             this.timeSlotOptions = dto.timeSlotOptions() != null
                     ? dto.timeSlotOptions().stream()
                     .map(tsoDto -> new TimeSlotOption(
-                            LocalDate.parse(tsoDto.date()),
+                            tsoDto.date(),
                             new TimeSlotOption.TimeRange(
                                     tsoDto.availableTime().start(),
                                     tsoDto.availableTime().end()

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/formQuestion/entity/TimeSlotOption.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/formQuestion/entity/TimeSlotOption.java
@@ -4,6 +4,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.Embedded;
 import java.time.LocalDate;
+import java.time.LocalTime;
 
 @Embeddable
 public record TimeSlotOption(
@@ -14,10 +15,10 @@ public record TimeSlotOption(
     @Embeddable
     public record TimeRange(
             @Column(name = "start_time")
-            String start,
+            LocalTime start,
 
             @Column(name = "end_time")
-            String end
+            LocalTime end
     ) {
     }
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/global/annotation/NoSpecialChar.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/annotation/NoSpecialChar.java
@@ -2,7 +2,11 @@ package com.kakaotech.team18.backend_server.global.annotation;
 
 import jakarta.validation.Constraint;
 import jakarta.validation.Payload;
-import java.lang.annotation.*;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 @Documented
 @Constraint(validatedBy = NoSpecialCharValidator.class)

--- a/src/main/java/com/kakaotech/team18/backend_server/global/annotation/NoSpecialChar.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/annotation/NoSpecialChar.java
@@ -1,0 +1,15 @@
+package com.kakaotech.team18.backend_server.global.annotation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = NoSpecialCharValidator.class)
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface NoSpecialChar {
+    String message() default "특수문자는 포함될 수 없습니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/global/annotation/NoSpecialCharValidator.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/annotation/NoSpecialCharValidator.java
@@ -1,0 +1,17 @@
+package com.kakaotech.team18.backend_server.global.annotation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import java.util.regex.Pattern;
+
+public class NoSpecialCharValidator implements ConstraintValidator<NoSpecialChar, String> {
+
+    // 한글, 영어, 숫자, 공백만 허용
+    private static final Pattern pattern = Pattern.compile("^[가-힣a-zA-Z0-9\\s]+$");
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        if (value == null) return true;
+        return pattern.matcher(value).matches();
+    }
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/global/exception/code/ErrorCode.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/exception/code/ErrorCode.java
@@ -53,7 +53,7 @@ public enum ErrorCode {
     // 404 NOT_FOUND: 리소스를 찾을 수 없음
     USER_NOT_FOUND("해당 유저가 존재하지 않습니다.", HttpStatus.NOT_FOUND),
     CLUB_NOT_FOUND("해당 동아리가 존재하지 않습니다.", HttpStatus.NOT_FOUND),
-    CLUB_MEMBER_NOT_FOUND("해당 클럽멤버 존재하지 않습니다.", HttpStatus.NOT_FOUND),
+    CLUB_MEMBER_NOT_FOUND("해당 클럽멤버가 존재하지 않습니다.", HttpStatus.NOT_FOUND),
     FORM_NOT_FOUND("지원폼이 존재하지 않습니다", HttpStatus.NOT_FOUND),
     APPLICATION_NOT_FOUND("해당 지원서를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     COMMENT_NOT_FOUND("해당 댓글을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),

--- a/src/main/java/com/kakaotech/team18/backend_server/global/exception/exceptions/ClubMemberNotFoundException.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/exception/exceptions/ClubMemberNotFoundException.java
@@ -2,9 +2,9 @@ package com.kakaotech.team18.backend_server.global.exception.exceptions;
 
 import com.kakaotech.team18.backend_server.global.exception.code.ErrorCode;
 
-public class ClubMemberNotFoudException extends CustomException {
+public class ClubMemberNotFoundException extends CustomException {
 
-    public ClubMemberNotFoudException(String detail) {
+    public ClubMemberNotFoundException(String detail) {
         super(ErrorCode.CLUB_MEMBER_NOT_FOUND, detail);
     }
 }

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/application/controller/ApplicationControllerTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/application/controller/ApplicationControllerTest.java
@@ -184,8 +184,8 @@ class ApplicationControllerTest {
         {
           "email":"stud@example.com",
           "name":"홍길동",
-          "studentId":"20231234",
-          "phoneNumber":"010-0000-0000",
+          "studentId":"202312",
+          "phoneNumber":"01000000000",
           "department":"컴퓨터공학과",
           "answers": [
           {"questionNum":0,"question":"q","answer":"자기소개입니다"},
@@ -207,6 +207,25 @@ class ApplicationControllerTest {
           "phoneNumber":"",
           "department":"",
           "answers":[]
+        }
+        """;
+        }
+
+        private String includeSpecialCharPayloadJson() {
+            // @Valid 위반: 이름과 학번에 특수문자 작성
+            return """
+        {
+          "email":"tester@email.com",
+          "name":"김@@",
+          "studentId":"@@@1@",
+          "phoneNumber":"01012345678",
+          "department":"소프트웨어공학과",
+          "answers": [
+          {"questionNum":0,"question":"q","answer":"자기소개입니다"},
+          {"questionNum":1,"question":"q","answer":"여"},
+          {"questionNum":2,"question":"q","answer":"A,B"},
+          {"questionNum":3,"question":"interview","answer": { "interviewDateAnswer": ["2025-10-15 14:00","2025-10-16 10:00"] }}
+          ]
         }
         """;
         }
@@ -269,6 +288,21 @@ class ApplicationControllerTest {
             mockMvc.perform(post("/api/clubs/{clubId}/apply-submit", 1L)
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(invalidPayloadJson()))
+                    .andExpect(status().isBadRequest());
+
+            verify(applicationService, never()).submitApplication(
+                    anyLong(),
+                    any(ApplicationApplyRequestDto.class),
+                    anyBoolean()
+            );
+        }
+
+        @Test
+        @DisplayName("특수문자 포함 → 400 BAD_REQUEST & 서비스 미호출")
+        void returnsBadRequest_whenIncludeSpecialChar() throws Exception {
+            mockMvc.perform(post("/api/clubs/{clubId}/apply-submit", 1L)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(includeSpecialCharPayloadJson()))
                     .andExpect(status().isBadRequest());
 
             verify(applicationService, never()).submitApplication(

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/controller/ClubApplyFormControllerTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/controller/ClubApplyFormControllerTest.java
@@ -348,11 +348,11 @@ class ClubApplyFormControllerTest {
                 .andExpect(jsonPath("$.message").exists());
     }
 
-    @DisplayName("동아리 지원서 저장 API 호출 - 실패(description이 200자를 초과하는 경우 400 응답)")
+    @DisplayName("동아리 지원서 저장 API 호출 - 실패(description이 100자를 초과하는 경우 400 응답)")
     @Test
     void createClubApplyForm_longDescription_shouldFailValidation() throws Exception {
         Long clubId = 1L;
-        String longDescription = "a".repeat(201); // 201 characters
+        String longDescription = "a".repeat(101);
         ClubApplyFormRequestDto invalidRequestDto = new ClubApplyFormRequestDto(
                 "제목",
                 longDescription,
@@ -596,11 +596,11 @@ class ClubApplyFormControllerTest {
                 .andExpect(jsonPath("$.message").exists());
     }
 
-    @DisplayName("동아리 지원서 수정 API 호출 - 실패(description이 200자를 초과하는 경우 400 응답)")
+    @DisplayName("동아리 지원서 수정 API 호출 - 실패(description이 100자를 초과하는 경우 400 응답)")
     @Test
     void updateClubApplyForm_longDescription_shouldFailValidation() throws Exception {
         Long clubId = 1L;
-        String longDescription = "a".repeat(201); // 201 characters
+        String longDescription = "a".repeat(101); // 201 characters
         ClubApplyFormUpdateDto invalidRequestDto = new ClubApplyFormUpdateDto(
                 "제목",
                 longDescription,

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/controller/ClubApplyFormControllerTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/controller/ClubApplyFormControllerTest.java
@@ -263,6 +263,156 @@ class ClubApplyFormControllerTest {
                 .andExpect(jsonPath("$.message").exists());
     }
 
+    @DisplayName("동아리 지원서 수정 API 호출 - 실패(RADIO 질문인데 optionList가 null이면 400 응답)")
+    @Test
+    void radioQuestionWithoutOptions_shouldFailValidation() throws Exception {
+        Long clubId = 1L;
+        ClubApplyFormRequestDto invalidRequestDto = new ClubApplyFormRequestDto(
+                "테스트 지원서",
+                "설명",
+                LocalDateTime.of(2025, 10, 1, 0, 0),
+                LocalDateTime.of(2025, 10, 31, 23, 59),
+                List.of(new FormQuestionRequestDto("성별을 선택해 주세요.", FieldType.RADIO, true, 1L, null, null))
+        );
+
+        mockMvc.perform(post("/api/clubs/{clubId}/dashboard/apply-form", clubId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(invalidRequestDto))
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").exists());
+    }
+
+    @DisplayName("동아리 지원서 저장 API 호출 - 실패(title이 blank인 경우 400 응답)")
+    @Test
+    void createClubApplyForm_blankTitle_shouldFailValidation() throws Exception {
+        Long clubId = 1L;
+        ClubApplyFormRequestDto invalidRequestDto = new ClubApplyFormRequestDto(
+                "", // Blank title
+                "설명",
+                LocalDateTime.of(2025, 10, 1, 0, 0),
+                LocalDateTime.of(2025, 10, 31, 23, 59),
+                List.of(new FormQuestionRequestDto("질문", FieldType.TEXT, true, 1L, null, null))
+        );
+
+        mockMvc.perform(post("/api/clubs/{clubId}/dashboard/apply-form", clubId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(invalidRequestDto))
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").exists());
+    }
+
+    @DisplayName("동아리 지원서 저장 API 호출 - 실패(description이 blank인 경우 400 응답)")
+    @Test
+    void createClubApplyForm_blankDescription_shouldFailValidation() throws Exception {
+        Long clubId = 1L;
+        ClubApplyFormRequestDto invalidRequestDto = new ClubApplyFormRequestDto(
+                "제목",
+                "", // Blank description
+                LocalDateTime.of(2025, 10, 1, 0, 0),
+                LocalDateTime.of(2025, 10, 31, 23, 59),
+                List.of(new FormQuestionRequestDto("질문", FieldType.TEXT, true, 1L, null, null))
+        );
+
+        mockMvc.perform(post("/api/clubs/{clubId}/dashboard/apply-form", clubId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(invalidRequestDto))
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").exists());
+    }
+
+    @DisplayName("동아리 지원서 저장 API 호출 - 실패(title이 50자를 초과하는 경우 400 응답)")
+    @Test
+    void createClubApplyForm_longTitle_shouldFailValidation() throws Exception {
+        Long clubId = 1L;
+        String longTitle = "a".repeat(51); // 51 characters
+        ClubApplyFormRequestDto invalidRequestDto = new ClubApplyFormRequestDto(
+                longTitle,
+                "설명",
+                LocalDateTime.of(2025, 10, 1, 0, 0),
+                LocalDateTime.of(2025, 10, 31, 23, 59),
+                List.of(new FormQuestionRequestDto("질문", FieldType.TEXT, true, 1L, null, null))
+        );
+
+        mockMvc.perform(post("/api/clubs/{clubId}/dashboard/apply-form", clubId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(invalidRequestDto))
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").exists());
+    }
+
+    @DisplayName("동아리 지원서 저장 API 호출 - 실패(description이 200자를 초과하는 경우 400 응답)")
+    @Test
+    void createClubApplyForm_longDescription_shouldFailValidation() throws Exception {
+        Long clubId = 1L;
+        String longDescription = "a".repeat(201); // 201 characters
+        ClubApplyFormRequestDto invalidRequestDto = new ClubApplyFormRequestDto(
+                "제목",
+                longDescription,
+                LocalDateTime.of(2025, 10, 1, 0, 0),
+                LocalDateTime.of(2025, 10, 31, 23, 59),
+                List.of(new FormQuestionRequestDto("질문", FieldType.TEXT, true, 1L, null, null))
+        );
+
+        mockMvc.perform(post("/api/clubs/{clubId}/dashboard/apply-form", clubId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(invalidRequestDto))
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").exists());
+    }
+
+    @DisplayName("동아리 지원서 저장 API 호출 - 실패(FormQuestionRequest의 question이 blank인 경우 400 응답)")
+    @Test
+    void createClubApplyForm_blankQuestion_shouldFailValidation() throws Exception {
+        Long clubId = 1L;
+        ClubApplyFormRequestDto invalidRequestDto = new ClubApplyFormRequestDto(
+                "제목",
+                "설명",
+                LocalDateTime.of(2025, 10, 1, 0, 0),
+                LocalDateTime.of(2025, 10, 31, 23, 59),
+                List.of(new FormQuestionRequestDto("", FieldType.TEXT, true, 1L, null, null)) // Blank question
+        );
+
+        mockMvc.perform(post("/api/clubs/{clubId}/dashboard/apply-form", clubId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(invalidRequestDto))
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").exists());
+    }
+
+    @DisplayName("동아리 지원서 저장 API 호출 - 실패(FormQuestionRequest의 question이 100자를 초과하는 경우 400 응답)")
+    @Test
+    void createClubApplyForm_longQuestion_shouldFailValidation() throws Exception {
+        Long clubId = 1L;
+        String longQuestion = "a".repeat(101); // 101 characters
+        ClubApplyFormRequestDto invalidRequestDto = new ClubApplyFormRequestDto(
+                "제목",
+                "설명",
+                LocalDateTime.of(2025, 10, 1, 0, 0),
+                LocalDateTime.of(2025, 10, 31, 23, 59),
+                List.of(new FormQuestionRequestDto(longQuestion, FieldType.TEXT, true, 1L, null, null))
+        );
+
+        mockMvc.perform(post("/api/clubs/{clubId}/dashboard/apply-form", clubId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(invalidRequestDto))
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").exists());
+    }
+
     @DisplayName("동아리 지원서 수정 API 호출 - 성공")
     @Test
     void updateClubApplyForm() throws Exception {
@@ -361,6 +511,154 @@ class ClubApplyFormControllerTest {
                 .andExpect(jsonPath("$.message").exists());
     }
 
+    @DisplayName("동아리 지원서 수정 API 호출 - 실패(RADIO 질문인데 optionList가 null이면 400 응답)")
+    @Test
+    void updateClubApplyForm_radioQuestionWithoutOptions_shouldFailValidation() throws Exception {
+        Long clubId = 1L;
+        ClubApplyFormUpdateDto invalidRequestDto = new ClubApplyFormUpdateDto(
+                "테스트 지원서",
+                "설명",
+                LocalDateTime.of(2025, 10, 1, 0, 0),
+                LocalDateTime.of(2025, 10, 31, 23, 59),
+                List.of(new FormQuestionUpdateDto(1L, "성별을 선택해 주세요.", FieldType.RADIO, true, 1L, null, null))
+        );
 
+        mockMvc.perform(patch("/api/clubs/{clubId}/dashboard/apply-form", clubId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(invalidRequestDto))
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").exists());
+    }
+
+    @DisplayName("동아리 지원서 수정 API 호출 - 실패(title이 blank인 경우 400 응답)")
+    @Test
+    void updateClubApplyForm_blankTitle_shouldFailValidation() throws Exception {
+        Long clubId = 1L;
+        ClubApplyFormUpdateDto invalidRequestDto = new ClubApplyFormUpdateDto(
+                "", // Blank title
+                "설명",
+                LocalDateTime.of(2025, 10, 1, 0, 0),
+                LocalDateTime.of(2025, 10, 31, 23, 59),
+                List.of(new FormQuestionUpdateDto(1L, "질문", FieldType.TEXT, true, 1L, null, null))
+        );
+
+        mockMvc.perform(patch("/api/clubs/{clubId}/dashboard/apply-form", clubId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(invalidRequestDto))
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").exists());
+    }
+
+    @DisplayName("동아리 지원서 수정 API 호출 - 실패(description이 blank인 경우 400 응답)")
+    @Test
+    void updateClubApplyForm_blankDescription_shouldFailValidation() throws Exception {
+        Long clubId = 1L;
+        ClubApplyFormUpdateDto invalidRequestDto = new ClubApplyFormUpdateDto(
+                "제목",
+                "", // Blank description
+                LocalDateTime.of(2025, 10, 1, 0, 0),
+                LocalDateTime.of(2025, 10, 31, 23, 59),
+                List.of(new FormQuestionUpdateDto(1L, "질문", FieldType.TEXT, true, 1L, null, null))
+        );
+
+        mockMvc.perform(patch("/api/clubs/{clubId}/dashboard/apply-form", clubId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(invalidRequestDto))
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").exists());
+    }
+
+    @DisplayName("동아리 지원서 수정 API 호출 - 실패(title이 50자를 초과하는 경우 400 응답)")
+    @Test
+    void updateClubApplyForm_longTitle_shouldFailValidation() throws Exception {
+        Long clubId = 1L;
+        String longTitle = "a".repeat(51); // 51 characters
+        ClubApplyFormUpdateDto invalidRequestDto = new ClubApplyFormUpdateDto(
+                longTitle,
+                "설명",
+                LocalDateTime.of(2025, 10, 1, 0, 0),
+                LocalDateTime.of(2025, 10, 31, 23, 59),
+                List.of(new FormQuestionUpdateDto(1L, "질문", FieldType.TEXT, true, 1L, null, null))
+        );
+
+        mockMvc.perform(patch("/api/clubs/{clubId}/dashboard/apply-form", clubId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(invalidRequestDto))
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").exists());
+    }
+
+    @DisplayName("동아리 지원서 수정 API 호출 - 실패(description이 200자를 초과하는 경우 400 응답)")
+    @Test
+    void updateClubApplyForm_longDescription_shouldFailValidation() throws Exception {
+        Long clubId = 1L;
+        String longDescription = "a".repeat(201); // 201 characters
+        ClubApplyFormUpdateDto invalidRequestDto = new ClubApplyFormUpdateDto(
+                "제목",
+                longDescription,
+                LocalDateTime.of(2025, 10, 1, 0, 0),
+                LocalDateTime.of(2025, 10, 31, 23, 59),
+                List.of(new FormQuestionUpdateDto(1L, "질문", FieldType.TEXT, true, 1L, null, null))
+        );
+
+        mockMvc.perform(patch("/api/clubs/{clubId}/dashboard/apply-form", clubId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(invalidRequestDto))
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").exists());
+    }
+
+    @DisplayName("동아리 지원서 수정 API 호출 - 실패(FormQuestionUpdateDto의 question이 blank인 경우 400 응답)")
+    @Test
+    void updateClubApplyForm_blankQuestion_shouldFailValidation() throws Exception {
+        Long clubId = 1L;
+        ClubApplyFormUpdateDto invalidRequestDto = new ClubApplyFormUpdateDto(
+                "제목",
+                "설명",
+                LocalDateTime.of(2025, 10, 1, 0, 0),
+                LocalDateTime.of(2025, 10, 31, 23, 59),
+                List.of(new FormQuestionUpdateDto(1L, "", FieldType.TEXT, true, 1L, null, null)) // Blank question
+        );
+
+        mockMvc.perform(patch("/api/clubs/{clubId}/dashboard/apply-form", clubId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(invalidRequestDto))
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").exists());
+    }
+
+    @DisplayName("동아리 지원서 수정 API 호출 - 실패(FormQuestionUpdateDto의 question이 100자를 초과하는 경우 400 응답)")
+    @Test
+    void updateClubApplyForm_longQuestion_shouldFailValidation() throws Exception {
+        Long clubId = 1L;
+        String longQuestion = "a".repeat(101); // 101 characters
+        ClubApplyFormUpdateDto invalidRequestDto = new ClubApplyFormUpdateDto(
+                "제목",
+                "설명",
+                LocalDateTime.of(2025, 10, 1, 0, 0),
+                LocalDateTime.of(2025, 10, 31, 23, 59),
+                List.of(new FormQuestionUpdateDto(1L, longQuestion, FieldType.TEXT, true, 1L, null, null))
+        );
+
+        mockMvc.perform(patch("/api/clubs/{clubId}/dashboard/apply-form", clubId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(invalidRequestDto))
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").exists());
+    }
 
 }

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/service/ClubApplyFormServiceImplMockTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/service/ClubApplyFormServiceImplMockTest.java
@@ -116,7 +116,7 @@ class ClubApplyFormServiceImplMockTest {
         FormQuestionRequestDto question1 = new FormQuestionRequestDto("질문 1", FieldType.TEXT, true, 1L, null, null);
         FormQuestionRequestDto question2 = new FormQuestionRequestDto("질문 2", FieldType.RADIO,
                 false, 2L, List.of("옵션 1", "옵션 2"),
-                List.of(new TimeSlotOptionRequestDto("2025-09-24", new TimeSlotOptionRequestDto.TimeRange(LocalTime.of(10, 0), LocalTime.of(21, 0))))
+                List.of(new TimeSlotOptionRequestDto(LocalDate.of(2025,9,24), new TimeSlotOptionRequestDto.TimeRange(LocalTime.of(10, 0), LocalTime.of(21, 0))))
         );
         ClubApplyFormRequestDto requestDto = new ClubApplyFormRequestDto("테스트 지원서",
                 "테스트 설명",

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/service/ClubApplyFormServiceImplMockTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/service/ClubApplyFormServiceImplMockTest.java
@@ -28,6 +28,7 @@ import com.kakaotech.team18.backend_server.global.exception.exceptions.ClubApply
 import com.kakaotech.team18.backend_server.global.exception.exceptions.ClubNotFoundException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
 import org.assertj.core.api.Assertions;
@@ -115,7 +116,7 @@ class ClubApplyFormServiceImplMockTest {
         FormQuestionRequestDto question1 = new FormQuestionRequestDto("질문 1", FieldType.TEXT, true, 1L, null, null);
         FormQuestionRequestDto question2 = new FormQuestionRequestDto("질문 2", FieldType.RADIO,
                 false, 2L, List.of("옵션 1", "옵션 2"),
-                List.of(new TimeSlotOptionRequestDto("2025-09-24", new TimeSlotOptionRequestDto.TimeRange("10:00", "21:00")))
+                List.of(new TimeSlotOptionRequestDto("2025-09-24", new TimeSlotOptionRequestDto.TimeRange(LocalTime.of(10, 0), LocalTime.of(21, 0))))
         );
         ClubApplyFormRequestDto requestDto = new ClubApplyFormRequestDto("테스트 지원서",
                 "테스트 설명",
@@ -284,7 +285,7 @@ class ClubApplyFormServiceImplMockTest {
                 .displayOrder(1L)
                 .options(List.of("치킨", "피자", "햄버거"))
                 .timeSlotOptions(List.of(new TimeSlotOption(LocalDate.of(2024, 10, 26),
-                        new TimeSlotOption.TimeRange("10:00", "12:00")
+                        new TimeSlotOption.TimeRange(LocalTime.of(10, 0), LocalTime.of(12, 0))
                 )))
                 .build();
     }

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/formQuestion/entity/FormQuestionTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/formQuestion/entity/FormQuestionTest.java
@@ -71,7 +71,7 @@ class FormQuestionTest {
         ReflectionTestUtils.setField(formQuestion, "id", 3L);
 
         TimeSlotOptionRequestDto.TimeRange newTimeRange = new TimeRange(LocalTime.of(22, 0), LocalTime.of(23, 0));
-        TimeSlotOptionRequestDto newOption = new TimeSlotOptionRequestDto("2025-09-26", newTimeRange);
+        TimeSlotOptionRequestDto newOption = new TimeSlotOptionRequestDto(LocalDate.of(2025,9,26), newTimeRange);
 
         FormQuestionUpdateDto dto = new FormQuestionUpdateDto(
                 3L, "면접 불가능한 시간대는?", FieldType.TIME_SLOT, true, 3L, null, List.of(newOption)

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/formQuestion/entity/FormQuestionTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/formQuestion/entity/FormQuestionTest.java
@@ -6,6 +6,7 @@ import com.kakaotech.team18.backend_server.domain.formQuestion.dto.FormQuestionU
 import com.kakaotech.team18.backend_server.domain.formQuestion.dto.TimeSlotOptionRequestDto;
 import com.kakaotech.team18.backend_server.domain.formQuestion.dto.TimeSlotOptionRequestDto.TimeRange;
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -64,12 +65,12 @@ class FormQuestionTest {
     @DisplayName("TIME_SLOT 타입 FormQuestionUpdateDto를 통해 필드를 수정할 수 있다.")
     @Test
     void updateFrom_shouldUpdateTimeSlotFieldsCorrectly() {
-        TimeSlotOption.TimeRange originalTimeRange = new TimeSlotOption.TimeRange("10:00", "18:00");
+        TimeSlotOption.TimeRange originalTimeRange = new TimeSlotOption.TimeRange(LocalTime.of(10, 0), LocalTime.of(18, 0));
         TimeSlotOption originalOption = new TimeSlotOption(LocalDate.of(2025, 9, 25), originalTimeRange);
         FormQuestion formQuestion = createFormQuestion("면접 가능한 시간대는?", FieldType.TIME_SLOT, 3L, null, List.of(originalOption));
         ReflectionTestUtils.setField(formQuestion, "id", 3L);
 
-        TimeSlotOptionRequestDto.TimeRange newTimeRange = new TimeRange("22:00", "23:00");
+        TimeSlotOptionRequestDto.TimeRange newTimeRange = new TimeRange(LocalTime.of(22, 0), LocalTime.of(23, 0));
         TimeSlotOptionRequestDto newOption = new TimeSlotOptionRequestDto("2025-09-26", newTimeRange);
 
         FormQuestionUpdateDto dto = new FormQuestionUpdateDto(


### PR DESCRIPTION
## 🚀 작업 내용
- [x] deploy-with-docker에서 appliaction.yml 파일 디버깅하는 부분 삭제하기
- [x] TimeSlotOptionRequestDto
  - 면점 → 먼졉으로 오타 수정
- [x] TimeSlotOption 엔티티의 start, end 필드 타입 String에서 시간으로 바꾸기
- [x] 전체적으로 RequestDTO에 글자수 같은 제한사항 추가하기
    - ClubApplyFormRequestDto
- [x] ClubServiceMockTest.java ClubMemberNotFoudException 검증 추가
- [ ] FormQuestionRequestDto 공통부분 추출 
  - 이 부분은 공통된 부분을 따로 추출해서 상속하면 좋겠다고 하셨는데 record 는 상속이 불가능해서 class로 바꿔서 상속하도록 해야합니다. 근데 그러면 class는 get 메서드를 사용하고 record는 필드 이름을 사용해서 필드에 접근가능한데 이런 메서드 이름 수정부터 시작해서 변경해야 할 부분이 굉장히 많아서 득보다 실이더 많은 변경이라고 생각해 변경하지 않았습니다. 
- docker compose에 secrets 문법을 고려해보라고 하셨는데, 이게 docker swarm이라는 도커에서 제공하는 컨테이너 오케이스트레이션 툴인데 여기서 제공하는 기능인 것 같더라고요. 원래 쿠버네티스를 컨테이너 오케이스레이션 툴로 사용하려고 했는데 도커 스웜이 더 적절할 수도 있을 것 같아서 공부해보고 추후에 적용해보겠습니다. 

## ⏱️ 소요 시간
3시간 반 

## 🤔 고민했던 내용
Request, Update DTO에 제약사항을 추가하는데 뭐가 적절할지 좀 고민해보았습니다. 제가 임의로 설정해둔 것들이 있는데 수정이 필요할 것 같으면 말씀해주세요

## 💬 리뷰 중점사항
- 커밋 메시지 확인해주시면서 리뷰해주시면 감사하겠습니다!

## 🔗관련 이슈
- #140 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 입력 유효성 강화: 이름 특수문자 차단(@NoSpecialChar), 학번 6자리 숫자 검증, 전화번호 10–11자리 검증 및 설명 추가
  * 폼 필드 길이 제한: 제목 50자, 설명 100자, 질문 100자 적용
  * 시간 슬롯 처리 엄격화: 날짜/시간 타입 및 필수 검증 강화로 면접 일정 정확도 향상

* **버그 수정**
  * 예외명 및 메시지 문구 정정(클럽 멤버 관련)

* **테스트**
  * 입력 검증 및 오류 케이스 테스트 대폭 추가 및 보강
<!-- end of auto-generated comment: release notes by coderabbit.ai -->