### PR TITLE
[REFACTOR] 지원폼 등록/수정 DTO 모집 일정 필드 수정 (#156)

### DIFF
--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/dto/ClubApplyFormRequestDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/dto/ClubApplyFormRequestDto.java
@@ -8,10 +8,14 @@ import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
-import java.time.LocalDateTime;
 import jakarta.validation.constraints.Size;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Schema(description = "지원서 양식 등록 정보")
 public record ClubApplyFormRequestDto(
         @Schema(description = "지원서 제목", example = "카태켐 12기 지원서")
@@ -24,13 +28,9 @@ public record ClubApplyFormRequestDto(
         @Size(max = 100, message = "설명은 100자 이내로 입력해주세요.")
         String description,
 
-        @Schema(description = "모집 시작일")
-        @NotNull(message = "모집 시작일은 필수입니다.")
-        LocalDateTime recruitStart,
-
-        @Schema(description = "모집 마감일")
-        @NotNull(message = "모집 마감일은 필수입니다.")
-        LocalDateTime recruitEnd,
+        @Schema(description = "모집 일정", example = "2025-03-01 ~ 2025-03-31")
+        @NotNull(message = "모집 일정은 필수입니다.")
+        String recruitDate,
 
         @Schema(description = "질문 목록")
         @NotEmpty(message = "질문 목록은 최소 1개 이상이어야 합니다.")
@@ -41,6 +41,27 @@ public record ClubApplyFormRequestDto(
         @JsonIgnore
         @Schema(hidden = true)
         public boolean isRecruitPeriodValid() {
-                return recruitStart == null || recruitEnd == null || !recruitEnd.isBefore(recruitStart);
+                try {
+                        // 공백 제거 후 "~" 기준으로 split
+                        String[] recruitDates = recruitDate.replaceAll("\\s+", "").split("~");
+
+                        // 날짜 형식 지정 (yyyy-MM-dd)
+                        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+                        // 문자열 → LocalDate 변환
+                        LocalDate startDate = LocalDate.parse(recruitDates[0], formatter);
+                        LocalDate endDate = LocalDate.parse(recruitDates[1], formatter);
+
+                        // LocalDateTime 변환 (하루 시작/끝 기준)
+                        LocalDateTime recruitStart = startDate.atStartOfDay();
+                        LocalDateTime recruitEnd = endDate.atTime(23, 59, 59);
+
+                        // 검증 로직: 마감일이 시작일보다 같거나 이후여야 함
+                        return !recruitEnd.isBefore(recruitStart);
+                } catch (Exception e) {
+                        // 파싱 실패 시 false 반환 (유효하지 않은 입력)
+                        log.warn("Invalid recruitDate format: '{}'", recruitDate, e);
+                        return false;
+                }
         }
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/dto/ClubApplyFormRequestDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/dto/ClubApplyFormRequestDto.java
@@ -7,7 +7,6 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -29,7 +28,7 @@ public record ClubApplyFormRequestDto(
         String description,
 
         @Schema(description = "모집 일정", example = "2025-03-01 ~ 2025-03-31")
-        @NotNull(message = "모집 일정은 필수입니다.")
+        @NotBlank(message = "모집 일정은 필수입니다.")
         String recruitDate,
 
         @Schema(description = "질문 목록")

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/dto/ClubApplyFormUpdateDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/dto/ClubApplyFormUpdateDto.java
@@ -8,10 +8,14 @@ import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import jakarta.validation.constraints.Size;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Schema(description = "지원서 양식 수정 정보")
 public record ClubApplyFormUpdateDto(
         @Schema(description = "지원서 제목", example = "카태켐 12기 지원서")
@@ -24,13 +28,9 @@ public record ClubApplyFormUpdateDto(
         @Size(max = 100, message = "설명은 100자 이내로 입력해주세요.")
         String description,
 
-        @Schema(description = "모집 시작일")
-        @NotNull(message = "모집 시작일은 필수입니다.")
-        LocalDateTime recruitStart,
-
-        @Schema(description = "모집 마감일")
-        @NotNull(message = "모집 마감일은 필수입니다.")
-        LocalDateTime recruitEnd,
+        @Schema(description = "모집 일정", example = "2025-03-01 ~ 2025-03-31")
+        @NotNull(message = "모집 일정은 필수입니다.")
+        String recruitDate,
 
         @Schema(description = "질문 목록")
         @NotEmpty(message = "질문 목록은 최소 1개 이상이어야 합니다.")
@@ -41,6 +41,27 @@ public record ClubApplyFormUpdateDto(
         @JsonIgnore
         @Schema(hidden = true)
         public boolean isRecruitPeriodValid() {
-                return recruitStart == null || recruitEnd == null || !recruitEnd.isBefore(recruitStart);
+                try {
+                        // 공백 제거 후 "~" 기준으로 split
+                        String[] recruitDates = recruitDate.replaceAll("\\s+", "").split("~");
+
+                        // 날짜 형식 지정 (yyyy-MM-dd)
+                        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+                        // 문자열 → LocalDate 변환
+                        LocalDate startDate = LocalDate.parse(recruitDates[0], formatter);
+                        LocalDate endDate = LocalDate.parse(recruitDates[1], formatter);
+
+                        // LocalDateTime 변환 (하루 시작/끝 기준)
+                        LocalDateTime recruitStart = startDate.atStartOfDay();
+                        LocalDateTime recruitEnd = endDate.atTime(23, 59, 59);
+
+                        // 검증 로직: 마감일이 시작일보다 같거나 이후여야 함
+                        return !recruitEnd.isBefore(recruitStart);
+                } catch (Exception e) {
+                        // 파싱 실패 시 false 반환 (유효하지 않은 입력)
+                        log.warn("Invalid recruitDate format: '{}'", recruitDate, e);
+                        return false;
+                }
         }
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/dto/ClubApplyFormUpdateDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/dto/ClubApplyFormUpdateDto.java
@@ -7,10 +7,9 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import jakarta.validation.constraints.Size;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
@@ -29,7 +28,7 @@ public record ClubApplyFormUpdateDto(
         String description,
 
         @Schema(description = "모집 일정", example = "2025-03-01 ~ 2025-03-31")
-        @NotNull(message = "모집 일정은 필수입니다.")
+        @NotBlank(message = "모집 일정은 필수입니다.")
         String recruitDate,
 
         @Schema(description = "질문 목록")

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/formQuestion/dto/TimeSlotOptionRequestDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/formQuestion/dto/TimeSlotOptionRequestDto.java
@@ -3,14 +3,13 @@ package com.kakaotech.team18.backend_server.domain.formQuestion.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-import java.time.LocalDate;
 import java.time.LocalTime;
 
 @Schema(description = "동아리의 면접 가능 날짜")
 public record TimeSlotOptionRequestDto(
-        @Schema(description = "면접 날짜", example = "2025-09-24")
+        @Schema(description = "면접 날짜", example = "2025-09-24 ~ 2025-09-25")
         @NotNull(message = "면접 날짜는 필수 입니다.")
-        LocalDate date,
+        String date,
 
         @Schema(description = "가능한 면접 시간")
         @Valid

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/formQuestion/entity/TimeSlotOption.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/formQuestion/entity/TimeSlotOption.java
@@ -3,12 +3,11 @@ package com.kakaotech.team18.backend_server.domain.formQuestion.entity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.Embedded;
-import java.time.LocalDate;
 import java.time.LocalTime;
 
 @Embeddable
 public record TimeSlotOption(
-        LocalDate date,
+        String date,
         @Embedded
         TimeRange availableTime
 ) {

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/application/controller/ApplicationControllerTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/application/controller/ApplicationControllerTest.java
@@ -185,7 +185,7 @@ class ApplicationControllerTest {
           "email":"stud@example.com",
           "name":"홍길동",
           "studentId":"202312",
-          "phoneNumber":"01000000000",
+          "phoneNumber":"010-0000-0000",
           "department":"컴퓨터공학과",
           "answers": [
           {"questionNum":0,"question":"q","answer":"자기소개입니다"},
@@ -218,7 +218,7 @@ class ApplicationControllerTest {
           "email":"tester@email.com",
           "name":"김@@",
           "studentId":"@@@1@",
-          "phoneNumber":"01012345678",
+          "phoneNumber":"010-1234-5678",
           "department":"소프트웨어공학과",
           "answers": [
           {"questionNum":0,"question":"q","answer":"자기소개입니다"},

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/auth/controller/AuthControllerTest.java
@@ -116,7 +116,7 @@ class AuthControllerTest {
         String accessToken = "newAccessToken";
         String refreshToken = "newRefreshToken";
         RegisterRequestDto requestDto = new RegisterRequestDto(
-                "testUser", "test@example.com", "123456", "컴퓨터공학과", "01012345678"
+                "testUser", "test@example.com", "123456", "컴퓨터공학과", "010-1234-5678"
         );
 
         LoginSuccessResponseDto serviceResponse = new LoginSuccessResponseDto(AuthStatus.REGISTER_SUCCESS, accessToken, refreshToken, List.of());

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/controller/ClubApplyFormControllerTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/controller/ClubApplyFormControllerTest.java
@@ -14,19 +14,19 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.kakaotech.team18.backend_server.domain.formQuestion.dto.FormQuestionRequestDto;
-import com.kakaotech.team18.backend_server.domain.formQuestion.dto.FormQuestionResponseDto;
-import com.kakaotech.team18.backend_server.domain.formQuestion.dto.FormQuestionUpdateDto;
-import com.kakaotech.team18.backend_server.domain.formQuestion.entity.FieldType;
 import com.kakaotech.team18.backend_server.domain.clubApplyForm.dto.ClubApplyFormRequestDto;
 import com.kakaotech.team18.backend_server.domain.clubApplyForm.dto.ClubApplyFormResponseDto;
 import com.kakaotech.team18.backend_server.domain.clubApplyForm.dto.ClubApplyFormUpdateDto;
 import com.kakaotech.team18.backend_server.domain.clubApplyForm.service.ClubApplyFormService;
+import com.kakaotech.team18.backend_server.domain.formQuestion.dto.FormQuestionRequestDto;
+import com.kakaotech.team18.backend_server.domain.formQuestion.dto.FormQuestionResponseDto;
+import com.kakaotech.team18.backend_server.domain.formQuestion.dto.FormQuestionUpdateDto;
+import com.kakaotech.team18.backend_server.domain.formQuestion.entity.FieldType;
 import com.kakaotech.team18.backend_server.global.config.SecurityConfig;
 import com.kakaotech.team18.backend_server.global.config.TestSecurityConfig;
-import com.kakaotech.team18.backend_server.global.security.JwtAuthenticationFilter;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.ClubApplyFormNotFoundException;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.ClubNotFoundException;
+import com.kakaotech.team18.backend_server.global.security.JwtAuthenticationFilter;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -153,8 +153,7 @@ class ClubApplyFormControllerTest {
         ClubApplyFormRequestDto clubApplyFormRequestDto = new ClubApplyFormRequestDto(
                 "테스트 지원서",
                 "테스트 설명",
-                LocalDateTime.of(2025, 10, 1, 0, 0),
-                LocalDateTime.of(2025, 10, 31, 23, 59),
+                "2025-10-01 ~ 2025-10-31",
                 List.of(new FormQuestionRequestDto("질문 1", FieldType.TEXT, true, 1L, null, null))
                 );
 
@@ -180,8 +179,7 @@ class ClubApplyFormControllerTest {
         ClubApplyFormRequestDto clubApplyFormRequestDto = new ClubApplyFormRequestDto(
                 "테스트 지원서",
                 "테스트 설명",
-                LocalDateTime.of(2025, 10, 1, 0, 0),
-                LocalDateTime.of(2025, 10, 31, 23, 59),
+                "2025-10-01 ~ 2025-10-31",
                 List.of(new FormQuestionRequestDto("질문 1", FieldType.TEXT, true, 1L, null, null))
         );
 
@@ -205,8 +203,7 @@ class ClubApplyFormControllerTest {
         Long clubId = 1L;
         // question 필드가 blank인 경우
         ClubApplyFormRequestDto clubApplyFormRequestDto = new ClubApplyFormRequestDto("테스트 지원서", "테스트 설명",
-                LocalDateTime.of(2025, 10, 1, 0, 0),
-                LocalDateTime.of(2025, 10, 31, 23, 59),
+                "2025-10-01 ~ 2025-10-31",
                 List.of(new FormQuestionRequestDto("", FieldType.TEXT, true, 1L, null, null)));
 
         //when & then
@@ -228,8 +225,7 @@ class ClubApplyFormControllerTest {
         ClubApplyFormRequestDto invalidRequestDto = new ClubApplyFormRequestDto(
                 "테스트 지원서",
                 "설명",
-                LocalDateTime.of(2025, 10, 1, 0, 0),
-                LocalDateTime.of(2025, 10, 31, 23, 59),
+                "2025-10-01 ~ 2025-10-31",
                 List.of(new FormQuestionRequestDto("면접 가능한 시간대를 선택해 주세요.", FieldType.TIME_SLOT, true, 1L, null, null))
         );
 
@@ -249,8 +245,7 @@ class ClubApplyFormControllerTest {
         ClubApplyFormRequestDto invalidRequestDto = new ClubApplyFormRequestDto(
                 "테스트 지원서",
                 "설명",
-                LocalDateTime.of(2025, 10, 31, 0, 0),
-                LocalDateTime.of(2025, 10, 1, 23, 59),
+                "2025-10-31 ~ 2025-10-01",
                 List.of(new FormQuestionRequestDto("면접 가능한 시간대를 선택해 주세요.", FieldType.TEXT, true, 1L, null, null))
         );
 
@@ -270,8 +265,7 @@ class ClubApplyFormControllerTest {
         ClubApplyFormRequestDto invalidRequestDto = new ClubApplyFormRequestDto(
                 "테스트 지원서",
                 "설명",
-                LocalDateTime.of(2025, 10, 1, 0, 0),
-                LocalDateTime.of(2025, 10, 31, 23, 59),
+                "2025-10-01 ~ 2025-10-31",
                 List.of(new FormQuestionRequestDto("성별을 선택해 주세요.", FieldType.RADIO, true, 1L, null, null))
         );
 
@@ -291,8 +285,7 @@ class ClubApplyFormControllerTest {
         ClubApplyFormRequestDto invalidRequestDto = new ClubApplyFormRequestDto(
                 "", // Blank title
                 "설명",
-                LocalDateTime.of(2025, 10, 1, 0, 0),
-                LocalDateTime.of(2025, 10, 31, 23, 59),
+                "2025-10-01 ~ 2025-10-31",
                 List.of(new FormQuestionRequestDto("질문", FieldType.TEXT, true, 1L, null, null))
         );
 
@@ -312,8 +305,7 @@ class ClubApplyFormControllerTest {
         ClubApplyFormRequestDto invalidRequestDto = new ClubApplyFormRequestDto(
                 "제목",
                 "", // Blank description
-                LocalDateTime.of(2025, 10, 1, 0, 0),
-                LocalDateTime.of(2025, 10, 31, 23, 59),
+                "2025-10-01 ~ 2025-10-31",
                 List.of(new FormQuestionRequestDto("질문", FieldType.TEXT, true, 1L, null, null))
         );
 
@@ -334,8 +326,7 @@ class ClubApplyFormControllerTest {
         ClubApplyFormRequestDto invalidRequestDto = new ClubApplyFormRequestDto(
                 longTitle,
                 "설명",
-                LocalDateTime.of(2025, 10, 1, 0, 0),
-                LocalDateTime.of(2025, 10, 31, 23, 59),
+                "2025-10-01 ~ 2025-10-31",
                 List.of(new FormQuestionRequestDto("질문", FieldType.TEXT, true, 1L, null, null))
         );
 
@@ -356,8 +347,7 @@ class ClubApplyFormControllerTest {
         ClubApplyFormRequestDto invalidRequestDto = new ClubApplyFormRequestDto(
                 "제목",
                 longDescription,
-                LocalDateTime.of(2025, 10, 1, 0, 0),
-                LocalDateTime.of(2025, 10, 31, 23, 59),
+                "2025-10-01 ~ 2025-10-31",
                 List.of(new FormQuestionRequestDto("질문", FieldType.TEXT, true, 1L, null, null))
         );
 
@@ -377,8 +367,7 @@ class ClubApplyFormControllerTest {
         ClubApplyFormRequestDto invalidRequestDto = new ClubApplyFormRequestDto(
                 "제목",
                 "설명",
-                LocalDateTime.of(2025, 10, 1, 0, 0),
-                LocalDateTime.of(2025, 10, 31, 23, 59),
+                "2025-10-01 ~ 2025-10-31",
                 List.of(new FormQuestionRequestDto("", FieldType.TEXT, true, 1L, null, null)) // Blank question
         );
 
@@ -399,8 +388,7 @@ class ClubApplyFormControllerTest {
         ClubApplyFormRequestDto invalidRequestDto = new ClubApplyFormRequestDto(
                 "제목",
                 "설명",
-                LocalDateTime.of(2025, 10, 1, 0, 0),
-                LocalDateTime.of(2025, 10, 31, 23, 59),
+                "2025-10-01 ~ 2025-10-31",
                 List.of(new FormQuestionRequestDto(longQuestion, FieldType.TEXT, true, 1L, null, null))
         );
 
@@ -421,8 +409,7 @@ class ClubApplyFormControllerTest {
         ClubApplyFormUpdateDto clubApplyFormUpdateDto = new ClubApplyFormUpdateDto(
                 "테스트 지원서",
                 "테스트 설명",
-                LocalDateTime.of(2025, 10, 1, 0, 0),
-                LocalDateTime.of(2025, 10, 31, 23, 59),
+                "2025-10-01 ~ 2025-10-31",
                 List.of(new FormQuestionUpdateDto(1L, "질문 1", FieldType.TEXT, true, 1L, null, null)
                 ));
 
@@ -447,8 +434,7 @@ class ClubApplyFormControllerTest {
         ClubApplyFormUpdateDto clubApplyFormUpdateDto = new ClubApplyFormUpdateDto(
                 "테스트 지원서",
                 "테스트 설명",
-                LocalDateTime.of(2025, 10, 1, 0, 0),
-                LocalDateTime.of(2025, 10, 31, 23, 59),
+                "2025-10-01 ~ 2025-10-31",
                 List.of(new FormQuestionUpdateDto(1L, "질문 1", FieldType.TEXT, true, 1L, null, null)
                 ));
 
@@ -474,8 +460,7 @@ class ClubApplyFormControllerTest {
         ClubApplyFormUpdateDto clubApplyFormUpdateDto = new ClubApplyFormUpdateDto(
                 "테스트 지원서",
                 "테스트 설명",
-                LocalDateTime.of(2025, 10, 1, 0, 0),
-                LocalDateTime.of(2025, 10, 31, 23, 59),
+                "2025-10-01 ~ 2025-10-31",
                 List.of(new FormQuestionUpdateDto(1L, "", FieldType.TEXT, true, 1L, null, null)));
 
         //when & then
@@ -497,8 +482,7 @@ class ClubApplyFormControllerTest {
         ClubApplyFormUpdateDto invalidRequestDto = new ClubApplyFormUpdateDto(
                 "테스트 지원서",
                 "설명",
-                LocalDateTime.of(2025, 10, 1, 0, 0),
-                LocalDateTime.of(2025, 10, 31, 23, 59),
+                "2025-10-01 ~ 2025-10-31",
                 List.of(new FormQuestionUpdateDto(1L, "면접 가능한 시간대를 선택해 주세요.", FieldType.TIME_SLOT, true, 1L, null, null))
         );
 
@@ -518,8 +502,7 @@ class ClubApplyFormControllerTest {
         ClubApplyFormUpdateDto invalidRequestDto = new ClubApplyFormUpdateDto(
                 "테스트 지원서",
                 "설명",
-                LocalDateTime.of(2025, 10, 1, 0, 0),
-                LocalDateTime.of(2025, 10, 31, 23, 59),
+                "2025-10-01 ~ 2025-10-31",
                 List.of(new FormQuestionUpdateDto(1L, "성별을 선택해 주세요.", FieldType.RADIO, true, 1L, null, null))
         );
 
@@ -539,8 +522,7 @@ class ClubApplyFormControllerTest {
         ClubApplyFormUpdateDto invalidRequestDto = new ClubApplyFormUpdateDto(
                 "", // Blank title
                 "설명",
-                LocalDateTime.of(2025, 10, 1, 0, 0),
-                LocalDateTime.of(2025, 10, 31, 23, 59),
+                "2025-10-01 ~ 2025-10-31",
                 List.of(new FormQuestionUpdateDto(1L, "질문", FieldType.TEXT, true, 1L, null, null))
         );
 
@@ -560,8 +542,7 @@ class ClubApplyFormControllerTest {
         ClubApplyFormUpdateDto invalidRequestDto = new ClubApplyFormUpdateDto(
                 "제목",
                 "", // Blank description
-                LocalDateTime.of(2025, 10, 1, 0, 0),
-                LocalDateTime.of(2025, 10, 31, 23, 59),
+                "2025-10-01 ~ 2025-10-31",
                 List.of(new FormQuestionUpdateDto(1L, "질문", FieldType.TEXT, true, 1L, null, null))
         );
 
@@ -582,8 +563,7 @@ class ClubApplyFormControllerTest {
         ClubApplyFormUpdateDto invalidRequestDto = new ClubApplyFormUpdateDto(
                 longTitle,
                 "설명",
-                LocalDateTime.of(2025, 10, 1, 0, 0),
-                LocalDateTime.of(2025, 10, 31, 23, 59),
+                "2025-10-01 ~ 2025-10-31",
                 List.of(new FormQuestionUpdateDto(1L, "질문", FieldType.TEXT, true, 1L, null, null))
         );
 
@@ -604,8 +584,7 @@ class ClubApplyFormControllerTest {
         ClubApplyFormUpdateDto invalidRequestDto = new ClubApplyFormUpdateDto(
                 "제목",
                 longDescription,
-                LocalDateTime.of(2025, 10, 1, 0, 0),
-                LocalDateTime.of(2025, 10, 31, 23, 59),
+                "2025-10-01 ~ 2025-10-31",
                 List.of(new FormQuestionUpdateDto(1L, "질문", FieldType.TEXT, true, 1L, null, null))
         );
 
@@ -625,8 +604,7 @@ class ClubApplyFormControllerTest {
         ClubApplyFormUpdateDto invalidRequestDto = new ClubApplyFormUpdateDto(
                 "제목",
                 "설명",
-                LocalDateTime.of(2025, 10, 1, 0, 0),
-                LocalDateTime.of(2025, 10, 31, 23, 59),
+                "2025-10-01 ~ 2025-10-31",
                 List.of(new FormQuestionUpdateDto(1L, "", FieldType.TEXT, true, 1L, null, null)) // Blank question
         );
 
@@ -647,8 +625,7 @@ class ClubApplyFormControllerTest {
         ClubApplyFormUpdateDto invalidRequestDto = new ClubApplyFormUpdateDto(
                 "제목",
                 "설명",
-                LocalDateTime.of(2025, 10, 1, 0, 0),
-                LocalDateTime.of(2025, 10, 31, 23, 59),
+                "2025-10-01 ~ 2025-10-31",
                 List.of(new FormQuestionUpdateDto(1L, longQuestion, FieldType.TEXT, true, 1L, null, null))
         );
 

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/service/ClubApplyFormServiceImplMockTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/service/ClubApplyFormServiceImplMockTest.java
@@ -9,6 +9,13 @@ import static org.mockito.BDDMockito.then;
 import static org.mockito.BDDMockito.times;
 import static org.mockito.Mockito.mock;
 
+import com.kakaotech.team18.backend_server.domain.club.entity.Club;
+import com.kakaotech.team18.backend_server.domain.club.repository.ClubRepository;
+import com.kakaotech.team18.backend_server.domain.clubApplyForm.dto.ClubApplyFormRequestDto;
+import com.kakaotech.team18.backend_server.domain.clubApplyForm.dto.ClubApplyFormResponseDto;
+import com.kakaotech.team18.backend_server.domain.clubApplyForm.dto.ClubApplyFormUpdateDto;
+import com.kakaotech.team18.backend_server.domain.clubApplyForm.entity.ClubApplyForm;
+import com.kakaotech.team18.backend_server.domain.clubApplyForm.repository.ClubApplyFormRepository;
 import com.kakaotech.team18.backend_server.domain.formQuestion.dto.FormQuestionRequestDto;
 import com.kakaotech.team18.backend_server.domain.formQuestion.dto.FormQuestionResponseDto;
 import com.kakaotech.team18.backend_server.domain.formQuestion.dto.FormQuestionUpdateDto;
@@ -17,17 +24,8 @@ import com.kakaotech.team18.backend_server.domain.formQuestion.entity.FieldType;
 import com.kakaotech.team18.backend_server.domain.formQuestion.entity.FormQuestion;
 import com.kakaotech.team18.backend_server.domain.formQuestion.entity.TimeSlotOption;
 import com.kakaotech.team18.backend_server.domain.formQuestion.repository.FormQuestionRepository;
-import com.kakaotech.team18.backend_server.domain.club.entity.Club;
-import com.kakaotech.team18.backend_server.domain.club.repository.ClubRepository;
-import com.kakaotech.team18.backend_server.domain.clubApplyForm.dto.ClubApplyFormRequestDto;
-import com.kakaotech.team18.backend_server.domain.clubApplyForm.dto.ClubApplyFormResponseDto;
-import com.kakaotech.team18.backend_server.domain.clubApplyForm.dto.ClubApplyFormUpdateDto;
-import com.kakaotech.team18.backend_server.domain.clubApplyForm.entity.ClubApplyForm;
-import com.kakaotech.team18.backend_server.domain.clubApplyForm.repository.ClubApplyFormRepository;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.ClubApplyFormNotFoundException;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.ClubNotFoundException;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
@@ -116,12 +114,11 @@ class ClubApplyFormServiceImplMockTest {
         FormQuestionRequestDto question1 = new FormQuestionRequestDto("질문 1", FieldType.TEXT, true, 1L, null, null);
         FormQuestionRequestDto question2 = new FormQuestionRequestDto("질문 2", FieldType.RADIO,
                 false, 2L, List.of("옵션 1", "옵션 2"),
-                List.of(new TimeSlotOptionRequestDto(LocalDate.of(2025,9,24), new TimeSlotOptionRequestDto.TimeRange(LocalTime.of(10, 0), LocalTime.of(21, 0))))
+                List.of(new TimeSlotOptionRequestDto("2025-10-01 ~ 2025-10-31", new TimeSlotOptionRequestDto.TimeRange(LocalTime.of(10, 0), LocalTime.of(21, 0))))
         );
         ClubApplyFormRequestDto requestDto = new ClubApplyFormRequestDto("테스트 지원서",
                 "테스트 설명",
-                LocalDateTime.of(2025, 10, 1, 0, 0),
-                LocalDateTime.of(2025, 10, 31, 23, 59),
+                "2025-10-01 ~ 2025-10-31",
                 List.of(question1, question2));
 
         ClubApplyForm clubApplyForm = ClubApplyForm.builder()
@@ -155,8 +152,7 @@ class ClubApplyFormServiceImplMockTest {
         FormQuestionRequestDto question1 = new FormQuestionRequestDto("질문 1", FieldType.TEXT, true, 1L, null, null);
         ClubApplyFormRequestDto requestDto = new ClubApplyFormRequestDto("테스트 지원서",
                 "테스트 설명",
-                LocalDateTime.of(2025, 10, 1, 0, 0),
-                LocalDateTime.of(2025, 10, 31, 23, 59),
+                "2025-10-01 ~ 2025-10-31",
                 List.of(question1));
 
         given(clubRepository.findById(clubId)).willReturn(Optional.empty());
@@ -202,8 +198,7 @@ class ClubApplyFormServiceImplMockTest {
         ClubApplyFormUpdateDto requestDto = new ClubApplyFormUpdateDto(
                 "수정된 지원서 제목",
                 "수정된 지원서 설명",
-                LocalDateTime.of(2025, 10, 1, 0, 0),
-                LocalDateTime.of(2025, 10, 31, 23, 59),
+                "2025-10-01 ~ 2025-10-31",
                 List.of(
                         new FormQuestionUpdateDto(
                                 1L,
@@ -248,8 +243,7 @@ class ClubApplyFormServiceImplMockTest {
         ClubApplyFormUpdateDto requestDto = new ClubApplyFormUpdateDto(
                 "테스트 지원서",
                 "테스트 설명",
-                LocalDateTime.of(2025, 10, 1, 0, 0),
-                LocalDateTime.of(2025, 10, 31, 23, 59),
+                "2025-10-01 ~ 2025-10-31",
                 List.of(question1));
 
         given(club.getId()).willReturn(1L);
@@ -284,7 +278,7 @@ class ClubApplyFormServiceImplMockTest {
                 .isRequired(true)
                 .displayOrder(1L)
                 .options(List.of("치킨", "피자", "햄버거"))
-                .timeSlotOptions(List.of(new TimeSlotOption(LocalDate.of(2024, 10, 26),
+                .timeSlotOptions(List.of(new TimeSlotOption("2025-10-01 ~ 2025-10-31",
                         new TimeSlotOption.TimeRange(LocalTime.of(10, 0), LocalTime.of(12, 0))
                 )))
                 .build();

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/formQuestion/entity/FormQuestionTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/formQuestion/entity/FormQuestionTest.java
@@ -66,12 +66,12 @@ class FormQuestionTest {
     @Test
     void updateFrom_shouldUpdateTimeSlotFieldsCorrectly() {
         TimeSlotOption.TimeRange originalTimeRange = new TimeSlotOption.TimeRange(LocalTime.of(10, 0), LocalTime.of(18, 0));
-        TimeSlotOption originalOption = new TimeSlotOption(LocalDate.of(2025, 9, 25), originalTimeRange);
+        TimeSlotOption originalOption = new TimeSlotOption("2025-10-01 ~ 2025-10-31", originalTimeRange);
         FormQuestion formQuestion = createFormQuestion("면접 가능한 시간대는?", FieldType.TIME_SLOT, 3L, null, List.of(originalOption));
         ReflectionTestUtils.setField(formQuestion, "id", 3L);
 
         TimeSlotOptionRequestDto.TimeRange newTimeRange = new TimeRange(LocalTime.of(22, 0), LocalTime.of(23, 0));
-        TimeSlotOptionRequestDto newOption = new TimeSlotOptionRequestDto(LocalDate.of(2025,9,26), newTimeRange);
+        TimeSlotOptionRequestDto newOption = new TimeSlotOptionRequestDto("2025-10-01 ~ 2025-10-31", newTimeRange);
 
         FormQuestionUpdateDto dto = new FormQuestionUpdateDto(
                 3L, "면접 불가능한 시간대는?", FieldType.TIME_SLOT, true, 3L, null, List.of(newOption)
@@ -83,7 +83,7 @@ class FormQuestionTest {
             .containsExactly("면접 불가능한 시간대는?", FieldType.TIME_SLOT, true, 3L, null);
 
         assertThat(formQuestion.getTimeSlotOptions()).hasSize(1);
-        assertThat(formQuestion.getTimeSlotOptions().get(0).date()).isEqualTo(LocalDate.of(2025, 9, 26));
+        assertThat(formQuestion.getTimeSlotOptions().get(0).date()).isEqualTo("2025-10-01 ~ 2025-10-31");
         assertThat(formQuestion.getTimeSlotOptions().get(0).availableTime().start()).isEqualTo("22:00");
         assertThat(formQuestion.getTimeSlotOptions().get(0).availableTime().end()).isEqualTo("23:00");
     }


### PR DESCRIPTION
## 🚀 작업 내용
프론트 요청에 맞춰 지원폼의 모집 일정과 TimeSlot의 date 값을 전달 받는 방식을 변경했습니다. 
기존 지원폼 모집 일정의 경우 등록/수정시 모집 시작일, 마감일을 따로 받았는데 이 값을 "2025-03-01 ~ 2025-03-31" 형식으로 주고 싶으시다고 하셔서 String 타입으로 받고 이 값을 파싱해서 사용하는 것으로 변경했습니다. 
TimeSlot의 경우 Date 필드에 날짜가 하루만 들어오는게 아니라 캘린더에서 날짜를 선택해 이 또한 "2025-03-01 ~ 2025-03-31"  이런 식으로 값을 넣어주셔서 이를 저장하기 쉽도록 String 타입으로 타입을 변경했습니다. 


## ⏱️ 소요 시간
2시간 

## 🤔 고민했던 내용
"2025-03-01 ~ 2025-03-31"  형식을 String으로 받고 이를 다시 반영할 때 파싱해서 LocalDateTime으로 변경해 저장하도록 했습니다. 
TimeSlot의 경우에는 타입만 String으로 변경하면 문제가 없을 것 같아서 그렇게만 진행했는데 제가 생각 못한 side effect가 있을지 모르겠습니다. 

## 💬 리뷰 중점사항
"2025-03-01 ~ 2025-03-31" 와 같은 String을 파싱하는 과정과 DB에 저장되고 수정되는 과정이 적절한지 체크 해주세요. 
테스트 코드를 수정했는데 더 수정할 부분 없을지 체크 부탁드립니다. 


## 🔗관련 이슈
- Close #156 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **리팩토링**
  * 모집 기간 입력 형식을 "YYYY-MM-DD ~ YYYY-MM-DD" 단일 문자열로 변경했습니다.
  * 시간대 선택의 날짜 필드를 문자열로 통일했습니다.
  * 모집 기간 문자열을 파싱해 시작/종료 일자를 계산하고 유효성 검사를 강화했습니다.

* **테스트**
  * 테스트 데이터의 전화번호 형식을 하이픈 포함(010-0000-0000)으로 업데이트했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->