### PR TITLE
[ERROR] JPA - Redis Repository 충돌

### DIFF
--- a/src/main/java/com/kakaotech/team18/backend_server/global/config/RepositoryConfig.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/config/RepositoryConfig.java
@@ -1,0 +1,26 @@
+package com.kakaotech.team18.backend_server.global.config;
+
+import com.kakaotech.team18.backend_server.domain.auth.repository.RefreshTokenRepository;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+
+@Configuration
+@EnableJpaRepositories(
+        basePackages = "com.kakaotech.team18.backend_server.domain",
+        excludeFilters = @ComponentScan.Filter(
+                type = FilterType.ASSIGNABLE_TYPE,
+                classes = RefreshTokenRepository.class
+        )
+)
+@EnableRedisRepositories(
+        basePackages = "com.kakaotech.team18.backend_server.domain",
+        includeFilters = @ComponentScan.Filter(
+                type = FilterType.ASSIGNABLE_TYPE,
+                classes = RefreshTokenRepository.class
+        )
+)
+public class RepositoryConfig {
+}


### PR DESCRIPTION
## 🚀 작업 내용

프로젝트에 Spring Data JPA와 Spring Data Redis가 함께 존재하여, 애플리케이션 시작 시 각 모듈이 어떤 Repository를 관리해야 할지 명확히 구분하지 못하는 스캔 충돌 문제를 해결했습니다.

이 문제를 해결하기 위해, 기존 파일 구조를 변경하지 않으면서 각 데이터 모듈의 스캔 범위를 명시적으로 지정하는 `RepositoryConfig.java` 설정 파일을 새로 생성했습니다.

**주요 설정 내용:**

* **`@EnableJpaRepositories`**
    * `basePackages`: 기존 Repository들이 위치한 `com.kakaotech.team18.backend_server.domain` 패키지를 스캔하도록 설정합니다.
    * `excludeFilters`: 스캔 대상에서 Redis 전용 Repository인 `RefreshTokenRepository`를 명시적으로 제외하여, JPA가 이를 자신의 후보로 등록하지 않도록 합니다.

* **`@EnableRedisRepositories`**
    * `basePackages`: 동일하게 `com.kakaotech.team18.backend_server.domain` 패키지를 스캔하도록 설정합니다.
    * `includeFilters`: 스캔 대상 중 `RefreshTokenRepository`만을 명시적으로 포함하여, Redis가 오직 해당 Repository만 관리하도록 지정합니다.

이 설정을 통해 JPA와 Redis의 영역을 논리적으로 명확히 분리하여, 애플리케이션 시작 시 발생하던 다수의 경고 로그를 제거하고 안정적으로 구동되도록 보장합니다.

---

## ⏱️ 소요 시간

1h

---

## 🤔 고민했던 내용

### 1. 문제의 원인: 

배포 환경 에러 로그의 핵심은 `Multiple Spring Data modules found`와 `Could not safely identify store assignment`였습니다.

이는 프로젝트에 JPA와 Redis라는 두 데이터 모듈이 존재하는데, Spring이 `RefreshTokenRepository`는 JPA가, 나머지 모든 Repository는 Redis가 자신의 관리 대상이 아니라고 판단하며 발생하는 문제였습니다. 

### 2. 해결 전략 수립: "패키지 분리 vs. 설정으로 해결"

이 문제를 해결하기 위한 두 가지 전략을 고민했습니다.

* **전략 A (패키지 분리):**
    * `jpa`와 `redis` 패키지를 새로 만들고, 각각의 Repository를 물리적으로 분리하는 방법입니다.
    * **장점:** 아키텍처가 명확해지고 확장성이 좋습니다.

* **전략 B (설정으로 해결):**
    * 현재 파일 구조를 그대로 유지한 채, `@Enable...Repositories`의 `includeFilters` / `excludeFilters` 필터를 사용하여 논리적으로만 분리하는 방법입니다.

**최종 선택 (전략 B) 및 이유:**

* 현재 우리 프로젝트에는 Redis를 사용하는 Repository가 **`RefreshTokenRepository` 단 하나**뿐입니다.
* 이 하나의 파일을 위해 모든 JPA Repository의 위치를 변경하는 것은 과한 작업(over-engineering)이라고 판단했습니다.
* 따라서 현재 구조를 최대한 유지하면서 문제를 해결하기 위해 **전략 B를 채택**했습니다. 이 방법은 파일 구조 변경을 최소화하면서도, 설정 파일을 통해 명확하게 각 모듈의 책임을 분리하여 문제를 해결할 수 있는 가장 효율적인 접근법이었습니다.
* *(참고) 만약 향후 Redis Repository가 더 늘어난다면, 그때는 장기적인 유지보수성을 위해 '전략 A' (패키지 분리)로 리팩토링하는 것을 고려해볼 수 있습니다.*

---

## 💬 리뷰 중점사항

* `RepositoryConfig.java` 파일의 설정이 올바른지 확인 부탁드립니다.
    * `basePackages` 경로가 정확한지
    * `includeFilters`와 `excludeFilters`가 `RefreshTokenRepository`를 올바르게 타겟팅하고 있는지
* 이 설정으로 인해 다른 Repository들이 영향을 받지 않는지, 의도치 않은 사이드 이펙트는 없는지 검토해 주세요.
* 애플리케이션 시작 시, 기존에 발생하던 `Could not safely identify store assignment` 경고 로그들이 모두 사라졌는지 확인이 필요합니다.

---

## 🔗 관련 이슈

* Close #162 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 백엔드 데이터 저장소 관리 구조 최적화 완료

---

**단어 수: 15자** (추가 정보 제공 필요 시 알려주세요)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->