### PR TITLE
[FIX] 도커 컴포즈 파일 s3 관련 env 변수명 수정

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,8 +85,8 @@ services:
       SPRING_DATA_REDIS_PORT: ${REDIS_PORT}
 
       #AWS S3
-      CLOUD_AWS_S3_BUCKET: ${S3_BUCKET}
-      CLOUD_AWS_REGION_STATIC: ${S3_REGION}
+      CLOUD_AWS_S3_BUCKET: ${CLOUD_AWS_S3_BUCKET}
+      CLOUD_AWS_REGION_STATIC: ${CLOUD_AWS_REGION_STATIC}
 
     healthcheck:
       # 상태 코드 200이고 본문에 "status":"UP" 포함되면 성공


### PR DESCRIPTION
## 🚀 작업 내용
docker compose 파일의 환경변수 중에 s3 관련 환경변수의 env 명이 잘못돼 변경했습니다. 

      CLOUD_AWS_S3_BUCKET: ${S3_BUCKET}
      CLOUD_AWS_REGION_STATIC: ${S3_REGION}
-> 

      CLOUD_AWS_S3_BUCKET: ${CLOUD_AWS_S3_BUCKET}
      CLOUD_AWS_REGION_STATIC: ${CLOUD_AWS_REGION_STATIC}


## ⏱️ 소요 시간
10분 

## 🤔 고민했던 내용


## 💬 리뷰 중점사항


## 🔗관련 이슈
- Close #이슈번호