### PR TITLE
[REFACTOR] Refresh Token 전달 방식 개선 및 보안 강화 about HttpOnly 및 Cookie

### DIFF
--- a/src/main/java/com/kakaotech/team18/backend_server/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/auth/controller/AuthController.java
@@ -54,7 +54,7 @@ public class AuthController {
                     .maxAge(jwtProperties.refreshTokenValidityInSeconds())
                     .build();
 
-            LoginSuccessResponseDto.Body body = new LoginSuccessResponseDto.Body(dto.status(), dto.accessToken());
+            LoginSuccessResponseDto.Body body = new LoginSuccessResponseDto.Body(dto.status(), dto.accessToken(), dto.clubIdAndRoleList());
 
             return ResponseEntity.ok()
                     .header(HttpHeaders.SET_COOKIE, responseCookie.toString())
@@ -85,7 +85,7 @@ public class AuthController {
                 .maxAge(jwtProperties.refreshTokenValidityInSeconds())
                 .build();
 
-        LoginSuccessResponseDto.Body body = new LoginSuccessResponseDto.Body(responseDto.status(), responseDto.accessToken());
+        LoginSuccessResponseDto.Body body = new LoginSuccessResponseDto.Body(responseDto.status(), responseDto.accessToken(), responseDto.clubIdAndRoleList());
 
         return ResponseEntity.status(HttpStatus.CREATED)
                 .header(HttpHeaders.SET_COOKIE, responseCookie.toString())

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/auth/controller/AuthController.java
@@ -7,6 +7,7 @@ import com.kakaotech.team18.backend_server.domain.auth.dto.RegisterRequestDto;
 import com.kakaotech.team18.backend_server.domain.auth.dto.RegistrationRequiredResponseDto;
 import com.kakaotech.team18.backend_server.domain.auth.dto.ReissueResponseDto;
 import com.kakaotech.team18.backend_server.domain.auth.service.AuthService;
+import com.kakaotech.team18.backend_server.global.security.JwtProperties;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -34,7 +35,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     private final AuthService authService;
-    private final long REFRESH_TOKEN_EXPIRE_TIME = 1000L * 60 * 60 * 24 * 14; // 14일
+    private final JwtProperties jwtProperties;
 
     @Operation(summary = "카카오 인가 코드로 로그인/회원가입", description = "클라이언트가 카카오로부터 받은 인가 코드를 전송하면, 서버는 이를 검증하여 기존 회원이면 즉시 로그인 처리하고, 신규 회원이면 추가 정보 입력을 위한 임시 토큰을 발급합니다.")
     @ApiResponses(value = {
@@ -50,7 +51,7 @@ public class AuthController {
                     .httpOnly(true)
                     .secure(true)
                     .path("/")
-                    .maxAge(REFRESH_TOKEN_EXPIRE_TIME)
+                    .maxAge(jwtProperties.refreshTokenValidityInSeconds())
                     .build();
 
             LoginSuccessResponseDto.Body body = new LoginSuccessResponseDto.Body(dto.status(), dto.accessToken());
@@ -81,7 +82,7 @@ public class AuthController {
                 .httpOnly(true)
                 .secure(true)
                 .path("/")
-                .maxAge(REFRESH_TOKEN_EXPIRE_TIME)
+                .maxAge(jwtProperties.refreshTokenValidityInSeconds())
                 .build();
 
         LoginSuccessResponseDto.Body body = new LoginSuccessResponseDto.Body(responseDto.status(), responseDto.accessToken());
@@ -107,7 +108,7 @@ public class AuthController {
                 .httpOnly(true)
                 .secure(true)
                 .path("/")
-                .maxAge(REFRESH_TOKEN_EXPIRE_TIME)
+                .maxAge(jwtProperties.refreshTokenValidityInSeconds())
                 .build();
 
         ReissueResponseDto.Body body = new ReissueResponseDto.Body(reissueResponseDto.accessToken());

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/auth/controller/AuthController.java
@@ -16,7 +16,9 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -31,32 +33,61 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     private final AuthService authService;
+    private final long REFRESH_TOKEN_EXPIRE_TIME = 1000L * 60 * 60 * 24 * 14; // 14일
 
     @Operation(summary = "카카오 인가 코드로 로그인/회원가입", description = "클라이언트가 카카오로부터 받은 인가 코드를 전송하면, 서버는 이를 검증하여 기존 회원이면 즉시 로그인 처리하고, 신규 회원이면 추가 정보 입력을 위한 임시 토큰을 발급합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "로그인 성공 또는 추가 정보 입력 필요",
-                    content = @Content(schema = @Schema(oneOf = {LoginSuccessResponseDto.class, RegistrationRequiredResponseDto.class})))
+                    content = @Content(schema = @Schema(oneOf = {LoginSuccessResponseDto.Body.class, RegistrationRequiredResponseDto.class})))
     })
     @PostMapping("/kakao/login")
     public ResponseEntity<LoginResponse> kakaoLogin(@Valid @RequestBody KakaoLoginRequestDto kakaoLoginRequestDto) {
         LoginResponse loginResponse = authService.kakaoLogin(kakaoLoginRequestDto.authorizationCode());
+
+        if (loginResponse instanceof LoginSuccessResponseDto dto) {
+            ResponseCookie responseCookie = ResponseCookie.from("refreshToken", dto.refreshToken())
+                    .httpOnly(true)
+                    .secure(true)
+                    .path("/")
+                    .maxAge(REFRESH_TOKEN_EXPIRE_TIME)
+                    .build();
+
+            LoginSuccessResponseDto.Body body = new LoginSuccessResponseDto.Body(dto.status(), dto.accessToken());
+
+            return ResponseEntity.ok()
+                    .header(HttpHeaders.SET_COOKIE, responseCookie.toString())
+                    .body(body);
+        }
+
         return ResponseEntity.ok(loginResponse);
     }
 
     @Operation(summary = "추가 정보 제출 및 최종 회원가입", description = "임시 토큰과 함께 사용자의 추가 정보(학번, 학과 등)를 받아 최종적으로 회원가입을 완료하고, 정식 토큰을 발급합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "201", description = "회원가입 및 로그인 성공",
-                    content = @Content(schema = @Schema(implementation = LoginSuccessResponseDto.class))),
+                    content = @Content(schema = @Schema(implementation = LoginSuccessResponseDto.Body.class))),
             @ApiResponse(responseCode = "401", description = "유효하지 않은 임시 토큰")
     })
     @SecurityRequirement(name = "temporary-token") // Swagger에서 임시 토큰 헤더를 명시
     @PostMapping("/register")
-    public ResponseEntity<LoginSuccessResponseDto> register(
+    public ResponseEntity<LoginSuccessResponseDto.Body> register(
             @RequestHeader("Authorization") String temporaryToken,
             @Valid @RequestBody RegisterRequestDto registerRequestDto) {
 
         LoginSuccessResponseDto responseDto = authService.register(temporaryToken, registerRequestDto);
-        return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
+
+        ResponseCookie responseCookie = ResponseCookie.from("refreshToken", responseDto.refreshToken())
+                .httpOnly(true)
+                .secure(true)
+                .path("/")
+                .maxAge(REFRESH_TOKEN_EXPIRE_TIME)
+                .build();
+
+        LoginSuccessResponseDto.Body body = new LoginSuccessResponseDto.Body(responseDto.status(), responseDto.accessToken());
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .header(HttpHeaders.SET_COOKIE, responseCookie.toString())
+                .body(body);
     }
 
     @Operation(summary = "Access Token 재발급", description = "유효한 Refresh Token을 사용하여 만료된 Access Token을 재발급받습니다.")

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/auth/dto/LoginSuccessResponseDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/auth/dto/LoginSuccessResponseDto.java
@@ -24,7 +24,10 @@ public record LoginSuccessResponseDto(
                 AuthStatus status,
 
                 @Schema(description = "우리 서비스의 Access Token")
-                String accessToken
+                String accessToken,
+
+                @Schema(description = "clubId와 Role 정보를 담은 리스트")
+                List<ClubIdAndRoleInfoDto> clubIdAndRoleList
         ) implements LoginResponse {
                 // LoginResponse 인터페이스를 구현합니다.
         }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/auth/dto/LoginSuccessResponseDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/auth/dto/LoginSuccessResponseDto.java
@@ -18,5 +18,14 @@ public record LoginSuccessResponseDto(
         @Schema(description = "clubId와 Role 정보를 담은 리스트")
         List<ClubIdAndRoleInfoDto> clubIdAndRoleList
 ) implements LoginResponse {
-    // LoginResponse 인터페이스를 구현합니다.
+        @Schema(description = "로그인 성공 시 실제 클라이언트에게 전달되는 응답 본문")
+        public record Body(
+                @Schema(description = "응답 상태", example = "LOGIN_SUCCESS")
+                AuthStatus status,
+
+                @Schema(description = "우리 서비스의 Access Token")
+                String accessToken
+        ) implements LoginResponse {
+                // LoginResponse 인터페이스를 구현합니다.
+        }
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/auth/dto/ReissueResponseDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/auth/dto/ReissueResponseDto.java
@@ -12,4 +12,10 @@ public record ReissueResponseDto(
     public static ReissueResponseDto of(String accessToken, String refreshToken) {
         return new ReissueResponseDto(accessToken, refreshToken);
     }
+
+    @Schema(description = "토큰 재발급 시 실제 클라이언트에게 전달되는 응답 본문")
+    public record Body(
+            @Schema(description = "새로 발급된 Access Token", example = "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwidG9rZW5UeXBlIjoiQUNDRVNTIiwiaWF0IjoxNzE1MjMxMzU5LCJleHAiOjE3MTUyMzMxNTl9.example")
+            String accessToken
+    ) {}
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/auth/service/AuthServiceImpl.java
@@ -189,24 +189,21 @@ public class AuthServiceImpl implements AuthService {
 
     @Override
     @Transactional
-    public ReissueResponseDto reissue(String bearerToken) {
-        // 1. Bearer 접두사 제거 및 토큰 추출
-        String refreshToken = jwtProvider.extractToken(bearerToken);
-
-        // 2. Refresh Token 자체 유효성 검증 (만료, 서명 등)
+    public ReissueResponseDto reissue(String refreshToken) {
+        // 1. Refresh Token 자체 유효성 검증 (만료, 서명 등)
         Claims claims = jwtProvider.verify(refreshToken);
 
-        // 3. 토큰 타입 검증
+        // 2. 토큰 타입 검증
         String tokenType = claims.get("tokenType", String.class);
         if (!TokenType.REFRESH.name().equals(tokenType)) {
             log.warn("Refresh Token 재발급 시도 실패: 토큰 타입이 REFRESH가 아님");
             throw new NotRefreshTokenException();
         }
 
-        // 4. 사용자 ID 추출
+        // 3. 사용자 ID 추출
         Long userId = Long.valueOf(claims.getSubject());
 
-        // 5. Redis에 저장된 토큰과 일치하는지 검증
+        // 4. Redis에 저장된 토큰과 일치하는지 검증
         RefreshToken storedRefreshToken = refreshTokenRepository.findById(userId)
                 .orElseThrow(LoggedOutUserException::new);
 
@@ -215,20 +212,20 @@ public class AuthServiceImpl implements AuthService {
             throw new InvalidRefreshTokenException();
         }
 
-        // 6. 사용자 정보 조회
+        // 5. 사용자 정보 조회
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserNotFoundException("해당 유저가 존재하지 않습니다."));
 
-        // 7. 새로운 토큰 발급 (Access, Refresh 둘 다)
+        // 6. 새로운 토큰 발급 (Access, Refresh 둘 다)
         String newAccessToken = jwtProvider.createAccessToken(user);
         String newRefreshToken = jwtProvider.createRefreshToken(user);
         log.info("Access & Refresh Token 재발급 성공: userId={}", userId);
 
-        // 8. Redis에 새로운 Refresh Token 덮어쓰기 (Rotation)
+        // 7. Redis에 새로운 Refresh Token 덮어쓰기 (Rotation)
         refreshTokenRepository.save(new RefreshToken(user.getId(), newRefreshToken, jwtProperties.refreshTokenValidityInSeconds()));
         log.info("Redis에 새로운 Refresh Token 저장(덮어쓰기) 완료: userId={}", user.getId());
 
-        // 9. DTO로 감싸서 반환
+        // 8. DTO로 감싸서 반환
         return ReissueResponseDto.of(newAccessToken, newRefreshToken);
     }
 

--- a/src/main/java/com/kakaotech/team18/backend_server/global/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/exception/handler/GlobalExceptionHandler.java
@@ -11,6 +11,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestCookieException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
@@ -98,6 +99,29 @@ public class GlobalExceptionHandler {
         log.warn("TypeMisMatch: {}", errorCode.getMessage(), e);
         return new ResponseEntity<>(response, errorCode.getHttpStatus());
     }
+
+    /**
+     * MissingRequestCookieException 예외를 처리
+     * <p>
+     * @CookieValue 어노테이션으로 필수 쿠키가 지정되었으나, 요청에 해당 쿠키가 포함되지 않았을 때 발생합니다.
+     * HTTP 400 Bad Request와 함께 적절한 에러 메시지를 반환합니다.
+     *
+     * @param e MissingRequestCookieException
+     * @return 400 Bad Request 상태 코드와 표준 에러 응답
+     */
+    @ExceptionHandler(MissingRequestCookieException.class)
+    protected ResponseEntity<ErrorResponseDto> handleMissingRequestCookieException(final MissingRequestCookieException e) {
+        final ErrorCode errorCode = ErrorCode.INVALID_INPUT_VALUE; // 클라이언트 요청 오류이므로 INVALID_INPUT_VALUE 사용
+        final String detail = "필수 쿠키 '" + e.getCookieName() + "'가 요청에 포함되지 않았습니다.";
+        final ErrorResponseDto response = ErrorResponseDto.of(errorCode, detail);
+
+        log.warn("MissingRequestCookieException: {} (detail: {})",
+                errorCode.getMessage(),
+                detail);
+
+        return new ResponseEntity<>(response, errorCode.getHttpStatus());
+    }
+
 
 
     /**

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/auth/controller/AuthControllerTest.java
@@ -11,6 +11,7 @@ import com.kakaotech.team18.backend_server.domain.auth.service.AuthService;
 import com.kakaotech.team18.backend_server.global.config.SecurityConfig;
 import com.kakaotech.team18.backend_server.global.config.TestSecurityConfig;
 import com.kakaotech.team18.backend_server.global.security.JwtAuthenticationFilter;
+import com.kakaotech.team18.backend_server.global.security.JwtProperties;
 import com.kakaotech.team18.backend_server.global.security.JwtProvider;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -55,6 +56,9 @@ class AuthControllerTest {
 
     @MockBean
     private JwtProvider jwtProvider; // AuthController에 직접 주입되지는 않지만, JwtProvider가 필요한 경우를 대비하여 MockBean으로 등록
+
+    @MockBean
+    private JwtProperties jwtProperties;
 
     @DisplayName("카카오 로그인 성공 - 기존 회원")
     @Test

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/auth/controller/AuthControllerTest.java
@@ -1,0 +1,169 @@
+package com.kakaotech.team18.backend_server.domain.auth.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kakaotech.team18.backend_server.domain.auth.dto.AuthStatus;
+import com.kakaotech.team18.backend_server.domain.auth.dto.KakaoLoginRequestDto;
+import com.kakaotech.team18.backend_server.domain.auth.dto.LoginSuccessResponseDto;
+import com.kakaotech.team18.backend_server.domain.auth.dto.RegisterRequestDto;
+import com.kakaotech.team18.backend_server.domain.auth.dto.RegistrationRequiredResponseDto;
+import com.kakaotech.team18.backend_server.domain.auth.dto.ReissueResponseDto;
+import com.kakaotech.team18.backend_server.domain.auth.service.AuthService;
+import com.kakaotech.team18.backend_server.global.config.SecurityConfig;
+import com.kakaotech.team18.backend_server.global.config.TestSecurityConfig;
+import com.kakaotech.team18.backend_server.global.security.JwtAuthenticationFilter;
+import com.kakaotech.team18.backend_server.global.security.JwtProvider;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import jakarta.servlet.http.Cookie; // jakarta.servlet.http.Cookie 임포트
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(
+        controllers = AuthController.class,
+        excludeFilters = {
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = SecurityConfig.class),
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JwtAuthenticationFilter.class)
+        }
+)
+@Import(TestSecurityConfig.class)
+class AuthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private AuthService authService;
+
+    @MockBean
+    private JwtProvider jwtProvider; // AuthController에 직접 주입되지는 않지만, JwtProvider가 필요한 경우를 대비하여 MockBean으로 등록
+
+    @DisplayName("카카오 로그인 성공 - 기존 회원")
+    @Test
+    void kakaoLogin_existingUser_success() throws Exception {
+        // given
+        String authorizationCode = "testAuthCode";
+        String accessToken = "mockAccessToken";
+        String refreshToken = "mockRefreshToken";
+        KakaoLoginRequestDto requestDto = new KakaoLoginRequestDto(authorizationCode);
+
+        LoginSuccessResponseDto serviceResponse = new LoginSuccessResponseDto(AuthStatus.LOGIN_SUCCESS, accessToken, refreshToken, List.of());
+
+        given(authService.kakaoLogin(authorizationCode)).willReturn(serviceResponse);
+
+        // when & then
+        mockMvc.perform(post("/api/auth/kakao/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto)))
+                .andExpect(status().isOk())
+                .andExpect(cookie().exists("refreshToken"))
+                .andExpect(cookie().httpOnly("refreshToken", true))
+                .andExpect(cookie().secure("refreshToken", true))
+                .andExpect(cookie().path("refreshToken", "/"))
+                .andExpect(jsonPath("$.status").value(AuthStatus.LOGIN_SUCCESS.name()))
+                .andExpect(jsonPath("$.accessToken").value(accessToken))
+                .andExpect(jsonPath("$.refreshToken").doesNotExist()); // 응답 본문에 refreshToken이 없어야 함
+    }
+
+    @DisplayName("카카오 로그인 성공 - 신규 회원 (추가 정보 필요)")
+    @Test
+    void kakaoLogin_newUser_registrationRequired() throws Exception {
+        // given
+        String authorizationCode = "testAuthCode";
+        String temporaryToken = "mockTemporaryToken";
+        KakaoLoginRequestDto requestDto = new KakaoLoginRequestDto(authorizationCode);
+        RegistrationRequiredResponseDto serviceResponse = new RegistrationRequiredResponseDto(AuthStatus.REGISTRATION_REQUIRED, temporaryToken);
+
+        given(authService.kakaoLogin(authorizationCode)).willReturn(serviceResponse);
+
+        // when & then
+        mockMvc.perform(post("/api/auth/kakao/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto)))
+                .andExpect(status().isOk())
+                .andExpect(cookie().doesNotExist("refreshToken")) // 신규 회원은 refreshToken 쿠키가 없어야 함
+                .andExpect(jsonPath("$.status").value(AuthStatus.REGISTRATION_REQUIRED.name()))
+                .andExpect(jsonPath("$.temporaryToken").value(temporaryToken));
+    }
+
+    @DisplayName("회원가입 성공")
+    @Test
+    void register_success() throws Exception {
+        // given
+        String temporaryToken = "mockTemporaryToken";
+        String accessToken = "newAccessToken";
+        String refreshToken = "newRefreshToken";
+        RegisterRequestDto requestDto = new RegisterRequestDto(
+                "testUser", "test@example.com", "123456", "컴퓨터공학과", "01012345678"
+        );
+
+        LoginSuccessResponseDto serviceResponse = new LoginSuccessResponseDto(AuthStatus.REGISTER_SUCCESS, accessToken, refreshToken, List.of());
+
+        given(authService.register(anyString(), any(RegisterRequestDto.class))).willReturn(serviceResponse);
+
+        // when & then
+        mockMvc.perform(post("/api/auth/register")
+                        .header("Authorization", "Bearer " + temporaryToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto)))
+                .andExpect(status().isCreated())
+                .andExpect(cookie().exists("refreshToken"))
+                .andExpect(cookie().httpOnly("refreshToken", true))
+                .andExpect(cookie().secure("refreshToken", true))
+                .andExpect(cookie().path("refreshToken", "/"))
+                .andExpect(jsonPath("$.status").value(AuthStatus.REGISTER_SUCCESS.name()))
+                .andExpect(jsonPath("$.accessToken").value(accessToken))
+                .andExpect(jsonPath("$.refreshToken").doesNotExist());
+    }
+
+    @DisplayName("Access Token 재발급 성공")
+    @Test
+    void reissue_success() throws Exception {
+        // given
+        String oldRefreshToken = "oldMockRefreshToken";
+        String newAccessToken = "newMockAccessToken";
+        String newRefreshToken = "newMockRefreshToken";
+        ReissueResponseDto serviceResponse = ReissueResponseDto.of(newAccessToken, newRefreshToken);
+
+        given(authService.reissue(oldRefreshToken)).willReturn(serviceResponse);
+
+        // when & then
+        mockMvc.perform(post("/api/auth/reissue")
+                        .cookie(new Cookie("refreshToken", oldRefreshToken))) // 쿠키에 refreshToken 담아 전송
+                .andExpect(status().isOk())
+                .andExpect(cookie().exists("refreshToken"))
+                .andExpect(cookie().httpOnly("refreshToken", true))
+                .andExpect(cookie().secure("refreshToken", true))
+                .andExpect(cookie().path("refreshToken", "/"))
+                .andExpect(jsonPath("$.accessToken").value(newAccessToken))
+                .andExpect(jsonPath("$.refreshToken").doesNotExist()); // 응답 본문에 refreshToken이 없어야 함
+    }
+
+    @DisplayName("Access Token 재발급 실패 - Refresh Token 쿠키 없음")
+    @Test
+    void reissue_fail_noRefreshTokenCookie() throws Exception {
+        // given (authService.reissue는 호출되지 않을 것이므로 given 설정 불필요)
+
+        // when & then
+        mockMvc.perform(post("/api/auth/reissue")) // 쿠키 없이 요청
+                .andExpect(status().isBadRequest()); // @CookieValue는 쿠키가 없으면 400 Bad Request 반환
+    }
+}


### PR DESCRIPTION
## 💡 작업 배경 및 문제점

기존 로그인 응답 방식은 **Access Token**과 **Refresh Token**을 모두 JSON 본문에 담아 클라이언트에게 전달했습니다. 하지만 프론트엔드 팀에서는 보안 강화를 위해 상대적으로 오래 보관되는 **Refresh Token**을 JavaScript에서 접근할 수 없는 **HttpOnly 쿠키**에 저장하고자 했습니다.

### 핵심 문제

**HttpOnly** 속성이 붙은 쿠키는 보안상의 이유로 브라우저가 JavaScript의 접근을 원천적으로 차단합니다. 따라서 프론트엔드에서는 쿠키에 저장된 Refresh Token을 JavaScript로 읽어서 Authorization 헤더에 담는 것이 기술적으로 불가능했습니다. 이는 현재 백엔드의 Access Token 재발급 API 명세(클라이언트가 Authorization 헤더에 Refresh Token을 담아 보내도록 되어 있음)와 충돌하는 문제였습니다.

### 보안적 중요성 (XSS 공격 방어)

이 문제의 핵심에는 **XSS(Cross-Site Scripting) 공격 방어**라는 중요한 보안 원칙이 있습니다. 만약 해커가 웹사이트에 악성 스크립트를 삽입하는 데 성공하면, JavaScript가 접근할 수 있는 모든 정보를 탈취할 수 있습니다. **HttpOnly 쿠키**는 브라우저에게 "이 쿠키는 절대 JavaScript가 만지지 못하게 해!"라고 명령하는 것과 같으므로, 만에 하나 XSS 공격을 당하더라도 해커가 가장 중요한 **Refresh Token**을 훔쳐가는 것을 막을 수 있습니다.

### 결론

현재 우리의 API 명세는 프론트엔드의 올바른 보안 전략과 충돌하고 있었으며, 백엔드 코드를 수정하여 프론트엔드가 **HttpOnly 쿠키**를 안전하게 사용할 수 있도록 지원해야 했습니다. 이 PR은 이러한 문제점을 해결하고 보안을 강화하기 위해 진행되었습니다.

---

## 🚀 작업 내용

프론트엔드의 보안 강화 요구사항에 따라, **Refresh Token**의 전달 방식을 기존 JSON 본문에서 **HttpOnly** 속성이 적용된 쿠키로 전면 변경했습니다. 이를 통해 **XSS(Cross-Site Scripting) 공격**으로부터 Refresh Token을 안전하게 보호합니다.

주요 변경 사항은 다음과 같습니다:

1. **로그인 & 회원가입 API 응답 변경**
    - 로그인/회원가입 성공 시, 서버는 Set-Cookie 헤더를 통해 **Refresh Token**을 **HttpOnly 쿠키**로 전달합니다.
    - 클라이언트 응답 본문(JSON)에서는 **Refresh Token** 필드를 제거하고, **Access Token**만 포함하도록 수정했습니다. 이를 위해 응답 전용 DTO(Body record)를 추가했습니다.
2. **토큰 재발급 API 요청/응답 방식 변경**
    - reissue API가 Authorization 헤더 대신, 브라우저가 자동으로 전송하는 쿠키에서 **Refresh Token**을 받도록 **@CookieValue** 를 사용해 수정했습니다.
    - 재발급 성공 시, 새로 발급된 **Refresh Token** (Refresh Token Rotation) 또한 **HttpOnly 쿠키**로 갱신하여 전달합니다.
3. **전역 예외 처리 강화**
    - 필수 쿠키(refreshToken)가 요청에 포함되지 않았을 때 발생하는 **MissingRequestCookieException** 을 처리하기 위한 핸들러를 **GlobalExceptionHandler** 에 추가했습니다. 이를 통해 500 에러 대신 명확한 **400 Bad Request**를 응답합니다.
4. **테스트 코드 수정 및 보강**
    - 변경된 서비스 로직에 맞춰 AuthServiceImplTest의 단위 테스트를 수정했습니다.
    - **@WebMvcTest** 를 사용하여 AuthController의 쿠키 처리 로직을 검증하는 통합 테스트(AuthControllerTest)를 신규 작성했습니다.
5. **설정 외부화 리팩토링**
    - AuthController에 하드코딩되어 있던 Refresh Token 만료 시간을 application.yml의 jwt.refresh-token-validity-in-seconds 값을 사용하도록 리팩토링했습니다.

---

## ⏱️ 소요 시간

3h

---

## 🤔 고민했던 내용

1. 응답 DTO를 어떻게 분리할 것인가?
    
    Refresh Token을 쿠키로 옮기면서, 클라이언트에게 보내는 JSON 응답에서는 해당 필드를 제거해야 했습니다. 처음에는 기존 LoginSuccessResponseDto에서 필드를 제거하는 방안을 생각했지만, 이 경우 AuthService가 생성한 Refresh Token을 AuthController로 전달할 방법이 사라지는 문제가 있었습니다.
    
    **해결:** 서비스와 컨트롤러 간의 데이터 전달 역할은 유지하되, 최종 응답 명세만 변경하기 위해 기존 DTO 내부에 **응답 본문 전용 Body record를 중첩하여 정의**하는 방식을 채택했습니다. 이를 통해 각 계층의 책임은 명확히 유지하면서 API 명세의 일관성을 확보할 수 있었습니다.
    
2. 프레임워크 레벨 예외는 어떻게 처리해야 하는가?
    
    @CookieValue를 사용하면서, 필수 쿠키가 누락되었을 때 MissingRequestCookieException 이 발생하며 테스트가 실패하는 문제를 마주했습니다. 저희 팀의 예외 처리 컨벤션은 커스텀 예외를 던져서 처리하는 것이었지만, 이 경우에는 적용할 수 없었습니다.
    
    **이유:** 해당 예외는 저희가 작성한 컨트롤러 메소드의 코드가 실행되기 전, **Spring의 ArgumentResolver 단에서 발생하는 프레임워크 레벨 예외**이기 때문입니다. 즉, 저희 코드 내에서 try-catch로 잡아 커스텀 예외로 변환할 기회 자체가 없었습니다.
    
    **해결:** 이러한 프레임워크 레벨의 예외를 처리하는 표준적인 방법인 **@RestControllerAdvice(GlobalExceptionHandler)에 직접 핸들러를 추가**하는 방식을 채택했습니다. 이를 통해 클라이언트의 잘못된 요청에 대해 명확한 **400 Bad Request** 응답을 제공하고, 애플리케이션의 안정성을 높였습니다.
    
3. 무엇을, 어떻게 테스트해야 하는가?
    
    단순히 서비스 로직의 단위 테스트만 수정하는 것은 충분하지 않다고 판단했습니다. 이번 작업의 핵심은 HTTP 프로토콜 수준에서의 변화(쿠키, 헤더, 응답 본문)였기 때문입니다.
    
    **해결:** **MockMvc**를 사용한 **@WebMvcTest** 를 적극적으로 활용하여 AuthController에 대한 통합 테스트를 작성했습니다. 이를 통해 실제 컨트롤러가 HTTP 요청을 받았을 때, 의도한 대로 쿠키의 속성(HttpOnly, Secure등)이 올바르게 설정되는지, 응답 본문에서 민감한 정보가 잘 제거되었는지 등을 꼼꼼하게 검증할 수 있었습니다.
    

---

## 💬 리뷰 중점사항

- 변경된 인증/인가 흐름(로그인, 재발급)이 보안적인 관점에서 올바르게 구현되었는지 확인 부탁드립니다.
- AuthController에서 ResponseCookie를 생성하고 사용하는 방식이 적절한지 검토해 주세요.
- GlobalExceptionHandler에 추가된 예외 처리 로직이 다른 핸들러와 충돌 없이 잘 동작할지 확인 부탁드립니다.
- 새롭게 작성된 AuthControllerTest가 쿠키 기반 인증의 핵심적인 시나리오들을 충분히 커버하고 있는지 검토해 주세요.

---

## 🔗 관련 이슈

- Close #153

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 새로고침 토큰이 HttpOnly/Secure 쿠키로 발급·갱신됩니다.
  * 로그인·회원가입·토큰재발급 응답에 상태와 accessToken을 담은 표준화된 응답 본문이 포함됩니다 (응답 본문에서 refreshToken 노출 없음).
  * 토큰 재발급 요청이 쿠키 기반으로 처리됩니다.
  * 누락된 쿠키에 대한 400 에러 처리(명확한 오류 메시지) 추가.

* **테스트**
  * 인증 흐름(로그인·회원가입·재발급)과 쿠키 동작을 검증하는 통합/단위 테스트 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->