### PR TITLE
[REFACTOR] EXPIRED_JWT_TOKEN 분리

### DIFF
--- a/src/main/java/com/kakaotech/team18/backend_server/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/auth/service/AuthServiceImpl.java
@@ -18,6 +18,7 @@ import com.kakaotech.team18.backend_server.domain.user.repository.UserRepository
 import com.kakaotech.team18.backend_server.global.exception.code.ErrorCode;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.CustomException;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.DuplicateKakaoIdException;
+import com.kakaotech.team18.backend_server.global.exception.exceptions.ExpiredRefreshTokenException;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.LoggedOutUserException;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.InvalidRefreshTokenException;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.KakaoApiTimeoutException;
@@ -200,7 +201,7 @@ public class AuthServiceImpl implements AuthService {
             claims = jwtProvider.verify(refreshToken);
         } catch (ExpiredJwtException e) {
             // Refresh Token이 만료된 경우, 새로운 에러 코드로 예외 발생
-            throw new CustomException(ErrorCode.EXPIRED_REFRESH_TOKEN);
+            throw new ExpiredRefreshTokenException();
         }
 
         // 2. 토큰 타입 검증

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/auth/service/AuthServiceImpl.java
@@ -15,6 +15,8 @@ import com.kakaotech.team18.backend_server.domain.clubMember.entity.Role;
 import com.kakaotech.team18.backend_server.domain.clubMember.repository.ClubMemberRepository;
 import com.kakaotech.team18.backend_server.domain.user.entity.User;
 import com.kakaotech.team18.backend_server.domain.user.repository.UserRepository;
+import com.kakaotech.team18.backend_server.global.exception.code.ErrorCode;
+import com.kakaotech.team18.backend_server.global.exception.exceptions.CustomException;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.DuplicateKakaoIdException;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.LoggedOutUserException;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.InvalidRefreshTokenException;
@@ -25,6 +27,7 @@ import com.kakaotech.team18.backend_server.global.exception.exceptions.UserNotFo
 import com.kakaotech.team18.backend_server.global.security.JwtProperties;
 import com.kakaotech.team18.backend_server.global.security.JwtProvider;
 import com.kakaotech.team18.backend_server.global.security.TokenType;
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Claims;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -191,7 +194,14 @@ public class AuthServiceImpl implements AuthService {
     @Transactional
     public ReissueResponseDto reissue(String refreshToken) {
         // 1. Refresh Token 자체 유효성 검증 (만료, 서명 등)
-        Claims claims = jwtProvider.verify(refreshToken);
+        // Refresh Token은 HttpOnly 쿠키 등으로 전달되어 이미 순수한 토큰 문자열로 가정합니다.
+        Claims claims;
+        try {
+            claims = jwtProvider.verify(refreshToken);
+        } catch (ExpiredJwtException e) {
+            // Refresh Token이 만료된 경우, 새로운 에러 코드로 예외 발생
+            throw new CustomException(ErrorCode.EXPIRED_REFRESH_TOKEN);
+        }
 
         // 2. 토큰 타입 검증
         String tokenType = claims.get("tokenType", String.class);

--- a/src/main/java/com/kakaotech/team18/backend_server/global/config/SecurityConfig.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/config/SecurityConfig.java
@@ -43,8 +43,7 @@ public class SecurityConfig {
      */
     @Bean
     public WebSecurityCustomizer webSecurityCustomizer() {
-        return (web) -> web.ignoring()
-                .requestMatchers("/h2-console/**", "/api/auth/**", "/swagger-ui.html", "/v3/api-docs/**", "/swagger-ui/**");
+        return (web) -> web.ignoring().requestMatchers("/h2-console/**", "/swagger-ui.html", "/v3/api-docs/**", "/swagger-ui/**");
     }
 
     @Bean

--- a/src/main/java/com/kakaotech/team18/backend_server/global/config/SecurityConfig.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/config/SecurityConfig.java
@@ -13,6 +13,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer.FrameOptionsConfig;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
@@ -39,12 +40,11 @@ public class SecurityConfig {
 
     /**
      * 정적 리소스나 인증이 전혀 필요 없는 경로들을 Spring Security 필터 체인에서 제외합니다.
-     * 이 설정은 filterChain(HttpSecurity http) 보다 우선적으로 적용됩니다.
      */
     @Bean
     public WebSecurityCustomizer webSecurityCustomizer() {
         return (web) -> web.ignoring()
-                .requestMatchers("/api/auth/**", "/swagger-ui.html", "/v3/api-docs/**", "/swagger-ui/**");
+                .requestMatchers("/h2-console/**", "/api/auth/**", "/swagger-ui.html", "/v3/api-docs/**", "/swagger-ui/**");
     }
 
     @Bean
@@ -52,6 +52,8 @@ public class SecurityConfig {
         http.csrf(csrf -> csrf.disable());
         http.formLogin(formLogin -> formLogin.disable());
         http.httpBasic(httpBasic -> httpBasic.disable());
+
+        http.headers(headers -> headers.frameOptions(FrameOptionsConfig::disable));
 
         http.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
 

--- a/src/main/java/com/kakaotech/team18/backend_server/global/exception/code/ErrorCode.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/exception/code/ErrorCode.java
@@ -35,7 +35,8 @@ public enum ErrorCode {
 
     // 401 UNAUTHORIZED: 인증되지 않은 사용자
     UNAUTHENTICATED_USER("인증되지 않은 사용자입니다.", HttpStatus.UNAUTHORIZED),
-    EXPIRED_JWT_TOKEN("만료된 토큰입니다.", HttpStatus.UNAUTHORIZED),
+    EXPIRED_ACCESS_TOKEN("만료된 Access Token입니다.", HttpStatus.UNAUTHORIZED),
+    EXPIRED_REFRESH_TOKEN("만료된 Refresh Token입니다. 다시 로그인해주세요.", HttpStatus.UNAUTHORIZED),
     MALFORMED_JWT("잘못된 형식의 토큰입니다.", HttpStatus.UNAUTHORIZED),
     INVALID_JWT_SIGNATURE("토큰의 서명이 유효하지 않습니다.", HttpStatus.UNAUTHORIZED),
     UNSUPPORTED_JWT("지원하지 않는 형식의 토큰입니다.", HttpStatus.UNAUTHORIZED),

--- a/src/main/java/com/kakaotech/team18/backend_server/global/exception/exceptions/ExpiredRefreshTokenException.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/exception/exceptions/ExpiredRefreshTokenException.java
@@ -1,0 +1,10 @@
+package com.kakaotech.team18.backend_server.global.exception.exceptions;
+
+import com.kakaotech.team18.backend_server.global.exception.code.ErrorCode;
+
+public class ExpiredRefreshTokenException extends CustomException {
+
+    public ExpiredRefreshTokenException() {
+        super(ErrorCode.EXPIRED_REFRESH_TOKEN);
+    }
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/security/JwtAuthenticationFilter.java
@@ -38,6 +38,13 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
 
+        // 요청 URI를 확인하여 /api/auth/** 경로의 요청은 필터를 그냥 통과시킨다.
+        String requestURI = request.getRequestURI();
+        if (requestURI.startsWith("/api/auth/")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
         // 1. 헤더에서 "Authorization" 값을 가져온다.
         String bearerToken = request.getHeader("Authorization");
 

--- a/src/main/java/com/kakaotech/team18/backend_server/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/security/JwtAuthenticationFilter.java
@@ -88,7 +88,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             resolver.resolveException(request, response, null, new InvalidJwtException(ErrorCode.MALFORMED_JWT));
             return;
         } catch (ExpiredJwtException e) {
-            resolver.resolveException(request, response, null, new InvalidJwtException(ErrorCode.EXPIRED_JWT_TOKEN));
+            resolver.resolveException(request, response, null, new InvalidJwtException(ErrorCode.EXPIRED_ACCESS_TOKEN));
             return;
         } catch (UnsupportedJwtException e) {
             resolver.resolveException(request, response, null, new InvalidJwtException(ErrorCode.UNSUPPORTED_JWT));

--- a/src/main/java/com/kakaotech/team18/backend_server/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/security/JwtAuthenticationFilter.java
@@ -11,19 +11,16 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.web.servlet.HandlerExceptionResolver;
 
 import java.io.IOException;
 
-@Component
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtProvider jwtProvider;

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/application/controller/ApplicationControllerTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/application/controller/ApplicationControllerTest.java
@@ -185,7 +185,7 @@ class ApplicationControllerTest {
           "email":"stud@example.com",
           "name":"홍길동",
           "studentId":"202312",
-          "phoneNumber":"01000000000",
+          "phoneNumber":"010-0000-0000",
           "department":"컴퓨터공학과",
           "answers": [
           {"questionNum":0,"question":"q","answer":"자기소개입니다"},
@@ -218,7 +218,7 @@ class ApplicationControllerTest {
           "email":"tester@email.com",
           "name":"김@@",
           "studentId":"@@@1@",
-          "phoneNumber":"01012345678",
+          "phoneNumber":"010-1234-5678",
           "department":"소프트웨어공학과",
           "answers": [
           {"questionNum":0,"question":"q","answer":"자기소개입니다"},

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/auth/controller/AuthControllerTest.java
@@ -8,6 +8,8 @@ import com.kakaotech.team18.backend_server.domain.auth.dto.RegisterRequestDto;
 import com.kakaotech.team18.backend_server.domain.auth.dto.RegistrationRequiredResponseDto;
 import com.kakaotech.team18.backend_server.domain.auth.dto.ReissueResponseDto;
 import com.kakaotech.team18.backend_server.domain.auth.service.AuthService;
+import com.kakaotech.team18.backend_server.global.exception.code.ErrorCode;
+import com.kakaotech.team18.backend_server.global.exception.exceptions.CustomException;
 import com.kakaotech.team18.backend_server.global.config.SecurityConfig;
 import com.kakaotech.team18.backend_server.global.config.TestSecurityConfig;
 import com.kakaotech.team18.backend_server.global.security.JwtAuthenticationFilter;
@@ -116,7 +118,7 @@ class AuthControllerTest {
         String accessToken = "newAccessToken";
         String refreshToken = "newRefreshToken";
         RegisterRequestDto requestDto = new RegisterRequestDto(
-                "testUser", "test@example.com", "123456", "컴퓨터공학과", "01012345678"
+                "testUser", "test@example.com", "123456", "컴퓨터공학과", "010-1234-5678"
         );
 
         LoginSuccessResponseDto serviceResponse = new LoginSuccessResponseDto(AuthStatus.REGISTER_SUCCESS, accessToken, refreshToken, List.of());
@@ -169,5 +171,22 @@ class AuthControllerTest {
         // when & then
         mockMvc.perform(post("/api/auth/reissue")) // 쿠키 없이 요청
                 .andExpect(status().isBadRequest()); // @CookieValue는 쿠키가 없으면 400 Bad Request 반환
+    }
+
+    @DisplayName("Access Token 재발급 실패 - Refresh Token 만료")
+    @Test
+    void reissue_fail_expiredRefreshToken() throws Exception {
+        // given
+        String expiredRefreshToken = "expiredMockRefreshToken";
+        // authService.reissue가 CustomException(EXPIRED_REFRESH_TOKEN)을 던지도록 설정
+        given(authService.reissue(expiredRefreshToken))
+                .willThrow(new CustomException(ErrorCode.EXPIRED_REFRESH_TOKEN));
+
+
+        // when & then
+        mockMvc.perform(post("/api/auth/reissue")
+                        .cookie(new Cookie("refreshToken", expiredRefreshToken)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error_code").value("EXPIRED_REFRESH_TOKEN"));
     }
 }

--- a/src/test/java/com/kakaotech/team18/backend_server/global/security/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/global/security/JwtAuthenticationFilterTest.java
@@ -81,7 +81,7 @@ class JwtAuthenticationFilterTest {
         // then
         resultActions
                 .andExpect(status().isUnauthorized())
-                .andExpect(jsonPath("$.message").value(ErrorCode.EXPIRED_JWT_TOKEN.getMessage()))
+                .andExpect(jsonPath("$.message").value(ErrorCode.EXPIRED_ACCESS_TOKEN.getMessage()))
                 .andDo(print());
     }
 


### PR DESCRIPTION
## 🚀 작업 내용

프론트엔드 개발자의 요청에 따라, 클라이언트에서 인증 상태를 더 명확하게 처리할 수 있도록 토큰 만료 관련 에러 응답을 세분화했습니다.

- **에러 코드 분리 및 명확화**
    - 기존의 범용적인 **EXPIRED_JWT_TOKEN** 에러 코드를 폐기했습니다.
    - Access Token 만료 시에는 **EXPIRED_ACCESS_TOKEN**을, Refresh Token 만료 시에는 **EXPIRED_REFRESH_TOKEN**을 반환하도록 **ErrorCode Enum**을 수정했습니다.
- **Refresh Token 만료 처리 로직 수정 (AuthServiceImpl)**
    - 토큰 재발급(reissue) 로직 내에서 Refresh Token이 만료되었을 때 발생하는 **ExpiredJwtException**을 **try-catch**로 잡아, **CustomException(ErrorCode.EXPIRED_REFRESH_TOKEN)**을 던지도록 수정했습니다.
- **Access Token 만료 처리 로직 수정 (JwtAuthenticationFilter)**
    - 모든 API 요청의 진입점인 **JwtAuthenticationFilter**에서 Access Token 만료 시 **EXPIRED_ACCESS_TOKEN** 에러 코드를 반환하도록 수정했습니다.
- **테스트 코드 추가 및 수정**
    - **AuthControllerTest**: Refresh Token이 만료되었을 때, 재발급 API가 의도한 대로 401 Unauthorized 상태와 **EXPIRED_REFRESH_TOKEN** 에러 코드를 반환하는지 검증하는 테스트 케이스를 추가했습니다.
    - **JwtAuthenticationFilterTest**: Access Token 만료 시 반환되는 에러 메시지가 새로운 에러 코드의 메시지와 일치하도록 테스트 검증 로직을 수정했습니다.

추가로 reissue 재발급 로직이 무한루프가 도는 문제를 해결하기 위해 
JwtAuthenticationFilter 이중 등록을 제거하고 
WebSecurityCustomizer ignoring()을 사용했습니다.

---

## ⏱️ 소요 시간

2h

---

## 🤔 고민했던 내용

1. **문제의 시작: 프론트엔드의 요청**
    - 처음에는 Access Token과 Refresh Token이 만료되었을 때 모두 동일한 **EXPIRED_JWT_TOKEN** 에러 코드를 반환하고 있었습니다.
    - 이로 인해 프론트엔드에서는 두 가지 상황을 구분할 수 없어, 다음과 같은 후속 처리에 어려움이 있었습니다.
        - **Access Token 만료:** Refresh Token을 이용해 Access Token 재발급을 요청해야 함.
        - **Refresh Token 만료:** 세션이 완전히 끝났으므로, 사용자를 로그인 페이지로 보내야 함.
    - 이 두 시나리오의 클라이언트 처리 방식이 완전히 다르기 때문에, 서버에서 내려주는 에러 코드를 분리하는 것이 필수적이었습니다.
2. **예외의 명확한 분리와 중앙 관리**
    1. **1단계: 에러 코드부터 명확하게 정의**
        - 가장 먼저 **ErrorCode Enum**에 **EXPIRED_ACCESS_TOKEN**과 **EXPIRED_REFRESH_TOKEN**을 명시적으로 정의했습니다. 
    2. **2단계: 각 토큰이 만료되는 '장소'에서 예외를 처리**
        - **Access Token:** 거의 모든 인증이 필요한 API 요청의 가장 앞단인 **JwtAuthenticationFilter**에서 검증됩니다. 따라서 이 필터에서 만료 예외가 발생했을 때 **EXPIRED_ACCESS_TOKEN**을 반환하도록 수정하는 것이 가장 적절하다고 판단했습니다.
        - **Refresh Token:** 오직 토큰 재발급(reissue) 로직에서만 사용됩니다. 따라서 **AuthServiceImpl**의 **reissue** 메소드 내부에서 만료 예외를 처리하는 것이 책임과 역할 분리에 가장 적합하다고 판단했습니다. **try-catch**를 사용해 jjwt 라이브러리가 던지는 **ExpiredJwtException**을 정의된 **CustomException**으로 '전환'하여, 비즈니스에 더 가까운 예외를 던지도록 구현했습니다.
    3. **3단계: 변경 사항을 보장하는 테스트를 작성**
        - 새로 추가된 Refresh Token 만료 시나리오에 대한 컨트롤러 테스트(**AuthControllerTest**)를 작성하여, 실제 API 호출 시 의도한 JSON 응답이 반환되는지 전체 흐름을 검증했습니다. 이를 통해 향후 리팩토링 시에도 해당 기능이 깨지지 않음을 보장할 수 있습니다.

---

## 💬 리뷰 중점사항

- **AuthServiceImpl**의 **reissue** 메소드에서 **try-catch**를 사용하여 예외를 전환하는 방식이 적절한지 확인 부탁드립니다. Refresh Token 만료라는 비즈니스 상황을 서비스 계층에서 명확히 표현하기 위한 선택이었습니다.
- **JwtAuthenticationFilter**에서 Access Token 만료를 처리하고, **AuthServiceImpl**에서 Refresh Token 만료를 처리하는 역할 분리가 명확하게 이루어졌는지 검토 부탁드립니다.
- 새로 추가된 **reissue_fail_expiredRefreshToken** 테스트 케이스가 Refresh Token 만료 시나리오를 충분히 잘 검증하고 있는지 확인 부탁드립니다.

---

## 🔗 관련 이슈

- Close #172

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 만료된 토큰 처리 분리: Access/Refresh 토큰 만료 상황에 대해 구체적인 오류 코드 및 메시지로 응답
  * 리프레시 토큰 만료 시 재로그인 안내 반환

* **보안/인증**
  * 재발급 엔드포인트 재요청 시 인증 필터 우회 처리 추가
  * 만료 토큰 예외 매핑과 JWT 필터 통합 로직 개선

* **테스트**
  * 테스트 및 API 입력에서 전화번호 형식을 하이픈 표준으로 통일
<!-- end of auto-generated comment: release notes by coderabbit.ai -->