### PR TITLE
[REFACTOR] 로그인시 응답 DTO에 clubId와 Role 추가 (#145)

### DIFF
--- a/src/main/java/com/kakaotech/team18/backend_server/domain/auth/dto/LoginSuccessResponseDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/auth/dto/LoginSuccessResponseDto.java
@@ -1,17 +1,22 @@
 package com.kakaotech.team18.backend_server.domain.auth.dto;
 
+import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubIdAndRoleInfoDto;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
 
 @Schema(description = "로그인 성공 시 응답 데이터")
 public record LoginSuccessResponseDto(
-    @Schema(description = "응답 상태", example = "LOGIN_SUCCESS")
-    AuthStatus status,
+        @Schema(description = "응답 상태", example = "LOGIN_SUCCESS")
+        AuthStatus status,
 
-    @Schema(description = "우리 서비스의 Access Token")
-    String accessToken,
+        @Schema(description = "우리 서비스의 Access Token")
+        String accessToken,
 
-    @Schema(description = "Access Token 재발급을 위한 Refresh Token")
-    String refreshToken
+        @Schema(description = "Access Token 재발급을 위한 Refresh Token")
+        String refreshToken,
+
+        @Schema(description = "clubId와 Role 정보를 담은 리스트")
+        List<ClubIdAndRoleInfoDto> clubIdAndRoleList
 ) implements LoginResponse {
     // LoginResponse 인터페이스를 구현합니다.
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/auth/service/AuthServiceImpl.java
@@ -10,6 +10,10 @@ import com.kakaotech.team18.backend_server.domain.auth.dto.RegistrationRequiredR
 import com.kakaotech.team18.backend_server.domain.auth.dto.ReissueResponseDto;
 import com.kakaotech.team18.backend_server.domain.auth.entity.RefreshToken;
 import com.kakaotech.team18.backend_server.domain.auth.repository.RefreshTokenRepository;
+import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubIdAndRoleInfoDto;
+import com.kakaotech.team18.backend_server.domain.clubMember.entity.ClubMember;
+import com.kakaotech.team18.backend_server.domain.clubMember.entity.Role;
+import com.kakaotech.team18.backend_server.domain.clubMember.repository.ClubMemberRepository;
 import com.kakaotech.team18.backend_server.domain.user.entity.User;
 import com.kakaotech.team18.backend_server.domain.user.repository.UserRepository;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.DuplicateKakaoIdException;
@@ -23,6 +27,7 @@ import com.kakaotech.team18.backend_server.global.security.JwtProperties;
 import com.kakaotech.team18.backend_server.global.security.JwtProvider;
 import com.kakaotech.team18.backend_server.global.security.TokenType;
 import io.jsonwebtoken.Claims;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -47,6 +52,7 @@ public class AuthServiceImpl implements AuthService {
     private final RestClient restClient;
     private final RefreshTokenRepository refreshTokenRepository;
     private final JwtProperties jwtProperties;
+    private final ClubMemberRepository clubMemberRepository;
 
     @Value("${spring.security.oauth2.client.registration.kakao.client-id}")
     private String kakaoClientId;
@@ -91,7 +97,15 @@ public class AuthServiceImpl implements AuthService {
             refreshTokenRepository.save(new RefreshToken(user.getId(), refreshToken, jwtProperties.refreshTokenValidityInSeconds()));
             log.info("Redis에 Refresh Token 저장 완료: userId={}", user.getId());
 
-            return new LoginSuccessResponseDto(AuthStatus.LOGIN_SUCCESS, accessToken, refreshToken);
+            //clubId, Role 전달
+            List<ClubIdAndRoleInfoDto> clubIdAndRoleList = clubMemberRepository.findClubIdAndRoleByUser(user);
+
+            //서비스 관리자가 로그인하는 경우
+            if (clubIdAndRoleList.isEmpty() && isSystemAdmin(user)) {
+                clubIdAndRoleList = List.of(new ClubIdAndRoleInfoDto(null, Role.SYSTEM_ADMIN));
+            }
+
+            return new LoginSuccessResponseDto(AuthStatus.LOGIN_SUCCESS, accessToken, refreshToken, clubIdAndRoleList);
         } else {
             // 4-2. 신규 회원일 경우: 추가 정보 입력 필요
             log.info("신규 회원, 추가 정보 입력 필요");
@@ -155,6 +169,14 @@ public class AuthServiceImpl implements AuthService {
             userRepository.save(user);
         }
 
+        //clubId, Role 전달
+        List<ClubIdAndRoleInfoDto> clubIdAndRoleList = clubMemberRepository.findClubIdAndRoleByUser(user);
+
+        //서비스 관리자가 로그인하는 경우
+        if (clubIdAndRoleList.isEmpty() && isSystemAdmin(user)) {
+            clubIdAndRoleList = List.of(new ClubIdAndRoleInfoDto(null, Role.SYSTEM_ADMIN));
+        }
+
         // 4. 정식 토큰 발급
         String accessToken = jwtProvider.createAccessToken(user);
         String refreshToken = jwtProvider.createRefreshToken(user);
@@ -163,7 +185,7 @@ public class AuthServiceImpl implements AuthService {
         refreshTokenRepository.save(new RefreshToken(user.getId(), refreshToken, jwtProperties.refreshTokenValidityInSeconds()));
         log.info("Redis에 Refresh Token 저장 완료: userId={}", user.getId());
 
-        return new LoginSuccessResponseDto(AuthStatus.REGISTER_SUCCESS, accessToken, refreshToken);
+        return new LoginSuccessResponseDto(AuthStatus.REGISTER_SUCCESS, accessToken, refreshToken, clubIdAndRoleList);
     }
 
     @Override
@@ -244,5 +266,10 @@ public class AuthServiceImpl implements AuthService {
             log.warn("카카오 사용자 정보 요청 중 타임아웃 발생", e);
             throw new KakaoApiTimeoutException();
         }
+    }
+
+    private boolean isSystemAdmin(User user) {
+        return clubMemberRepository.findByUser(user).stream()
+                .anyMatch(cm -> cm.getRole() == Role.SYSTEM_ADMIN);
     }
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/auth/service/AuthServiceImpl.java
@@ -11,7 +11,6 @@ import com.kakaotech.team18.backend_server.domain.auth.dto.ReissueResponseDto;
 import com.kakaotech.team18.backend_server.domain.auth.entity.RefreshToken;
 import com.kakaotech.team18.backend_server.domain.auth.repository.RefreshTokenRepository;
 import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubIdAndRoleInfoDto;
-import com.kakaotech.team18.backend_server.domain.clubMember.entity.ClubMember;
 import com.kakaotech.team18.backend_server.domain.clubMember.entity.Role;
 import com.kakaotech.team18.backend_server.domain.clubMember.repository.ClubMemberRepository;
 import com.kakaotech.team18.backend_server.domain.user.entity.User;

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/dto/ClubIdAndRoleInfoDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/dto/ClubIdAndRoleInfoDto.java
@@ -1,0 +1,13 @@
+package com.kakaotech.team18.backend_server.domain.clubMember.dto;
+
+import com.kakaotech.team18.backend_server.domain.clubMember.entity.Role;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "user가 등록된 club의 clubId와 Role 정보를 담은 DTO")
+public record ClubIdAndRoleInfoDto(
+        @Schema(description = "user가 등록된 club의 clubId")
+        Long clubId,
+        @Schema(description = "user가 등록된 club의 Role")
+        Role role
+) {
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/repository/ClubMemberRepository.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/repository/ClubMemberRepository.java
@@ -2,6 +2,7 @@ package com.kakaotech.team18.backend_server.domain.clubMember.repository;
 
 import com.kakaotech.team18.backend_server.domain.application.entity.Stage;
 import com.kakaotech.team18.backend_server.domain.application.entity.Status;
+import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubIdAndRoleInfoDto;
 import com.kakaotech.team18.backend_server.domain.clubMember.entity.ActiveStatus;
 import com.kakaotech.team18.backend_server.domain.clubMember.entity.ClubMember;
 import com.kakaotech.team18.backend_server.domain.clubMember.entity.Role;
@@ -66,6 +67,16 @@ public interface ClubMemberRepository extends JpaRepository<ClubMember, Long> {
           and cm.activeStatus = :status
         """)
     Optional<User> findUserByClubIdAndRoleAndStatus(Long clubId, Role role, ActiveStatus status);
+
+    @Query("""
+        select new com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubIdAndRoleInfoDto(cm.club.id, cm.role)
+        from ClubMember cm
+        join cm.club
+        where cm.user = :user
+        """)
+    List<ClubIdAndRoleInfoDto> findClubIdAndRoleByUser(User user);
+
+    List<ClubMember> findByUser(User user);
 
     Optional<ClubMember> findByClubIdAndUserStudentId(Long clubId, String studentId);
 }

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/auth/service/AuthServiceImplTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/auth/service/AuthServiceImplTest.java
@@ -1,20 +1,36 @@
 package com.kakaotech.team18.backend_server.domain.auth.service;
 
-import com.kakaotech.team18.backend_server.domain.auth.dto.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.kakaotech.team18.backend_server.domain.auth.dto.AuthStatus;
+import com.kakaotech.team18.backend_server.domain.auth.dto.KakaoTokenResponseDto;
+import com.kakaotech.team18.backend_server.domain.auth.dto.KakaoUserInfoResponseDto;
+import com.kakaotech.team18.backend_server.domain.auth.dto.LoginResponse;
+import com.kakaotech.team18.backend_server.domain.auth.dto.LoginSuccessResponseDto;
+import com.kakaotech.team18.backend_server.domain.auth.dto.RegisterRequestDto;
+import com.kakaotech.team18.backend_server.domain.auth.dto.RegistrationRequiredResponseDto;
+import com.kakaotech.team18.backend_server.domain.auth.dto.ReissueResponseDto;
 import com.kakaotech.team18.backend_server.domain.auth.entity.RefreshToken;
 import com.kakaotech.team18.backend_server.domain.auth.repository.RefreshTokenRepository;
+import com.kakaotech.team18.backend_server.domain.clubMember.repository.ClubMemberRepository;
 import com.kakaotech.team18.backend_server.domain.user.entity.User;
 import com.kakaotech.team18.backend_server.domain.user.repository.UserRepository;
-import com.kakaotech.team18.backend_server.global.security.JwtProperties;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.DuplicateKakaoIdException;
-import com.kakaotech.team18.backend_server.global.exception.exceptions.LoggedOutUserException;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.InvalidRefreshTokenException;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.KakaoApiTimeoutException;
+import com.kakaotech.team18.backend_server.global.exception.exceptions.LoggedOutUserException;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.NotRefreshTokenException;
+import com.kakaotech.team18.backend_server.global.security.JwtProperties;
 import com.kakaotech.team18.backend_server.global.security.JwtProvider;
 import com.kakaotech.team18.backend_server.global.security.TokenType;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -27,15 +43,6 @@ import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestClient;
-
-import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class AuthServiceImplTest {
@@ -53,6 +60,8 @@ class AuthServiceImplTest {
     private RefreshTokenRepository refreshTokenRepository;
     @Mock
     private JwtProperties jwtProperties;
+    @Mock
+    private ClubMemberRepository clubMemberRepository;
 
     // RestClient의 플루언트 API를 Mocking하기 위한 추가 Mock 객체들
     @Mock


### PR DESCRIPTION
## 🚀 작업 내용
로그인시 응답 DTO인 LoginSuccessResponseDto에 clubId와 Role을 전달하도록 했습니다. user를 기준으로 전달하는 값이라서 user가 여러 동아리에 가입되어 있을 수 있어 이 값을 List로 전달하고 관련해서 ClubIdAndRoleInfoDto라는 DTO를 추가했습니다. 
이 값은 동아리 관리 페이지에서 가입된 동아리를 선택할 수 있는데 사용하신다고 합니다. 

## ⏱️ 소요 시간
1시간 반 

## 🤔 고민했던 내용
베이스 코드를 제가 작성한게 아니라 지훈님이 처음 작성하신 의도를 살리려고 했습니다.
서비스 관리자의 경우 등록된 Club이 없어서 ClubMemberRepository의 findClubIdAndRoleByUser 매서드가 빈 배열로 넘어오게 됩니다. 그래서 서비스 관리자인 경우 clubId를 null로, Role은 SystemAdmin으로 반환하도록 코드를 작성했는데 서비스 관리자 로그인에 대한 논의를 제대로 진행한적이 없는 것 같아서 의견 주시면 감사하겠습니다. 

## 💬 리뷰 중점사항
추가된 DTO 필드가 문제 없는지, 원래 의도한 코드와 방향성은 다르지 않는지 봐주시면 감사하겠습니다. 
시스템 관리자 로그인 관련한 코드가 적절한지 다른 의견이 있는지 봐주시면 감사하겠습니다. 


## 🔗관련 이슈
- Close #145 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 로그인 및 회원가입 성공 응답에 사용자가 소속된 모든 클럽 목록과 각 클럽 내 역할 정보가 포함됩니다. 클럽 소속이 없더라도 시스템 관리자 권한 보유자는 별도로 표시되어 관리 권한이 반영됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->