### PR TITLE
[REFACTOR] Refresh Token 전달 방식 개선 및 보안 강화 about HttpOnly 및 Cookie 

### DIFF
--- a/src/main/java/com/kakaotech/team18/backend_server/domain/application/repository/ApplicationRepository.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/application/repository/ApplicationRepository.java
@@ -3,10 +3,10 @@ package com.kakaotech.team18.backend_server.domain.application.repository;
 import com.kakaotech.team18.backend_server.domain.application.entity.Application;
 import com.kakaotech.team18.backend_server.domain.application.entity.Stage;
 import com.kakaotech.team18.backend_server.domain.application.entity.Status;
+import com.kakaotech.team18.backend_server.domain.clubApplyForm.entity.ClubApplyForm;
 import jakarta.persistence.LockModeType;
 import java.util.List;
 
-import com.kakaotech.team18.backend_server.domain.clubApplyForm.entity.ClubApplyForm;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -40,6 +40,22 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
              FROM Application a
              WHERE a.id = :id""")
     Optional<Application> findByIdWithPessimisticLock(@Param("id") Long id);
+
+    /**
+     * applicationId를 사용하여, 해당 지원서가 속한 동아리의 ID(clubId)를 조회합니다.
+     * <p>
+     * 엔티티 전체를 로딩하지 않고 필요한 clubId 값만 직접 조회(Projection)하여 성능을 최적화합니다.
+     * CustomSecurityService에서 특정 지원서에 대한 권한을 검사할 때 사용됩니다.
+     *
+     * @param applicationId 조회할 지원서의 ID
+     * @return 해당 지원서가 속한 Club의 ID
+     */
+    @Query("""
+            SELECT a.clubApplyForm.club.id
+            FROM Application a
+            WHERE a.id = :applicationId
+            """)
+    Optional<Long> findClubIdByApplicationId(@Param("applicationId") Long applicationId);
 
     @Query("""
             SELECT a

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/auth/controller/AuthController.java
@@ -7,6 +7,7 @@ import com.kakaotech.team18.backend_server.domain.auth.dto.RegisterRequestDto;
 import com.kakaotech.team18.backend_server.domain.auth.dto.RegistrationRequiredResponseDto;
 import com.kakaotech.team18.backend_server.domain.auth.dto.ReissueResponseDto;
 import com.kakaotech.team18.backend_server.domain.auth.service.AuthService;
+import com.kakaotech.team18.backend_server.global.security.JwtProperties;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -34,7 +35,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     private final AuthService authService;
-    private final long REFRESH_TOKEN_EXPIRE_TIME = 1000L * 60 * 60 * 24 * 14; // 14일
+    private final JwtProperties jwtProperties;
 
     @Operation(summary = "카카오 인가 코드로 로그인/회원가입", description = "클라이언트가 카카오로부터 받은 인가 코드를 전송하면, 서버는 이를 검증하여 기존 회원이면 즉시 로그인 처리하고, 신규 회원이면 추가 정보 입력을 위한 임시 토큰을 발급합니다.")
     @ApiResponses(value = {
@@ -50,7 +51,7 @@ public class AuthController {
                     .httpOnly(true)
                     .secure(true)
                     .path("/")
-                    .maxAge(REFRESH_TOKEN_EXPIRE_TIME)
+                    .maxAge(jwtProperties.refreshTokenValidityInSeconds())
                     .build();
 
             LoginSuccessResponseDto.Body body = new LoginSuccessResponseDto.Body(dto.status(), dto.accessToken());
@@ -81,7 +82,7 @@ public class AuthController {
                 .httpOnly(true)
                 .secure(true)
                 .path("/")
-                .maxAge(REFRESH_TOKEN_EXPIRE_TIME)
+                .maxAge(jwtProperties.refreshTokenValidityInSeconds())
                 .build();
 
         LoginSuccessResponseDto.Body body = new LoginSuccessResponseDto.Body(responseDto.status(), responseDto.accessToken());
@@ -107,7 +108,7 @@ public class AuthController {
                 .httpOnly(true)
                 .secure(true)
                 .path("/")
-                .maxAge(REFRESH_TOKEN_EXPIRE_TIME)
+                .maxAge(jwtProperties.refreshTokenValidityInSeconds())
                 .build();
 
         ReissueResponseDto.Body body = new ReissueResponseDto.Body(reissueResponseDto.accessToken());

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/auth/controller/AuthController.java
@@ -16,7 +16,9 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -31,32 +33,61 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     private final AuthService authService;
+    private final long REFRESH_TOKEN_EXPIRE_TIME = 1000L * 60 * 60 * 24 * 14; // 14일
 
     @Operation(summary = "카카오 인가 코드로 로그인/회원가입", description = "클라이언트가 카카오로부터 받은 인가 코드를 전송하면, 서버는 이를 검증하여 기존 회원이면 즉시 로그인 처리하고, 신규 회원이면 추가 정보 입력을 위한 임시 토큰을 발급합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "로그인 성공 또는 추가 정보 입력 필요",
-                    content = @Content(schema = @Schema(oneOf = {LoginSuccessResponseDto.class, RegistrationRequiredResponseDto.class})))
+                    content = @Content(schema = @Schema(oneOf = {LoginSuccessResponseDto.Body.class, RegistrationRequiredResponseDto.class})))
     })
     @PostMapping("/kakao/login")
     public ResponseEntity<LoginResponse> kakaoLogin(@Valid @RequestBody KakaoLoginRequestDto kakaoLoginRequestDto) {
         LoginResponse loginResponse = authService.kakaoLogin(kakaoLoginRequestDto.authorizationCode());
+
+        if (loginResponse instanceof LoginSuccessResponseDto dto) {
+            ResponseCookie responseCookie = ResponseCookie.from("refreshToken", dto.refreshToken())
+                    .httpOnly(true)
+                    .secure(true)
+                    .path("/")
+                    .maxAge(REFRESH_TOKEN_EXPIRE_TIME)
+                    .build();
+
+            LoginSuccessResponseDto.Body body = new LoginSuccessResponseDto.Body(dto.status(), dto.accessToken());
+
+            return ResponseEntity.ok()
+                    .header(HttpHeaders.SET_COOKIE, responseCookie.toString())
+                    .body(body);
+        }
+
         return ResponseEntity.ok(loginResponse);
     }
 
     @Operation(summary = "추가 정보 제출 및 최종 회원가입", description = "임시 토큰과 함께 사용자의 추가 정보(학번, 학과 등)를 받아 최종적으로 회원가입을 완료하고, 정식 토큰을 발급합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "201", description = "회원가입 및 로그인 성공",
-                    content = @Content(schema = @Schema(implementation = LoginSuccessResponseDto.class))),
+                    content = @Content(schema = @Schema(implementation = LoginSuccessResponseDto.Body.class))),
             @ApiResponse(responseCode = "401", description = "유효하지 않은 임시 토큰")
     })
     @SecurityRequirement(name = "temporary-token") // Swagger에서 임시 토큰 헤더를 명시
     @PostMapping("/register")
-    public ResponseEntity<LoginSuccessResponseDto> register(
+    public ResponseEntity<LoginSuccessResponseDto.Body> register(
             @RequestHeader("Authorization") String temporaryToken,
             @Valid @RequestBody RegisterRequestDto registerRequestDto) {
 
         LoginSuccessResponseDto responseDto = authService.register(temporaryToken, registerRequestDto);
-        return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
+
+        ResponseCookie responseCookie = ResponseCookie.from("refreshToken", responseDto.refreshToken())
+                .httpOnly(true)
+                .secure(true)
+                .path("/")
+                .maxAge(REFRESH_TOKEN_EXPIRE_TIME)
+                .build();
+
+        LoginSuccessResponseDto.Body body = new LoginSuccessResponseDto.Body(responseDto.status(), responseDto.accessToken());
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .header(HttpHeaders.SET_COOKIE, responseCookie.toString())
+                .body(body);
     }
 
     @Operation(summary = "Access Token 재발급", description = "유효한 Refresh Token을 사용하여 만료된 Access Token을 재발급받습니다.")

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/auth/dto/LoginSuccessResponseDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/auth/dto/LoginSuccessResponseDto.java
@@ -18,5 +18,14 @@ public record LoginSuccessResponseDto(
         @Schema(description = "clubId와 Role 정보를 담은 리스트")
         List<ClubIdAndRoleInfoDto> clubIdAndRoleList
 ) implements LoginResponse {
-    // LoginResponse 인터페이스를 구현합니다.
+    @Schema(description = "로그인 성공 시 실제 클라이언트에게 전달되는 응답 본문")
+    public record Body(
+        @Schema(description = "응답 상태", example = "LOGIN_SUCCESS")
+        AuthStatus status,
+
+        @Schema(description = "우리 서비스의 Access Token")
+        String accessToken
+    ) implements LoginResponse {
+        // LoginResponse 인터페이스를 구현합니다.
+    }
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/auth/dto/ReissueResponseDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/auth/dto/ReissueResponseDto.java
@@ -12,4 +12,10 @@ public record ReissueResponseDto(
     public static ReissueResponseDto of(String accessToken, String refreshToken) {
         return new ReissueResponseDto(accessToken, refreshToken);
     }
+
+    @Schema(description = "토큰 재발급 시 실제 클라이언트에게 전달되는 응답 본문")
+    public record Body(
+            @Schema(description = "새로 발급된 Access Token", example = "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwidG9rZW5UeXBlIjoiQUNDRVNTIiwiaWF0IjoxNzE1MjMxMzU5LCJleHAiOjE3MTUyMzMxNTl9.example")
+            String accessToken
+    ) {}
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/auth/service/AuthServiceImpl.java
@@ -189,24 +189,21 @@ public class AuthServiceImpl implements AuthService {
 
     @Override
     @Transactional
-    public ReissueResponseDto reissue(String bearerToken) {
-        // 1. Bearer 접두사 제거 및 토큰 추출
-        String refreshToken = jwtProvider.extractToken(bearerToken);
-
-        // 2. Refresh Token 자체 유효성 검증 (만료, 서명 등)
+    public ReissueResponseDto reissue(String refreshToken) {
+        // 1. Refresh Token 자체 유효성 검증 (만료, 서명 등)
         Claims claims = jwtProvider.verify(refreshToken);
 
-        // 3. 토큰 타입 검증
+        // 2. 토큰 타입 검증
         String tokenType = claims.get("tokenType", String.class);
         if (!TokenType.REFRESH.name().equals(tokenType)) {
             log.warn("Refresh Token 재발급 시도 실패: 토큰 타입이 REFRESH가 아님");
             throw new NotRefreshTokenException();
         }
 
-        // 4. 사용자 ID 추출
+        // 3. 사용자 ID 추출
         Long userId = Long.valueOf(claims.getSubject());
 
-        // 5. Redis에 저장된 토큰과 일치하는지 검증
+        // 4. Redis에 저장된 토큰과 일치하는지 검증
         RefreshToken storedRefreshToken = refreshTokenRepository.findById(userId)
                 .orElseThrow(LoggedOutUserException::new);
 
@@ -215,20 +212,20 @@ public class AuthServiceImpl implements AuthService {
             throw new InvalidRefreshTokenException();
         }
 
-        // 6. 사용자 정보 조회
+        // 5. 사용자 정보 조회
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserNotFoundException("해당 유저가 존재하지 않습니다."));
 
-        // 7. 새로운 토큰 발급 (Access, Refresh 둘 다)
+        // 6. 새로운 토큰 발급 (Access, Refresh 둘 다)
         String newAccessToken = jwtProvider.createAccessToken(user);
         String newRefreshToken = jwtProvider.createRefreshToken(user);
         log.info("Access & Refresh Token 재발급 성공: userId={}", userId);
 
-        // 8. Redis에 새로운 Refresh Token 덮어쓰기 (Rotation)
+        // 7. Redis에 새로운 Refresh Token 덮어쓰기 (Rotation)
         refreshTokenRepository.save(new RefreshToken(user.getId(), newRefreshToken, jwtProperties.refreshTokenValidityInSeconds()));
         log.info("Redis에 새로운 Refresh Token 저장(덮어쓰기) 완료: userId={}", user.getId());
 
-        // 9. DTO로 감싸서 반환
+        // 8. DTO로 감싸서 반환
         return ReissueResponseDto.of(newAccessToken, newRefreshToken);
     }
 

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/club/controller/ClubController.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/club/controller/ClubController.java
@@ -18,6 +18,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -30,7 +31,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/clubs")
-public class ClubController{
+public class ClubController {
 
     private final ClubService clubService;
 
@@ -60,12 +61,13 @@ public class ClubController{
             @ApiResponse(responseCode = "200", description = "수정 성공"),
             @ApiResponse(responseCode = "404", description = "해당 동아리를 찾을 수 없음")
     })
+    @PreAuthorize("hasAuthority('CLUB_' + #clubId + '_CLUB_ADMIN') or hasAuthority('CLUB_' + #clubId + '_CLUB_EXECUTIVE')")
     @PostMapping("/{clubId}")
     public ResponseEntity<SuccessResponseDto> updateClub(
             @Parameter(description = "동아리의 고유 ID", required = true, example = "1") @PathVariable Long clubId,
             @Valid @RequestBody ClubDetailRequestDto dto
     ) {
-        SuccessResponseDto response = clubService.updateClubDetail(clubId,dto);
+        SuccessResponseDto response = clubService.updateClubDetail(clubId, dto);
         return ResponseEntity.ok(response);
     }
 
@@ -74,7 +76,7 @@ public class ClubController{
     @GetMapping(params = "category")
     public ResponseEntity<ClubListResponseDto> listClubsByCategory(
             @Parameter(description = "조회할 동아리 카테고리", required = true, example = "SPORTS") @RequestParam String category
-    ){
+    ) {
         ClubListResponseDto response = clubService.getClubByCategory(category);
         return ResponseEntity.ok(response);
     }
@@ -84,6 +86,7 @@ public class ClubController{
             @ApiResponse(responseCode = "200", description = "조회 성공"),
             @ApiResponse(responseCode = "404", description = "해당 동아리를 찾을 수 없음")
     })
+    @PreAuthorize("hasAuthority('CLUB_' + #clubId + '_CLUB_ADMIN') or hasAuthority('CLUB_' + #clubId + '_CLUB_EXECUTIVE')")
     @GetMapping("/{clubId}/dashboard")
     public ResponseEntity<ClubDashBoardResponseDto> getClubDashboard(
             @Parameter(description = "동아리의 고유 ID", required = true, example = "1") @PathVariable Long clubId
@@ -96,6 +99,7 @@ public class ClubController{
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
     })
+    @PreAuthorize("hasAuthority('CLUB_' + #clubId + '_CLUB_ADMIN') or hasAuthority('CLUB_' + #clubId + '_CLUB_EXECUTIVE')")
     @GetMapping("/{clubId}/dashboard/applicants")
     public ResponseEntity<ClubDashboardApplicantResponseDto> getClubApplicants(
             @PathVariable Long clubId,

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/controller/ClubApplyFormController.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/controller/ClubApplyFormController.java
@@ -13,6 +13,7 @@ import jakarta.validation.Valid;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -42,12 +43,12 @@ public class ClubApplyFormController {
         return ResponseEntity.ok(response);
     }
 
-    //TODO 권한 관련된 기능 로그인 기능 구현 이후 추가
     @Operation(summary = "지원서 양식 저장", description = "특정 동아리의 지원서 양식(질문 및 선택지 목록)을 저장합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "201", description = "저장 성공"),
             @ApiResponse(responseCode = "400", description = "입력 값 옳바르지 않은 경우")
     })
+    @PreAuthorize("hasAuthority('CLUB_' + #clubId + '_CLUB_ADMIN') or hasAuthority('CLUB_' + #clubId + '_CLUB_EXECUTIVE')")
     @PostMapping("/dashboard/apply-form")
     public ResponseEntity<Void> createClubApplyForm(
             @PathVariable("clubId") Long clubId,
@@ -56,12 +57,12 @@ public class ClubApplyFormController {
         return ResponseEntity.created(URI.create("/api/clubs/" + clubId + "/dashboard/apply-form")).build();
     }
 
-    //TODO 권한 관련된 기능 로그인 기능 구현 이후 추가
     @Operation(summary = "지원서 양식 수정", description = "특정 동아리의 지원서 양식(질문 및 선택지 목록)을 수정합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "202", description = "수정 성공"),
             @ApiResponse(responseCode = "400", description = "입력 값 옳바르지 않은 경우")
     })
+    @PreAuthorize("hasAuthority('CLUB_' + #clubId + '_CLUB_ADMIN') or hasAuthority('CLUB_' + #clubId + '_CLUB_EXECUTIVE')")
     @PatchMapping("/dashboard/apply-form")
     public ResponseEntity<Void> updateClubApplyForm(
             @PathVariable("clubId") Long clubId,

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/dto/ClubMembershipInfo.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/dto/ClubMembershipInfo.java
@@ -1,0 +1,6 @@
+package com.kakaotech.team18.backend_server.domain.clubMember.dto;
+
+import com.kakaotech.team18.backend_server.domain.clubMember.entity.Role;
+
+public record ClubMembershipInfo(Long clubId, Role role) {
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/repository/ClubMemberRepository.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/repository/ClubMemberRepository.java
@@ -2,6 +2,7 @@ package com.kakaotech.team18.backend_server.domain.clubMember.repository;
 
 import com.kakaotech.team18.backend_server.domain.application.entity.Stage;
 import com.kakaotech.team18.backend_server.domain.application.entity.Status;
+import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMembershipInfo;
 import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubIdAndRoleInfoDto;
 import com.kakaotech.team18.backend_server.domain.clubMember.entity.ActiveStatus;
 import com.kakaotech.team18.backend_server.domain.clubMember.entity.ClubMember;
@@ -11,6 +12,7 @@ import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ClubMemberRepository extends JpaRepository<ClubMember, Long> {
 
@@ -67,6 +69,13 @@ public interface ClubMemberRepository extends JpaRepository<ClubMember, Long> {
           and cm.activeStatus = :status
         """)
     Optional<User> findUserByClubIdAndRoleAndStatus(Long clubId, Role role, ActiveStatus status);
+
+    @Query("""            
+            select new com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMembershipInfo(cm.club.id, cm.role)
+            from ClubMember cm
+            where cm.user = :user
+            """)
+    List<ClubMembershipInfo> findClubMembershipsByUser(@Param("user") User user);
 
     Optional<ClubMember> findFirstByRole(Role role);
 

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/comment/controller/CommentController.java
@@ -3,17 +3,19 @@ package com.kakaotech.team18.backend_server.domain.comment.controller;
 import com.kakaotech.team18.backend_server.domain.comment.dto.CommentRequestDto;
 import com.kakaotech.team18.backend_server.domain.comment.dto.CommentResponseDto;
 import com.kakaotech.team18.backend_server.domain.comment.service.CommentService;
+import com.kakaotech.team18.backend_server.global.security.PrincipalDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-
-import java.util.List;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -33,6 +35,7 @@ public class CommentController {
 
     @Operation(summary = "특정 지원서의 모든 댓글 조회", description = "특정 지원서 ID를 받아, 해당 지원서에 달린 모든 댓글 목록을 조회합니다.")
     @ApiResponse(responseCode = "200", description = "조회 성공")
+    @PreAuthorize("@customSecurityService.isClubAdminOrExecutiveForApplication(#applicationId)")
     @GetMapping("/{applicationId}/comments")
     public ResponseEntity<List<CommentResponseDto>> getComments(
             @Parameter(description = "지원서의 고유 ID", required = true, example = "100") @PathVariable("applicationId") Long applicationId
@@ -46,13 +49,14 @@ public class CommentController {
             @ApiResponse(responseCode = "201", description = "작성 성공"),
             @ApiResponse(responseCode = "404", description = "댓글을 작성할 지원서를 찾을 수 없음")
     })
+    @PreAuthorize("@customSecurityService.isClubAdminOrExecutiveForApplication(#applicationId)")
     @PostMapping("/{applicationId}/comments")
     public ResponseEntity<CommentResponseDto> createComment(
             @Parameter(description = "지원서의 고유 ID", required = true, example = "100") @PathVariable("applicationId") Long applicationId,
-            @Valid @RequestBody CommentRequestDto commentRequestDto
+            @Valid @RequestBody CommentRequestDto commentRequestDto,
+            @AuthenticationPrincipal PrincipalDetails principalDetails
     ) {
-        // TODO: Spring Security 적용 후 실제 사용자 ID를 가져와야 함
-        Long currentUserId = 1L; // 임시 사용자 ID
+        Long currentUserId = principalDetails.getUser().getId();
 
         CommentResponseDto newComment = commentService.createComment(applicationId, commentRequestDto, currentUserId);
 
@@ -65,14 +69,15 @@ public class CommentController {
             @ApiResponse(responseCode = "403", description = "댓글을 수정할 권한이 없음"),
             @ApiResponse(responseCode = "404", description = "수정할 댓글을 찾을 수 없음")
     })
+    @PreAuthorize("@customSecurityService.isClubAdminOrExecutiveForApplication(#applicationId)")
     @PatchMapping("/{applicationId}/comments/{commentId}")
     public ResponseEntity<CommentResponseDto> updateComment(
             @Parameter(description = "관련 지원서의 고유 ID (URL 일관성을 위해 포함)", example = "100") @PathVariable("applicationId") Long applicationId,
             @Parameter(description = "수정할 댓글의 고유 ID", required = true, example = "20") @PathVariable("commentId") Long commentId,
-            @Valid @RequestBody CommentRequestDto commentRequestDto
+            @Valid @RequestBody CommentRequestDto commentRequestDto,
+            @AuthenticationPrincipal PrincipalDetails principalDetails
     ) {
-        // TODO: Spring Security 적용 후 실제 사용자 ID를 가져와야 함
-        Long currentUserId = 1L; // 임시 사용자 ID
+        Long currentUserId = principalDetails.getUser().getId();
 
         CommentResponseDto updatedComment = commentService.updateComment(commentId, commentRequestDto, currentUserId);
 
@@ -85,13 +90,14 @@ public class CommentController {
             @ApiResponse(responseCode = "403", description = "댓글을 삭제할 권한이 없음"),
             @ApiResponse(responseCode = "404", description = "삭제할 댓글을 찾을 수 없음")
     })
+    @PreAuthorize("@customSecurityService.isClubAdminOrExecutiveForApplication(#applicationId)")
     @DeleteMapping("/{applicationId}/comments/{commentId}")
     public ResponseEntity<Void> deleteComment(
             @Parameter(description = "관련 지원서의 고유 ID (URL 일관성을 위해 포함)", example = "100") @PathVariable("applicationId") Long applicationId,
-            @Parameter(description = "삭제할 댓글의 고유 ID", required = true, example = "20") @PathVariable("commentId") Long commentId
+            @Parameter(description = "삭제할 댓글의 고유 ID", required = true, example = "20") @PathVariable("commentId") Long commentId,
+            @AuthenticationPrincipal PrincipalDetails principalDetails
     ) {
-        // TODO: Spring Security 적용 후 실제 사용자 ID를 가져와야 함
-        Long currentUserId = 1L; // 임시 사용자 ID
+        Long currentUserId = principalDetails.getUser().getId();
 
         commentService.deleteComment(commentId, currentUserId);
 

--- a/src/main/java/com/kakaotech/team18/backend_server/global/config/SecurityConfig.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/config/SecurityConfig.java
@@ -9,6 +9,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -20,6 +21,7 @@ import org.springframework.web.servlet.HandlerExceptionResolver;
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity
 @EnableConfigurationProperties(JwtProperties.class)
 public class SecurityConfig {
 

--- a/src/main/java/com/kakaotech/team18/backend_server/global/config/SecurityConfig.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/config/SecurityConfig.java
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -36,19 +37,16 @@ public class SecurityConfig {
 
         http.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
 
-        // =================== 개발 단계에서 모든 API 허용 ===================
-        // TODO: 배포 시, 아래 주석을 풀고 원래의 보안 설정을 적용해야 합니다.
-        http.authorizeHttpRequests(authorize -> authorize.anyRequest().permitAll());
-        // ===============================================================
-
-        /*
-        // =================== 원래의 보안 설정 (배포 시 활성화) ===================
         http.authorizeHttpRequests(authorize -> authorize
                 .requestMatchers("/api/auth/**", "/swagger-ui.html", "/v3/api-docs/**", "/swagger-ui/**").permitAll()
+                // 동아리 정보 조회 관련 API (공개)
+                .requestMatchers(HttpMethod.GET, "/api/clubs", "/api/clubs/*").permitAll()
+                // 지원서 양식 조회 API (공개)
+                .requestMatchers(HttpMethod.GET, "/api/clubs/*/apply").permitAll()
+                // 지원서 제출 API (공개)
+                .requestMatchers(HttpMethod.POST, "/api/clubs/*/apply-submit").permitAll()
                 .anyRequest().authenticated()
         );
-        // ====================================================================
-        */
 
         http.exceptionHandling(exceptionHandling -> exceptionHandling
                 .authenticationEntryPoint(authenticationEntryPoint())

--- a/src/main/java/com/kakaotech/team18/backend_server/global/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/exception/handler/GlobalExceptionHandler.java
@@ -13,6 +13,7 @@ import org.springframework.security.authorization.AuthorizationDeniedException;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestCookieException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
@@ -117,6 +118,28 @@ public class GlobalExceptionHandler {
 
         // 기존의 CustomException 처리 로직을 재사용합니다.
         return this.handleCustomException(customException);
+    }
+
+    /**
+     * MissingRequestCookieException 예외를 처리
+     * <p>
+     * @CookieValue 어노테이션으로 필수 쿠키가 지정되었으나, 요청에 해당 쿠키가 포함되지 않았을 때 발생합니다.
+     * HTTP 400 Bad Request와 함께 적절한 에러 메시지를 반환합니다.
+     *
+     * @param e MissingRequestCookieException
+     * @return 400 Bad Request 상태 코드와 표준 에러 응답
+     */
+    @ExceptionHandler(MissingRequestCookieException.class)
+    protected ResponseEntity<ErrorResponseDto> handleMissingRequestCookieException(final MissingRequestCookieException e) {
+        final ErrorCode errorCode = ErrorCode.INVALID_INPUT_VALUE; // 클라이언트 요청 오류이므로 INVALID_INPUT_VALUE 사용
+        final String detail = "필수 쿠키 '" + e.getCookieName() + "'가 요청에 포함되지 않았습니다.";
+        final ErrorResponseDto response = ErrorResponseDto.of(errorCode, detail);
+
+        log.warn("MissingRequestCookieException: {} (detail: {})",
+                errorCode.getMessage(),
+                detail);
+
+        return new ResponseEntity<>(response, errorCode.getHttpStatus());
     }
 
 

--- a/src/main/java/com/kakaotech/team18/backend_server/global/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/exception/handler/GlobalExceptionHandler.java
@@ -4,10 +4,12 @@ import com.kakaotech.team18.backend_server.domain.application.entity.Status;
 import com.kakaotech.team18.backend_server.global.exception.code.ErrorCode;
 import com.kakaotech.team18.backend_server.global.exception.dto.ErrorResponseDto;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.CustomException;
+import com.kakaotech.team18.backend_server.global.exception.exceptions.ForbiddenAccessException;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.StatusNotFoundException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.convert.ConversionFailedException;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.authorization.AuthorizationDeniedException;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -97,6 +99,24 @@ public class GlobalExceptionHandler {
         final ErrorResponseDto response = ErrorResponseDto.from(errorCode);
         log.warn("TypeMisMatch: {}", errorCode.getMessage(), e);
         return new ResponseEntity<>(response, errorCode.getHttpStatus());
+    }
+
+    /**
+     * @PreAuthorize 와 같은 메소드 시큐리티에서 발생하는 인가 예외를 처리합니다.
+     * <p>
+     * Spring Security의 AuthorizationDeniedException을 우리가 정의한 ForbiddenAccessException으로 변환하고,
+     * 기존의 handleCustomException 로직을 재사용하여 일관된 에러 응답을 반환합니다.
+     *
+     * @param e AuthorizationDeniedException
+     * @return 403 Forbidden 상태 코드와 표준 에러 응답
+     */
+    @ExceptionHandler(AuthorizationDeniedException.class)
+    protected ResponseEntity<ErrorResponseDto> handleAuthorizationDeniedException(final AuthorizationDeniedException e) {
+        // AuthorizationDeniedException을 우리의 커스텀 예외인 ForbiddenAccessException으로 변환합니다.
+        final ForbiddenAccessException customException = new ForbiddenAccessException();
+
+        // 기존의 CustomException 처리 로직을 재사용합니다.
+        return this.handleCustomException(customException);
     }
 
 

--- a/src/main/java/com/kakaotech/team18/backend_server/global/security/CustomSecurityService.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/security/CustomSecurityService.java
@@ -1,0 +1,58 @@
+package com.kakaotech.team18.backend_server.global.security;
+
+import com.kakaotech.team18.backend_server.domain.application.repository.ApplicationRepository;
+import com.kakaotech.team18.backend_server.domain.clubMember.entity.Role;
+import java.util.Map;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CustomSecurityService {
+
+    private final ApplicationRepository applicationRepository;
+
+    /**
+     * 특정 지원서(applicationId)에 대한 접근 권한을 검사합니다.
+     * <p>
+     * 현재 로그인한 사용자가 해당 지원서가 속한 동아리의 CLUB_ADMIN 또는 CLUB_EXECUTIVE인지 확인합니다.
+     *
+     * @param applicationId 검사할 지원서의 ID
+     * @return 권한이 있으면 true, 없으면 false
+     */
+    @Transactional(readOnly = true)
+    public boolean isClubAdminOrExecutiveForApplication(Long applicationId) {
+        // 1. 현재 인증된 사용자 정보 가져오기
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !(authentication.getPrincipal() instanceof PrincipalDetails principalDetails)) {
+            return false; // 인증되지 않았거나, Principal 타입이 다르면 거부
+        }
+
+        // 2. applicationId로 clubId를 효율적으로 조회 (Projection)
+        Long clubId = applicationRepository.findClubIdByApplicationId(applicationId)
+                .orElse(null); // 지원서가 없으면 clubId는 null
+
+        if (clubId == null) {
+            // 지원서 자체가 존재하지 않는 경우, 서비스 계층에서 404 처리를 하겠지만,
+            // 인가 계층에서는 일단 접근을 거부하는 것이 안전합니다.
+            return false;
+        }
+
+        // 3. 사용자의 역할 정보(memberships) 가져오기
+        Map<String, String> memberships = principalDetails.getMemberships();
+        if (memberships == null) {
+            return false;
+        }
+
+        // 4. 해당 clubId에 대한 사용자의 역할(Role) 가져오기
+        String userRoleForClub = memberships.get(clubId.toString());
+
+        // 5. 역할이 CLUB_ADMIN 또는 CLUB_EXECUTIVE인지 확인
+        return Objects.equals(userRoleForClub, Role.CLUB_ADMIN.name()) ||
+               Objects.equals(userRoleForClub, Role.CLUB_EXECUTIVE.name());
+    }
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/global/security/PrincipalDetails.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/security/PrincipalDetails.java
@@ -4,9 +4,11 @@ import com.kakaotech.team18.backend_server.domain.user.entity.User;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
 @Getter
@@ -18,9 +20,13 @@ public class PrincipalDetails implements UserDetails {
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        // TODO: 사용자의 실제 역할(Role) 정보를 반환하도록 수정 필요
-        // 지금은 빈 권한 목록을 반환합니다.
-        return Collections.emptyList();
+        if (memberships == null || memberships.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        return memberships.entrySet().stream()
+                .map(entry -> new SimpleGrantedAuthority("CLUB_" + entry.getKey() + "_" + entry.getValue()))
+                .collect(Collectors.toList());
     }
 
     @Override

--- a/src/main/java/com/kakaotech/team18/backend_server/global/security/PrincipalDetails.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/security/PrincipalDetails.java
@@ -1,19 +1,20 @@
 package com.kakaotech.team18.backend_server.global.security;
 
 import com.kakaotech.team18.backend_server.domain.user.entity.User;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
-
-import java.util.Collection;
-import java.util.Collections;
 
 @Getter
 @RequiredArgsConstructor
 public class PrincipalDetails implements UserDetails {
 
     private final User user;
+    private final Map<String, String> memberships;
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {

--- a/src/main/java/com/kakaotech/team18/backend_server/global/security/PrincipalDetailsService.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/security/PrincipalDetailsService.java
@@ -2,6 +2,8 @@ package com.kakaotech.team18.backend_server.global.security;
 
 import com.kakaotech.team18.backend_server.domain.user.entity.User;
 import com.kakaotech.team18.backend_server.domain.user.repository.UserRepository;
+import java.util.Collections;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
@@ -16,16 +18,30 @@ public class PrincipalDetailsService implements UserDetailsService {
     private final UserRepository userRepository;
 
     /**
-     * Spring Security가 사용자를 인증할 때 호출하는 메서드입니다.
-     * 우리 시스템에서는 JWT 필터에서 토큰 검증 후, 토큰의 subject(userId)를 이 메서드의 username 파라미터로 전달하여 호출합니다.
+     * @deprecated 이 메서드는 UserDetailsService 인터페이스와의 계약을 위해 존재합니다.
+     *             JWT 인증 시에는 토큰의 memberships 정보가 필요하므로,
+     *             대신 {@link #loadUserByUsername(String, Map)}를 사용해야 합니다.
+     * @since 1.0.0
+     * @forRemoval true
+     */
+    @Override
+    @Deprecated(since = "1.0.0", forRemoval = true)
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        // memberships 정보 없이 호출될 경우, 빈 맵을 전달하여 핵심 로직을 수행하는 메서드를 호출합니다.
+        return this.loadUserByUsername(username, Collections.emptyMap());
+    }
+
+    /**
+     * JWT 필터에서 호출할 커스텀 메서드입니다.
+     * 토큰에서 추출한 subject(userId)와 memberships 정보를 모두 받아 완전한 PrincipalDetails 객체를 생성합니다.
      *
      * @param username 토큰의 subject, 즉 사용자의 ID(String 형태)
+     * @param memberships 토큰의 "memberships" 클레임에서 추출한 역할 정보 맵
      * @return UserDetails를 구현한 PrincipalDetails 객체
      * @throws UsernameNotFoundException 해당 ID의 사용자를 찾을 수 없는 경우
      */
-    @Override
     @Transactional(readOnly = true)
-    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+    public UserDetails loadUserByUsername(String username, Map<String, String> memberships) throws UsernameNotFoundException {
         final Long userId;
         try {
             userId = Long.parseLong(username);
@@ -36,6 +52,7 @@ public class PrincipalDetailsService implements UserDetailsService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UsernameNotFoundException("해당 ID의 사용자를 찾을 수 없습니다: " + userId));
 
-        return new PrincipalDetails(user);
+        // User 정보와 함께 memberships 정보도 PrincipalDetails 생성자에 전달합니다.
+        return new PrincipalDetails(user, memberships);
     }
 }

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/application/controller/ApplicationControllerAuthTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/application/controller/ApplicationControllerAuthTest.java
@@ -1,0 +1,97 @@
+package com.kakaotech.team18.backend_server.domain.application.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kakaotech.team18.backend_server.domain.application.service.ApplicationService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@AutoConfigureMockMvc
+class ApplicationControllerAuthTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private ApplicationService applicationService; // 서비스 로직은 Mocking 합니다.
+
+    @DisplayName("지원서 상세 조회 - 성공 (동아리 관리자)")
+    @Test
+    @WithMockUser(authorities = "CLUB_1_CLUB_ADMIN")
+    void getApplicationDetail_withAdminAuth_success() throws Exception {
+        // given
+        Long clubId = 1L;
+        Long applicantId = 12L;
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                get("/api/clubs/{clubId}/applicants/{applicantId}/application", clubId, applicantId)
+        );
+
+        // then
+        resultActions.andExpect(status().isOk());
+    }
+
+    @DisplayName("지원서 상세 조회 - 실패 (권한 부족)")
+    @Test
+    @WithMockUser(authorities = "CLUB_1_CLUB_MEMBER")
+    void getApplicationDetail_withMemberAuth_fail() throws Exception {
+        // given
+        Long clubId = 1L;
+        Long applicantId = 12L;
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                get("/api/clubs/{clubId}/applicants/{applicantId}/application", clubId, applicantId)
+        );
+
+        // then
+        resultActions.andExpect(status().isForbidden());
+    }
+
+    @DisplayName("지원서 상세 조회 - 실패 (다른 동아리 관리자)")
+    @Test
+    @WithMockUser(authorities = "CLUB_2_CLUB_ADMIN")
+    void getApplicationDetail_withOtherClubAdminAuth_fail() throws Exception {
+        // given
+        Long targetClubId = 1L;
+        Long applicantId = 12L;
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                get("/api/clubs/{clubId}/applicants/{applicantId}/application", targetClubId, applicantId)
+        );
+
+        // then
+        resultActions.andExpect(status().isForbidden());
+    }
+
+    @DisplayName("지원서 상세 조회 - 실패 (미인증 사용자)")
+    @Test
+    void getApplicationDetail_withUnauthenticatedUser_fail() throws Exception {
+        // given
+        Long clubId = 1L;
+        Long applicantId = 12L;
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                get("/api/clubs/{clubId}/applicants/{applicantId}/application", clubId, applicantId)
+        );
+
+        // then
+        resultActions.andExpect(status().isUnauthorized());
+    }
+}

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/application/controller/ApplicationControllerTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/application/controller/ApplicationControllerTest.java
@@ -117,6 +117,7 @@ class ApplicationControllerTest {
     @DisplayName("지원서 상태 변경 컨트롤러 - 성공")
     void updateApplicationStatus_success() throws Exception {
         // given
+        Long clubId = 1L;
         Long applicationId = 1L;
         ApplicationStatusUpdateRequestDto requestDto = new ApplicationStatusUpdateRequestDto(Status.APPROVED);
         given(applicationService.updateApplicationStatus(any(Long.class), any(ApplicationStatusUpdateRequestDto.class)))
@@ -124,7 +125,7 @@ class ApplicationControllerTest {
 
         // when
         ResultActions resultActions = mockMvc.perform(
-                patch("/api/applications/{applicationId}", applicationId)
+                patch("/api/clubs/{clubId}/applications/{applicationId}/status", clubId, applicationId)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(requestDto))
         );
@@ -138,6 +139,7 @@ class ApplicationControllerTest {
     @DisplayName("지원서 상태 변경 컨트롤러 - 실패 (지원서 없음)")
     void updateApplicationStatus_fail_applicationNotFound() throws Exception {
         // given
+        Long clubId = 1L;
         Long nonExistentApplicationId = 999L;
         ApplicationStatusUpdateRequestDto requestDto = new ApplicationStatusUpdateRequestDto(Status.APPROVED);
         given(applicationService.updateApplicationStatus(any(Long.class), any(ApplicationStatusUpdateRequestDto.class)))
@@ -145,7 +147,7 @@ class ApplicationControllerTest {
 
         // when
         ResultActions resultActions = mockMvc.perform(
-                patch("/api/applications/{applicationId}", nonExistentApplicationId)
+                patch("/api/clubs/{clubId}/applications/{applicationId}/status", clubId, nonExistentApplicationId)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(requestDto))
         );
@@ -159,13 +161,14 @@ class ApplicationControllerTest {
     @DisplayName("지원서 상태 변경 컨트롤러 - 실패 (잘못된 요청 값)")
     void updateApplicationStatus_fail_invalidInputValue() throws Exception {
         // given
+        Long clubId = 1L;
         Long applicationId = 1L;
         // status 필드가 없는 잘못된 요청
         String invalidRequestBody = "{}";
 
         // when
         ResultActions resultActions = mockMvc.perform(
-                patch("/api/applications/{applicationId}", applicationId)
+                patch("/api/clubs/{clubId}/applications/{applicationId}/status", clubId, applicationId)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(invalidRequestBody)
         );

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/auth/controller/AuthControllerTest.java
@@ -1,0 +1,170 @@
+package com.kakaotech.team18.backend_server.domain.auth.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kakaotech.team18.backend_server.domain.auth.dto.AuthStatus;
+import com.kakaotech.team18.backend_server.domain.auth.dto.KakaoLoginRequestDto;
+import com.kakaotech.team18.backend_server.domain.auth.dto.LoginSuccessResponseDto;
+import com.kakaotech.team18.backend_server.domain.auth.dto.RegisterRequestDto;
+import com.kakaotech.team18.backend_server.domain.auth.dto.RegistrationRequiredResponseDto;
+import com.kakaotech.team18.backend_server.domain.auth.dto.ReissueResponseDto;
+import com.kakaotech.team18.backend_server.domain.auth.service.AuthService;
+import com.kakaotech.team18.backend_server.domain.club.controller.ClubController;
+import com.kakaotech.team18.backend_server.global.config.SecurityConfig;
+import com.kakaotech.team18.backend_server.global.config.TestSecurityConfig;
+import com.kakaotech.team18.backend_server.global.security.JwtAuthenticationFilter;
+import com.kakaotech.team18.backend_server.global.security.JwtProvider;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import jakarta.servlet.http.Cookie; // jakarta.servlet.http.Cookie 임포트
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(
+        controllers = AuthController.class,
+        excludeFilters = {
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = SecurityConfig.class),
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JwtAuthenticationFilter.class)
+        }
+)
+@Import(TestSecurityConfig.class)
+class AuthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private AuthService authService;
+
+    @MockBean
+    private JwtProvider jwtProvider; // AuthController에 직접 주입되지는 않지만, JwtProvider가 필요한 경우를 대비하여 MockBean으로 등록
+
+    @DisplayName("카카오 로그인 성공 - 기존 회원")
+    @Test
+    void kakaoLogin_existingUser_success() throws Exception {
+        // given
+        String authorizationCode = "testAuthCode";
+        String accessToken = "mockAccessToken";
+        String refreshToken = "mockRefreshToken";
+        KakaoLoginRequestDto requestDto = new KakaoLoginRequestDto(authorizationCode);
+
+        LoginSuccessResponseDto serviceResponse = new LoginSuccessResponseDto(AuthStatus.LOGIN_SUCCESS, accessToken, refreshToken);
+
+        given(authService.kakaoLogin(authorizationCode)).willReturn(serviceResponse);
+
+        // when & then
+        mockMvc.perform(post("/api/auth/kakao/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto)))
+                .andExpect(status().isOk())
+                .andExpect(cookie().exists("refreshToken"))
+                .andExpect(cookie().httpOnly("refreshToken", true))
+                .andExpect(cookie().secure("refreshToken", true))
+                .andExpect(cookie().path("refreshToken", "/"))
+                .andExpect(jsonPath("$.status").value(AuthStatus.LOGIN_SUCCESS.name()))
+                .andExpect(jsonPath("$.accessToken").value(accessToken))
+                .andExpect(jsonPath("$.refreshToken").doesNotExist()); // 응답 본문에 refreshToken이 없어야 함
+    }
+
+    @DisplayName("카카오 로그인 성공 - 신규 회원 (추가 정보 필요)")
+    @Test
+    void kakaoLogin_newUser_registrationRequired() throws Exception {
+        // given
+        String authorizationCode = "testAuthCode";
+        String temporaryToken = "mockTemporaryToken";
+        KakaoLoginRequestDto requestDto = new KakaoLoginRequestDto(authorizationCode);
+        RegistrationRequiredResponseDto serviceResponse = new RegistrationRequiredResponseDto(AuthStatus.REGISTRATION_REQUIRED, temporaryToken);
+
+        given(authService.kakaoLogin(authorizationCode)).willReturn(serviceResponse);
+
+        // when & then
+        mockMvc.perform(post("/api/auth/kakao/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto)))
+                .andExpect(status().isOk())
+                .andExpect(cookie().doesNotExist("refreshToken")) // 신규 회원은 refreshToken 쿠키가 없어야 함
+                .andExpect(jsonPath("$.status").value(AuthStatus.REGISTRATION_REQUIRED.name()))
+                .andExpect(jsonPath("$.temporaryToken").value(temporaryToken));
+    }
+
+    @DisplayName("회원가입 성공")
+    @Test
+    void register_success() throws Exception {
+        // given
+        String temporaryToken = "mockTemporaryToken";
+        String accessToken = "newAccessToken";
+        String refreshToken = "newRefreshToken";
+        RegisterRequestDto requestDto = new RegisterRequestDto(
+                "testUser", "test@example.com", "123456", "컴퓨터공학과", "01012345678"
+        );
+
+        LoginSuccessResponseDto serviceResponse = new LoginSuccessResponseDto(AuthStatus.REGISTER_SUCCESS, accessToken, refreshToken);
+
+        given(authService.register(anyString(), any(RegisterRequestDto.class))).willReturn(serviceResponse);
+
+        // when & then
+        mockMvc.perform(post("/api/auth/register")
+                        .header("Authorization", "Bearer " + temporaryToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto)))
+                .andExpect(status().isCreated())
+                .andExpect(cookie().exists("refreshToken"))
+                .andExpect(cookie().httpOnly("refreshToken", true))
+                .andExpect(cookie().secure("refreshToken", true))
+                .andExpect(cookie().path("refreshToken", "/"))
+                .andExpect(jsonPath("$.status").value(AuthStatus.REGISTER_SUCCESS.name()))
+                .andExpect(jsonPath("$.accessToken").value(accessToken))
+                .andExpect(jsonPath("$.refreshToken").doesNotExist());
+    }
+
+    @DisplayName("Access Token 재발급 성공")
+    @Test
+    void reissue_success() throws Exception {
+        // given
+        String oldRefreshToken = "oldMockRefreshToken";
+        String newAccessToken = "newMockAccessToken";
+        String newRefreshToken = "newMockRefreshToken";
+        ReissueResponseDto serviceResponse = ReissueResponseDto.of(newAccessToken, newRefreshToken);
+
+        given(authService.reissue(oldRefreshToken)).willReturn(serviceResponse);
+
+        // when & then
+        mockMvc.perform(post("/api/auth/reissue")
+                        .cookie(new Cookie("refreshToken", oldRefreshToken))) // 쿠키에 refreshToken 담아 전송
+                .andExpect(status().isOk())
+                .andExpect(cookie().exists("refreshToken"))
+                .andExpect(cookie().httpOnly("refreshToken", true))
+                .andExpect(cookie().secure("refreshToken", true))
+                .andExpect(cookie().path("refreshToken", "/"))
+                .andExpect(jsonPath("$.accessToken").value(newAccessToken))
+                .andExpect(jsonPath("$.refreshToken").doesNotExist()); // 응답 본문에 refreshToken이 없어야 함
+    }
+
+    @DisplayName("Access Token 재발급 실패 - Refresh Token 쿠키 없음")
+    @Test
+    void reissue_fail_noRefreshTokenCookie() throws Exception {
+        // given (authService.reissue는 호출되지 않을 것이므로 given 설정 불필요)
+
+        // when & then
+        mockMvc.perform(post("/api/auth/reissue")) // 쿠키 없이 요청
+                .andExpect(status().isBadRequest()); // @CookieValue는 쿠키가 없으면 400 Bad Request 반환
+    }
+}

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/auth/controller/AuthControllerTest.java
@@ -12,6 +12,7 @@ import com.kakaotech.team18.backend_server.domain.club.controller.ClubController
 import com.kakaotech.team18.backend_server.global.config.SecurityConfig;
 import com.kakaotech.team18.backend_server.global.config.TestSecurityConfig;
 import com.kakaotech.team18.backend_server.global.security.JwtAuthenticationFilter;
+import com.kakaotech.team18.backend_server.global.security.JwtProperties;
 import com.kakaotech.team18.backend_server.global.security.JwtProvider;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -56,6 +57,9 @@ class AuthControllerTest {
 
     @MockBean
     private JwtProvider jwtProvider; // AuthController에 직접 주입되지는 않지만, JwtProvider가 필요한 경우를 대비하여 MockBean으로 등록
+
+    @MockBean
+    private JwtProperties jwtProperties;
 
     @DisplayName("카카오 로그인 성공 - 기존 회원")
     @Test

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/club/controller/ClubControllerAuthTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/club/controller/ClubControllerAuthTest.java
@@ -1,0 +1,71 @@
+package com.kakaotech.team18.backend_server.domain.club.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kakaotech.team18.backend_server.domain.club.service.ClubService;
+import com.kakaotech.team18.backend_server.global.security.CustomSecurityService;
+import com.kakaotech.team18.backend_server.global.security.JwtProvider;
+import com.kakaotech.team18.backend_server.global.security.PrincipalDetailsService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@AutoConfigureMockMvc
+// @Import(TestSecurityConfig.class) // 실제 SecurityConfig를 사용하기 위해 이 줄을 추가하지 않습니다.
+class ClubControllerAuthTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private ClubService clubService; // 서비스 로직은 Mocking 합니다.
+
+    @DisplayName("동아리 대시보드 조회 - 성공 (동아리 관리자)")
+    @Test
+    @WithMockUser(authorities = "CLUB_1_CLUB_ADMIN") // 1번 동아리의 관리자 권한을 가진 가짜 사용자
+    void getClubDashboard_withAdminAuth_success() throws Exception {
+        // given
+        Long clubId = 1L;
+
+        // 서비스 계층의 동작은 Mocking 처리합니다.
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                get("/api/clubs/{clubId}/dashboard", clubId)
+        );
+
+        // then
+        // 인가에 성공했으므로 200 OK 응답을 기대합니다.
+        resultActions.andExpect(status().isOk());
+    }
+
+    @DisplayName("동아리 대시보드 조회 - 실패 (권한 부족)")
+    @Test
+    @WithMockUser(authorities = "CLUB_1_CLUB_MEMBER") // 1번 동아리의 '일반 회원' 권한을 가진 가짜 사용자
+    void getClubDashboard_withMemberAuth_fail() throws Exception {
+        // given
+        Long clubId = 1L;
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                get("/api/clubs/{clubId}/dashboard", clubId)
+        );
+
+        // then
+        // 인가에 실패했으므로 403 Forbidden 응답을 기대합니다.
+        resultActions.andExpect(status().isForbidden());
+    }
+
+}

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/club/controller/ClubControllerAuthTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/club/controller/ClubControllerAuthTest.java
@@ -1,21 +1,27 @@
 package com.kakaotech.team18.backend_server.domain.club.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kakaotech.team18.backend_server.domain.club.dto.ClubDetailRequestDto;
+import com.kakaotech.team18.backend_server.domain.club.entity.Category;
 import com.kakaotech.team18.backend_server.domain.club.service.ClubService;
-import com.kakaotech.team18.backend_server.global.security.CustomSecurityService;
-import com.kakaotech.team18.backend_server.global.security.JwtProvider;
-import com.kakaotech.team18.backend_server.global.security.PrincipalDetailsService;
+import com.kakaotech.team18.backend_server.global.dto.SuccessResponseDto;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
@@ -66,6 +72,42 @@ class ClubControllerAuthTest {
         // then
         // 인가에 실패했으므로 403 Forbidden 응답을 기대합니다.
         resultActions.andExpect(status().isForbidden());
+    }
+
+    @DisplayName("동아리 대시보드 조회 - 실패 (다른 동아리 관리자)")
+    @Test
+    @WithMockUser(authorities = "CLUB_2_CLUB_ADMIN") // 2번 동아리의 관리자 권한을 가진 가짜 사용자
+    void getClubDashboard_withOtherClubAdminAuth_fail() throws Exception {
+        // given
+        Long targetClubId = 1L; // 접근하려는 대상은 1번 동아리
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                get("/api/clubs/{clubId}/dashboard", targetClubId)
+        );
+
+        // then
+        // 사용자는 2번 동아리 관리자 권한을 가졌지만, 1번 동아리 리소스에 접근하려 했으므로
+        // 인가에 실패하여 403 Forbidden 응답을 기대합니다.
+        resultActions.andExpect(status().isForbidden());
+    }
+
+    @DisplayName("동아리 대시보드 조회 - 실패 (미인증 사용자)")
+    @Test
+        // @WithMockUser 어노테이션 없음 (로그인하지 않은 상태)
+    void getClubDashboard_withUnauthenticatedUser_fail() throws Exception {
+        // given
+        Long clubId = 1L;
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                get("/api/clubs/{clubId}/dashboard", clubId)
+        );
+
+        // then
+        // 인증되지 않은 사용자이므로 401 Unauthorized 응답을 기대합니다.
+        // SecurityConfig의 authenticationEntryPoint가 올바르게 동작하는지 검증합니다.
+        resultActions.andExpect(status().isUnauthorized());
     }
 
 }

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/controller/ClubApplyFormControllerAuthTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/controller/ClubApplyFormControllerAuthTest.java
@@ -1,0 +1,128 @@
+package com.kakaotech.team18.backend_server.domain.clubApplyForm.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kakaotech.team18.backend_server.domain.clubApplyForm.dto.ClubApplyFormRequestDto;
+import com.kakaotech.team18.backend_server.domain.clubApplyForm.service.ClubApplyFormService;
+import com.kakaotech.team18.backend_server.domain.formQuestion.dto.FormQuestionRequestDto;
+import com.kakaotech.team18.backend_server.domain.formQuestion.dto.FormQuestionResponseDto;
+import com.kakaotech.team18.backend_server.domain.formQuestion.entity.FieldType;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@AutoConfigureMockMvc
+class ClubApplyFormControllerAuthTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private ClubApplyFormService clubApplyFormService;
+
+    @DisplayName("지원서 양식 생성 - 성공 (동아리 관리자)")
+    @Test
+    @WithMockUser(authorities = "CLUB_1_CLUB_ADMIN")
+    void createClubApplyForm_withAdminAuth_success() throws Exception {
+        // given
+        Long clubId = 1L;
+        ClubApplyFormRequestDto requestDto = new ClubApplyFormRequestDto(
+                "Dummy Title",
+                "Dummy Description",
+                List.of(new FormQuestionRequestDto("질문 1", FieldType.TEXT, true, 1L, null, null))
+        );
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                post("/api/clubs/{clubId}/dashboard/apply-form", clubId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto))
+        );
+
+        // then
+        // 리소스가 성공적으로 생성되었으므로 201 Created 응답을 기대합니다.
+        resultActions.andExpect(status().isCreated());
+    }
+
+    @DisplayName("지원서 양식 생성 - 실패 (권한 부족)")
+    @Test
+    @WithMockUser(authorities = "CLUB_1_CLUB_MEMBER")
+    void createClubApplyForm_withMemberAuth_fail() throws Exception {
+        // given
+        Long clubId = 1L;
+        ClubApplyFormRequestDto requestDto = new ClubApplyFormRequestDto(
+                "Dummy Title",
+                "Dummy Description",
+                List.of(new FormQuestionRequestDto("질문 1", FieldType.TEXT, true, 1L, null, null))
+        );
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                post("/api/clubs/{clubId}/dashboard/apply-form", clubId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto))
+        );
+
+        // then
+        resultActions.andExpect(status().isForbidden());
+    }
+
+    @DisplayName("지원서 양식 생성 - 실패 (다른 동아리 관리자)")
+    @Test
+    @WithMockUser(authorities = "CLUB_2_CLUB_ADMIN")
+    void createClubApplyForm_withOtherClubAdminAuth_fail() throws Exception {
+        // given
+        Long targetClubId = 1L;
+        ClubApplyFormRequestDto requestDto = new ClubApplyFormRequestDto(
+                "Dummy Title",
+                "Dummy Description",
+                List.of(new FormQuestionRequestDto("질문 1", FieldType.TEXT, true, 1L, null, null))
+        );
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                post("/api/clubs/{clubId}/dashboard/apply-form", targetClubId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto))
+        );
+
+        // then
+        resultActions.andExpect(status().isForbidden());
+    }
+
+    @DisplayName("지원서 양식 생성 - 실패 (미인증 사용자)")
+    @Test
+    void createClubApplyForm_withUnauthenticatedUser_fail() throws Exception {
+        // given
+        Long clubId = 1L;
+        ClubApplyFormRequestDto requestDto = new ClubApplyFormRequestDto(
+                "Dummy Title",
+                "Dummy Description",
+                List.of(new FormQuestionRequestDto("질문 1", FieldType.TEXT, true, 1L, null, null))
+        );
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                post("/api/clubs/{clubId}/dashboard/apply-form", clubId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto))
+        );
+
+        // then
+        resultActions.andExpect(status().isUnauthorized());
+    }
+}

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/comment/controller/CommentControllerAuthTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/comment/controller/CommentControllerAuthTest.java
@@ -1,0 +1,114 @@
+package com.kakaotech.team18.backend_server.domain.comment.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kakaotech.team18.backend_server.domain.application.repository.ApplicationRepository;
+import com.kakaotech.team18.backend_server.domain.comment.service.CommentService;
+import com.kakaotech.team18.backend_server.global.security.WithMockCustomUser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.util.Optional;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@AutoConfigureMockMvc
+class CommentControllerAuthTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private CommentService commentService; // 컨트롤러가 의존하므로 Mock으로 유지
+
+    @MockBean
+    private ApplicationRepository applicationRepository; // CustomSecurityService가 의존하므로 Mock으로 추가
+
+    @BeforeEach
+    void setUp() {
+        // @customSecurityService가 DB를 조회하는 부분을 Mocking합니다.
+        // 100번 지원서는 1번 동아리에 속해있다고 가정합니다.
+        given(applicationRepository.findClubIdByApplicationId(100L)).willReturn(Optional.of(1L));
+        // 101번 지원서는 2번 동아리에 속해있다고 가정합니다.
+        given(applicationRepository.findClubIdByApplicationId(101L)).willReturn(Optional.of(2L));
+    }
+
+    @DisplayName("댓글 조회 - 성공 (동아리 관리자)")
+    @Test
+    @WithMockCustomUser(memberships = {"1:CLUB_ADMIN"})
+    void getComments_withAdminAuth_success() throws Exception {
+        // given
+        Long applicationId = 100L; // 1번 동아리에 속한 지원서
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                get("/api/applications/{applicationId}/comments", applicationId)
+        );
+
+        // then
+        // 사용자는 1번 동아리 관리자이고, 지원서도 1번 동아리 소속이므로 200 OK를 기대합니다.
+        resultActions.andExpect(status().isOk());
+    }
+
+    @DisplayName("댓글 조회 - 실패 (권한 부족)")
+    @Test
+    @WithMockCustomUser(memberships = {"1:CLUB_MEMBER"})
+    void getComments_withMemberAuth_fail() throws Exception {
+        // given
+        Long applicationId = 100L; // 1번 동아리에 속한 지원서
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                get("/api/applications/{applicationId}/comments", applicationId)
+        );
+
+        // then
+        // 사용자는 1번 동아리의 일반 회원이므로, 403 Forbidden을 기대합니다.
+        resultActions.andExpect(status().isForbidden());
+    }
+
+    @DisplayName("댓글 조회 - 실패 (다른 동아리 관리자)")
+    @Test
+    @WithMockCustomUser(memberships = {"2:CLUB_ADMIN"})
+    void getComments_withOtherClubAdminAuth_fail() throws Exception {
+        // given
+        Long applicationId = 100L; // 접근하려는 대상은 1번 동아리에 속한 지원서
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                get("/api/applications/{applicationId}/comments", applicationId)
+        );
+
+        // then
+        // 사용자는 2번 동아리 관리자이지만, 지원서는 1번 동아리 소속이므로 403 Forbidden을 기대합니다.
+        resultActions.andExpect(status().isForbidden());
+    }
+
+    @DisplayName("댓글 조회 - 실패 (미인증 사용자)")
+    @Test
+    void getComments_withUnauthenticatedUser_fail() throws Exception {
+        // given
+        Long applicationId = 100L;
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                get("/api/applications/{applicationId}/comments", applicationId)
+        );
+
+        // then
+        // 인증되지 않은 사용자이므로 401 Unauthorized를 기대합니다.
+        resultActions.andExpect(status().isUnauthorized());
+    }
+}

--- a/src/test/java/com/kakaotech/team18/backend_server/global/security/WithMockCustomUser.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/global/security/WithMockCustomUser.java
@@ -1,0 +1,21 @@
+package com.kakaotech.team18.backend_server.global.security;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithMockCustomUserSecurityContextFactory.class)
+public @interface WithMockCustomUser {
+
+    long userId() default 1L;
+
+    String nickname() default "testuser";
+
+    /**
+     * 사용자의 동아리 멤버십 정보를 "clubId:ROLE" 형식의 문자열 배열로 설정합니다.
+     * <p>
+     * 예: {"1:CLUB_ADMIN", "3:CLUB_MEMBER"}
+     */
+    String[] memberships() default {};
+}

--- a/src/test/java/com/kakaotech/team18/backend_server/global/security/WithMockCustomUserSecurityContextFactory.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/global/security/WithMockCustomUserSecurityContextFactory.java
@@ -1,0 +1,47 @@
+package com.kakaotech.team18.backend_server.global.security;
+
+import com.kakaotech.team18.backend_server.domain.user.entity.User;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class WithMockCustomUserSecurityContextFactory
+    implements WithSecurityContextFactory<WithMockCustomUser> {
+
+  @Override
+  public SecurityContext createSecurityContext(WithMockCustomUser customUser) {
+    // 1. SecurityContext를 새로 생성합니다.
+    SecurityContext context = SecurityContextHolder.createEmptyContext();
+
+    // 2. memberships 문자열 배열을 Map<String, String>으로 변환합니다.
+    Map<String, String> memberships =
+        Arrays.stream(customUser.memberships())
+            .map(s -> s.split(":"))
+            .collect(Collectors.toMap(a -> a[0], a -> a[1]));
+
+    // 3. 어노테이션의 정보를 바탕으로 가짜 User 객체와 PrincipalDetails 객체를 생성합니다.
+    User mockUser =
+        User.builder()
+            .name(customUser.nickname())
+            .build();
+    ReflectionTestUtils.setField(mockUser, "id", customUser.userId());
+    PrincipalDetails principalDetails = new PrincipalDetails(mockUser, memberships);
+
+    // 4. Authentication 객체를 생성합니다.
+    Authentication authentication =
+        new UsernamePasswordAuthenticationToken(
+            principalDetails, null, principalDetails.getAuthorities());
+
+    // 5. SecurityContext에 Authentication 객체를 설정합니다.
+    context.setAuthentication(authentication);
+
+    // 6. 완성된 SecurityContext를 반환합니다.
+    return context;
+  }
+}


### PR DESCRIPTION
## 💡 작업 배경 및 문제점

기존 로그인 응답 방식은 **Access Token**과 **Refresh Token**을 모두 JSON 본문에 담아 클라이언트에게 전달했습니다. 하지만 프론트엔드 팀에서는 보안 강화를 위해 상대적으로 오래 보관되는 **Refresh Token**을 JavaScript에서 접근할 수 없는 **HttpOnly 쿠키**에 저장하고자 했습니다.

### 핵심 문제

**HttpOnly** 속성이 붙은 쿠키는 보안상의 이유로 브라우저가 JavaScript의 접근을 원천적으로 차단합니다. 따라서 프론트엔드에서는 쿠키에 저장된 Refresh Token을 JavaScript로 읽어서 Authorization 헤더에 담는 것이 기술적으로 불가능했습니다. 이는 현재 백엔드의 Access Token 재발급 API 명세(클라이언트가 Authorization 헤더에 Refresh Token을 담아 보내도록 되어 있음)와 충돌하는 문제였습니다.

### 보안적 중요성 (XSS 공격 방어)

이 문제의 핵심에는 **XSS(Cross-Site Scripting) 공격 방어**라는 중요한 보안 원칙이 있습니다. 만약 해커가 웹사이트에 악성 스크립트를 삽입하는 데 성공하면, JavaScript가 접근할 수 있는 모든 정보를 탈취할 수 있습니다. **HttpOnly 쿠키**는 브라우저에게 "이 쿠키는 절대 JavaScript가 만지지 못하게 해!"라고 명령하는 것과 같으므로, 만에 하나 XSS 공격을 당하더라도 해커가 가장 중요한 **Refresh Token**을 훔쳐가는 것을 막을 수 있습니다.

### 결론

현재 우리의 API 명세는 프론트엔드의 올바른 보안 전략과 충돌하고 있었으며, 백엔드 코드를 수정하여 프론트엔드가 **HttpOnly 쿠키**를 안전하게 사용할 수 있도록 지원해야 했습니다. 이 PR은 이러한 문제점을 해결하고 보안을 강화하기 위해 진행되었습니다.

---

## 🚀 작업 내용

프론트엔드의 보안 강화 요구사항에 따라, **Refresh Token**의 전달 방식을 기존 JSON 본문에서 **HttpOnly** 속성이 적용된 쿠키로 전면 변경했습니다. 이를 통해 **XSS(Cross-Site Scripting) 공격**으로부터 Refresh Token을 안전하게 보호합니다.

주요 변경 사항은 다음과 같습니다:

1. **로그인 & 회원가입 API 응답 변경**
    - 로그인/회원가입 성공 시, 서버는 Set-Cookie 헤더를 통해 **Refresh Token**을 **HttpOnly 쿠키**로 전달합니다.
    - 클라이언트 응답 본문(JSON)에서는 **Refresh Token** 필드를 제거하고, **Access Token**만 포함하도록 수정했습니다. 이를 위해 응답 전용 DTO(Body record)를 추가했습니다.
2. **토큰 재발급 API 요청/응답 방식 변경**
    - reissue API가 Authorization 헤더 대신, 브라우저가 자동으로 전송하는 쿠키에서 **Refresh Token**을 받도록 **@CookieValue** 를 사용해 수정했습니다.
    - 재발급 성공 시, 새로 발급된 **Refresh Token** (Refresh Token Rotation) 또한 **HttpOnly 쿠키**로 갱신하여 전달합니다.
3. **전역 예외 처리 강화**
    - 필수 쿠키(refreshToken)가 요청에 포함되지 않았을 때 발생하는 **MissingRequestCookieException** 을 처리하기 위한 핸들러를 **GlobalExceptionHandler** 에 추가했습니다. 이를 통해 500 에러 대신 명확한 **400 Bad Request**를 응답합니다.
4. **테스트 코드 수정 및 보강**
    - 변경된 서비스 로직에 맞춰 AuthServiceImplTest의 단위 테스트를 수정했습니다.
    - **@WebMvcTest** 를 사용하여 AuthController의 쿠키 처리 로직을 검증하는 통합 테스트(AuthControllerTest)를 신규 작성했습니다.
5. **설정 외부화 리팩토링**
    - AuthController에 하드코딩되어 있던 Refresh Token 만료 시간을 application.yml의 jwt.refresh-token-validity-in-seconds 값을 사용하도록 리팩토링했습니다.

---

## ⏱️ 소요 시간

3h

---

## 🤔 고민했던 내용

1. 응답 DTO를 어떻게 분리할 것인가?
    
    Refresh Token을 쿠키로 옮기면서, 클라이언트에게 보내는 JSON 응답에서는 해당 필드를 제거해야 했습니다. 처음에는 기존 LoginSuccessResponseDto에서 필드를 제거하는 방안을 생각했지만, 이 경우 AuthService가 생성한 Refresh Token을 AuthController로 전달할 방법이 사라지는 문제가 있었습니다.
    
    **해결:** 서비스와 컨트롤러 간의 데이터 전달 역할은 유지하되, 최종 응답 명세만 변경하기 위해 기존 DTO 내부에 **응답 본문 전용 Body record를 중첩하여 정의**하는 방식을 채택했습니다. 이를 통해 각 계층의 책임은 명확히 유지하면서 API 명세의 일관성을 확보할 수 있었습니다.
    
2. 프레임워크 레벨 예외는 어떻게 처리해야 하는가?
    
    @CookieValue를 사용하면서, 필수 쿠키가 누락되었을 때 MissingRequestCookieException 이 발생하며 테스트가 실패하는 문제를 마주했습니다. 저희 팀의 예외 처리 컨벤션은 커스텀 예외를 던져서 처리하는 것이었지만, 이 경우에는 적용할 수 없었습니다.
    
    **이유:** 해당 예외는 저희가 작성한 컨트롤러 메소드의 코드가 실행되기 전, **Spring의 ArgumentResolver 단에서 발생하는 프레임워크 레벨 예외**이기 때문입니다. 즉, 저희 코드 내에서 try-catch로 잡아 커스텀 예외로 변환할 기회 자체가 없었습니다.
    
    **해결:** 이러한 프레임워크 레벨의 예외를 처리하는 표준적인 방법인 **@RestControllerAdvice(GlobalExceptionHandler)에 직접 핸들러를 추가**하는 방식을 채택했습니다. 이를 통해 클라이언트의 잘못된 요청에 대해 명확한 **400 Bad Request** 응답을 제공하고, 애플리케이션의 안정성을 높였습니다.
    
3. 무엇을, 어떻게 테스트해야 하는가?
    
    단순히 서비스 로직의 단위 테스트만 수정하는 것은 충분하지 않다고 판단했습니다. 이번 작업의 핵심은 HTTP 프로토콜 수준에서의 변화(쿠키, 헤더, 응답 본문)였기 때문입니다.
    
    **해결:** **MockMvc**를 사용한 **@WebMvcTest** 를 적극적으로 활용하여 AuthController에 대한 통합 테스트를 작성했습니다. 이를 통해 실제 컨트롤러가 HTTP 요청을 받았을 때, 의도한 대로 쿠키의 속성(HttpOnly, Secure등)이 올바르게 설정되는지, 응답 본문에서 민감한 정보가 잘 제거되었는지 등을 꼼꼼하게 검증할 수 있었습니다.
    

---

## 💬 리뷰 중점사항

- 변경된 인증/인가 흐름(로그인, 재발급)이 보안적인 관점에서 올바르게 구현되었는지 확인 부탁드립니다.
- AuthController에서 ResponseCookie를 생성하고 사용하는 방식이 적절한지 검토해 주세요.
- GlobalExceptionHandler에 추가된 예외 처리 로직이 다른 핸들러와 충돌 없이 잘 동작할지 확인 부탁드립니다.
- 새롭게 작성된 AuthControllerTest가 쿠키 기반 인증의 핵심적인 시나리오들을 충분히 커버하고 있는지 검토해 주세요.

---

## 🔗 관련 이슈

- Close #153

---

rebase 및 push 과정에서 실수를 해가지고 이전 commit이 조금 포함되었습니다.
feat: 로그인 응답 본문 전용 DTO 추가 
포함해서 이후 commit들 리뷰해주시면 감사하겠습니다 !

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 보안 및 인증 개선사항

* **New Features**
  * 안전한 쿠키 기반 리프레시 토큰 처리 추가
  * 클럽 리소스에 대한 접근 제어 강화
  * 토큰 자동 갱신 메커니즘 개선

* **Security**
  * API 엔드포인트별 권한 검증 적용
  * 조직별 역할 기반 접근 제한 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->