### PR TITLE
[REFACTOR] 동아리 상세 페이지 이미지 등록 방식 변경 #151

### DIFF
--- a/src/main/java/com/kakaotech/team18/backend_server/domain/club/dto/ClubDetailResponseDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/club/dto/ClubDetailResponseDto.java
@@ -2,7 +2,6 @@ package com.kakaotech.team18.backend_server.domain.club.dto;
 
 import com.kakaotech.team18.backend_server.domain.club.entity.Category;
 import com.kakaotech.team18.backend_server.domain.club.entity.Club;
-import com.kakaotech.team18.backend_server.domain.club.entity.ClubImage;
 import com.kakaotech.team18.backend_server.domain.club.entity.ClubIntroduction;
 import com.kakaotech.team18.backend_server.domain.club.util.RecruitStatusCalculator;
 import com.kakaotech.team18.backend_server.domain.user.entity.User;
@@ -10,7 +9,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import lombok.Builder;
 
 @Builder
@@ -21,7 +19,7 @@ public record ClubDetailResponseDto(
         @Schema(description = "주요 활동 장소", example = "학생회관 101호") String location,
         @Schema(description = "동아리 카테고리", example = "STUDY") Category category,
         @Schema(description = "동아리 한 줄 소개", example = "함께 성장하는 개발 동아리입니다.") String shortIntroduction,
-        @Schema(description = "동아리 소개 이미지 URL 목록") List<String> introductionImages,
+        @Schema(description = "동아리 소개 이미지 URL 목록") List<ClubImageResponseDto> introductionImages,
         @Schema(description = "동아리 소개 (개요)", example = "저희는 스프링부트와 리액트를 공부하는 스터디 동아리입니다...") String introductionOverview,
         @Schema(description = "동아리 소개 (활동 내용)", example = "매주 월요일 정기 스터디, 분기별 해커톤 진행") String introductionActivity,
         @Schema(description = "동아리 소개 (인재상)", example = "개발에 대한 열정이 넘치는 분") String introductionIdeal,
@@ -45,8 +43,8 @@ public record ClubDetailResponseDto(
                 shortIntroduction(club.getShortIntroduction()).
                 introductionImages(clubIntroduction.map(ClubIntroduction::getImages)
                         .map(images -> images.stream()
-                                .map(ClubImage::getImageUrl)
-                                .collect(Collectors.toList()))
+                                .map(img -> new ClubImageResponseDto(img.getId(), img.getImageUrl()))
+                                .toList())
                         .orElse(List.of())).
                 introductionOverview(clubIntroduction.map(ClubIntroduction::getOverview).orElse("")).
                 introductionActivity(clubIntroduction.map(ClubIntroduction::getActivities).orElse("")).
@@ -60,4 +58,8 @@ public record ClubDetailResponseDto(
                 applicationNotice(club.getCaution()).
                 build();
     }
+    public record ClubImageResponseDto(
+            @Schema(description = "동아리 이미지 ID", example = "1") Long id,
+            @Schema(description = "동아리 이미지 URL", example = "dongairum.jpo") String url
+    ) {}
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/club/entity/ClubIntroduction.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/club/entity/ClubIntroduction.java
@@ -30,6 +30,9 @@ public class ClubIntroduction extends BaseEntity {
     @Column(columnDefinition = "TEXT")
     private String ideal;
 
+    @OneToOne(mappedBy = "introduction")
+    private Club club;
+
     @Builder
     private ClubIntroduction(String overview, String activities, String ideal, List<ClubImage> images) {
         this.overview = overview;
@@ -48,8 +51,7 @@ public class ClubIntroduction extends BaseEntity {
         }
     }
 
-    public void updateImages(List<String> imageUrl) {
-        this.images.clear();
+    public void addImages(List<String> imageUrl) {
         for (String url : imageUrl) {
             ClubImage image = ClubImage.builder()
                     .imageUrl(url)

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/club/repository/ClubImageRepository.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/club/repository/ClubImageRepository.java
@@ -3,10 +3,35 @@ package com.kakaotech.team18.backend_server.domain.club.repository;
 import com.kakaotech.team18.backend_server.domain.club.entity.ClubImage;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 public interface ClubImageRepository extends JpaRepository<ClubImage, Long> {
 
     @Query("SELECT ci.imageUrl FROM ClubImage ci")
     List<String> findAllImageUrls();
+
+    @Modifying(clearAutomatically = true)
+    @Query("""
+            DELETE FROM ClubImage ci
+            WHERE ci.clubIntroduction.club.id = :clubId
+            AND ci.id NOT IN :keepImageId
+            """)
+    void deleteAllByClubIdAndIdNotIn(Long clubId, List<Long> keepImageId);
+
+    @Query("""
+            SELECT ci
+            FROM ClubImage ci
+            JOIN ci.clubIntroduction ci_intro
+            JOIN ci_intro.club c
+            WHERE c.id = :clubId
+            """)
+    List<ClubImage> findAllByClubId(Long clubId);
+
+    @Modifying(clearAutomatically = true)
+    @Query("""
+            DELETE FROM ClubImage ci
+            WHERE ci.clubIntroduction.club.id = :clubId
+            """)
+    void deleteAllByClubId(Long clubId);
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/club/repository/ClubImageRepository.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/club/repository/ClubImageRepository.java
@@ -3,21 +3,12 @@ package com.kakaotech.team18.backend_server.domain.club.repository;
 import com.kakaotech.team18.backend_server.domain.club.entity.ClubImage;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 public interface ClubImageRepository extends JpaRepository<ClubImage, Long> {
 
     @Query("SELECT ci.imageUrl FROM ClubImage ci")
     List<String> findAllImageUrls();
-
-    @Modifying(clearAutomatically = true)
-    @Query("""
-            DELETE FROM ClubImage ci
-            WHERE ci.clubIntroduction.club.id = :clubId
-            AND ci.id NOT IN :keepImageId
-            """)
-    void deleteAllByClubIdAndIdNotIn(Long clubId, List<Long> keepImageId);
 
     @Query("""
             SELECT ci
@@ -27,11 +18,4 @@ public interface ClubImageRepository extends JpaRepository<ClubImage, Long> {
             WHERE c.id = :clubId
             """)
     List<ClubImage> findAllByClubId(Long clubId);
-
-    @Modifying(clearAutomatically = true)
-    @Query("""
-            DELETE FROM ClubImage ci
-            WHERE ci.clubIntroduction.club.id = :clubId
-            """)
-    void deleteAllByClubId(Long clubId);
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/club/service/ClubService.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/club/service/ClubService.java
@@ -27,5 +27,5 @@ public interface ClubService {
 
     ClubDashboardApplicantResponseDto getApplicantsByStatusAndStage(Long clubId, Status status, Stage stage);
 
-    SuccessResponseDto uploadClubImages(Long clubId, List<MultipartFile> images);
+    SuccessResponseDto uploadClubImages(Long clubId, List<Long> keepImageId, List<MultipartFile> images);
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/club/service/ClubServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/club/service/ClubServiceImpl.java
@@ -175,7 +175,8 @@ public class ClubServiceImpl implements ClubService {
             findClub.getIntroduction().getImages().clear();
         } else {
             findClub.getIntroduction().getImages().removeIf(img -> !keepImageId.contains(img.getId()));
-        }        log.info("Successfully deleted old images for clubId: {}", clubId);
+        }
+        log.info("Successfully deleted old images for clubId: {}", clubId);
 
         // 새 이미지 업로드
         List<String> newImageUrls = new ArrayList<>();

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/club/service/ClubServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/club/service/ClubServiceImpl.java
@@ -171,15 +171,11 @@ public class ClubServiceImpl implements ClubService {
                 .map(ClubImage::getImageUrl)
                 .toList();
 
-        // DB + 영속성 컨텍스트 삭제 동기화
         if (keepImageId == null || keepImageId.isEmpty()) {
-            clubImageRepository.deleteAllByClubId(clubId);
             findClub.getIntroduction().getImages().clear();
         } else {
-            clubImageRepository.deleteAllByClubIdAndIdNotIn(clubId, keepImageId);
             findClub.getIntroduction().getImages().removeIf(img -> !keepImageId.contains(img.getId()));
-        }
-        log.info("Successfully deleted old images for clubId: {}", clubId);
+        }        log.info("Successfully deleted old images for clubId: {}", clubId);
 
         // 새 이미지 업로드
         List<String> newImageUrls = new ArrayList<>();

--- a/src/main/java/com/kakaotech/team18/backend_server/global/service/S3Service.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/service/S3Service.java
@@ -104,8 +104,7 @@ public class S3Service {
             throw new InvalidFileException("확장자가 JPG 또는 PNG가 아닙니다.");
         }
 
-        String dir = "club_detail_image/";
-        String fileName = dir + UUID.randomUUID() + "-" + originalName;
+        String fileName = UUID.randomUUID() + "-" + originalName;
 
         PutObjectRequest putObjectRequest = PutObjectRequest.builder()
             .bucket(bucket)

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/club/controller/ClubControllerTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/club/controller/ClubControllerTest.java
@@ -143,7 +143,9 @@ class ClubControllerTest {
                 .location("공대7호관 201호")
                 .category(LITERATURE)
                 .shortIntroduction("카카오 부트캠프")
-                .introductionImages(List.of("ex.image","ex.image2","ex.image3"))
+                .introductionImages(List.of(new ClubDetailResponseDto.ClubImageResponseDto(1L, "ex.image"),
+                        new ClubDetailResponseDto.ClubImageResponseDto(2L, "ex.image2"),
+                        new ClubDetailResponseDto.ClubImageResponseDto(3L, "ex.image3")))
                 .introductionOverview("개발자로 성장할 수 있는 부트캠프입니다.")
                 .introductionActivity("총 3단계로 이루어진 코스")
                 .introductionIdeal("열심열심")

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/club/controller/ClubRestClientTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/club/controller/ClubRestClientTest.java
@@ -83,11 +83,20 @@ public class ClubRestClientTest {
             }
         };
 
+        ByteArrayResource keepIdsResource = new ByteArrayResource("[]".getBytes()) {
+            @Override
+            public String getFilename() {
+                return "keepImageIds.json";
+            }
+        };
+
         MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
-        body.add("images", resource);
+        body.add("newImages", resource);
+
+        body.add("keepImageIds", keepIdsResource);
 
         // when
-        var response = restClient.put()
+        var response = restClient.patch()
                 .uri("/api/clubs/1/images")
                 .contentType(MediaType.MULTIPART_FORM_DATA)
                 .body(body)
@@ -117,8 +126,18 @@ public class ClubRestClientTest {
             }
         };
 
+
+        ByteArrayResource keepIdsResource = new ByteArrayResource("[]".getBytes()) {
+            @Override
+            public String getFilename() {
+                return "keepImageIds.json";
+            }
+        };
+
         MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
-        body.add("images", resource);
+        body.add("newImages", resource);
+        body.add("keepImageIds", keepIdsResource);
+
 
         // when & then: Tomcat에서 연결을 끊기 때문에 ResourceAccessException 발생
         assertThatThrownBy(() ->
@@ -154,8 +173,19 @@ public class ClubRestClientTest {
                     return "image_" + System.nanoTime() + ".jpg";
                 }
             };
-            body.add("images", resource);
+            body.add("newImages", resource);
         }
+
+
+        ByteArrayResource keepIdsResource = new ByteArrayResource("[]".getBytes()) {
+            @Override
+            public String getFilename() {
+                return "keepImageIds.json";
+            }
+        };
+
+        body.add("keepImageIds", keepIdsResource);
+
 
         assertThatThrownBy(() ->
                 restClient.put()

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/club/controller/ClubRestClientTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/club/controller/ClubRestClientTest.java
@@ -141,7 +141,7 @@ public class ClubRestClientTest {
 
         // when & then: Tomcat에서 연결을 끊기 때문에 ResourceAccessException 발생
         assertThatThrownBy(() ->
-                restClient.put()
+                restClient.patch()
                         .uri("/api/clubs/1/images")
                         .contentType(MediaType.MULTIPART_FORM_DATA)
                         .body(body)
@@ -188,7 +188,7 @@ public class ClubRestClientTest {
 
 
         assertThatThrownBy(() ->
-                restClient.put()
+                restClient.patch()
                         .uri("/api/clubs/1/images")
                         .contentType(MediaType.MULTIPART_FORM_DATA)
                         .body(body)

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/club/service/ClubServiceImplTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/club/service/ClubServiceImplTest.java
@@ -13,6 +13,7 @@ import com.kakaotech.team18.backend_server.domain.application.repository.Applica
 import com.kakaotech.team18.backend_server.domain.club.dto.ClubListResponseDto;
 import com.kakaotech.team18.backend_server.domain.club.dto.ClubSummary;
 import com.kakaotech.team18.backend_server.domain.club.entity.Category;
+import com.kakaotech.team18.backend_server.domain.club.repository.ClubImageRepository;
 import com.kakaotech.team18.backend_server.domain.club.repository.ClubRepository;
 import com.kakaotech.team18.backend_server.domain.club.util.RecruitStatus;
 import com.kakaotech.team18.backend_server.domain.club.util.RecruitStatusCalculator;
@@ -50,7 +51,8 @@ class ClubServiceImplTest {
         ClubApplyFormRepository clubApplyFormRepository = mock(ClubApplyFormRepository.class);
         S3Service s3Service = mock(S3Service.class);
         ApplicationEventPublisher applicationEventPublisher = mock(ApplicationEventPublisher.class);
-        clubService = new ClubServiceImpl(clubRepository, applicationRepository, clubMemberRepository, clubApplyFormRepository, s3Service, applicationEventPublisher);
+        ClubImageRepository clubImageRepository = mock(ClubImageRepository.class);
+        clubService = new ClubServiceImpl(clubRepository, applicationRepository, clubMemberRepository, clubApplyFormRepository, s3Service, applicationEventPublisher, clubImageRepository);
     }
 
     @Getter

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/club/service/ClubServiceMockTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/club/service/ClubServiceMockTest.java
@@ -20,6 +20,7 @@ import com.kakaotech.team18.backend_server.domain.club.dto.ClubDashBoardResponse
 import com.kakaotech.team18.backend_server.domain.club.dto.ClubDashboardApplicantResponseDto;
 import com.kakaotech.team18.backend_server.domain.club.dto.ClubDetailRequestDto;
 import com.kakaotech.team18.backend_server.domain.club.dto.ClubDetailResponseDto;
+import com.kakaotech.team18.backend_server.domain.club.dto.ClubDetailResponseDto.ClubImageResponseDto;
 import com.kakaotech.team18.backend_server.domain.club.entity.Category;
 import com.kakaotech.team18.backend_server.domain.club.entity.Club;
 import com.kakaotech.team18.backend_server.domain.club.entity.ClubImage;
@@ -214,7 +215,7 @@ public class ClubServiceMockTest {
                     "공7 1호관",
                     Category.LITERATURE,
                     "함께 배우는 카태켐",
-                    List.of("image1.url"),
+                    List.of(new ClubImageResponseDto(1L,"image1.url")),
                     "overview",
                     "activities",
                     "ideal",

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/club/service/ClubServiceMockTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/club/service/ClubServiceMockTest.java
@@ -3,10 +3,8 @@ package com.kakaotech.team18.backend_server.domain.club.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -25,6 +23,8 @@ import com.kakaotech.team18.backend_server.domain.club.entity.Category;
 import com.kakaotech.team18.backend_server.domain.club.entity.Club;
 import com.kakaotech.team18.backend_server.domain.club.entity.ClubImage;
 import com.kakaotech.team18.backend_server.domain.club.entity.ClubIntroduction;
+import com.kakaotech.team18.backend_server.domain.club.eventListener.ClubImageDeletedEvent;
+import com.kakaotech.team18.backend_server.domain.club.repository.ClubImageRepository;
 import com.kakaotech.team18.backend_server.domain.club.repository.ClubRepository;
 import com.kakaotech.team18.backend_server.domain.club.util.RecruitStatus;
 import com.kakaotech.team18.backend_server.domain.club.util.RecruitStatusCalculator;
@@ -39,6 +39,7 @@ import com.kakaotech.team18.backend_server.domain.user.entity.User;
 import com.kakaotech.team18.backend_server.global.dto.SuccessResponseDto;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.ClubMemberNotFoundException;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.ClubNotFoundException;
+import com.kakaotech.team18.backend_server.global.exception.exceptions.InvalidFileException;
 import com.kakaotech.team18.backend_server.global.service.S3Service;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -74,6 +75,8 @@ public class ClubServiceMockTest {
     ClubApplyFormRepository clubApplyFormRepository;
     @Mock
     S3Service s3Service;
+    @Mock
+    ClubImageRepository clubImageRepository;
     @Mock
     ApplicationEventPublisher applicationEventPublisher;
 
@@ -374,64 +377,133 @@ public class ClubServiceMockTest {
         );
         return club;
     }
-    @DisplayName("동아리 운영진이 동아리 상세페이지에 이미지를 수정할 수 있다.")
+
+    @DisplayName("동아리 운영진이 동아리 상세페이지의 이미지를 선택적으로 유지/추가할 수 있다.")
     @Test
-    void uploadClubImages_shouldUploadAndReplaceImages() {
+    void updateClubImages_shouldKeepSomeAndAddNewOnes() {
         // given
-        Long clubId = 1L;
-        Club club = sampleClubWithIntroduction(
-                "기존동아리", Category.STUDY, "공대 1호관", "old short",
-                "old overview", "old activity", "old ideal",
-                List.of("old1.jpg", "old2.jpg")
-        );
-        ReflectionTestUtils.setField(club, "id", clubId);
+        // 기존 클럽 이미지 설정
+        ClubImage existingImage1 = ClubImage.builder().imageUrl("old1.jpg").build();
+        ClubImage existingImage2 = ClubImage.builder().imageUrl("old2.jpg").build();
+        ClubImage existingImage3 = ClubImage.builder().imageUrl("old3.jpg").build();
 
-        MultipartFile newImage1 = new MockMultipartFile("image1", "new1.jpg", "image/jpeg", "new image data 1".getBytes());
-        MultipartFile newImage2 = new MockMultipartFile("image2", "new2.jpg", "image/jpeg", "new image data 2".getBytes());
-        List<MultipartFile> newImages = List.of(newImage1, newImage2);
+        // clubIntroduction에 이미지 추가 (실제 ClubImage 객체에 ID를 설정해야 함)
+        ReflectionTestUtils.setField(existingImage1, "id", 1L);
+        ReflectionTestUtils.setField(existingImage2, "id", 2L);
+        ReflectionTestUtils.setField(existingImage3, "id", 3L);
 
-        given(clubRepository.findClubDetailById(clubId)).willReturn(Optional.of(club));
-        club.getIntroduction().getImages().forEach(
-                image -> willDoNothing().given(s3Service).deleteFile(image.getImageUrl())
-        );
-        given(s3Service.upload(newImage1)).willReturn("http://s3.amazon.com/new1.jpg");
-        given(s3Service.upload(newImage2)).willReturn("http://s3.amazon.com/new2.jpg");
+        ClubIntroduction clubIntroduction = ClubIntroduction.builder()
+                .overview("overview")
+                .activities("activities")
+                .ideal("ideal")
+                .build();
+        clubIntroduction.addImage(existingImage1);
+        clubIntroduction.addImage(existingImage2);
+        clubIntroduction.addImage(existingImage3);
+
+        Club club = createClub(clubIntroduction, LocalDateTime.of(2025, 9, 3, 0, 0),
+                LocalDateTime.of(2025, 9, 20, 23, 59));
+        ReflectionTestUtils.setField(club, "id", 1L);
+
+        // 유지할 이미지 ID: 1L (old1.jpg)
+        List<Long> keepImageIds = List.of(1L);
+
+        // 새로 추가할 이미지
+        MockMultipartFile newImageFile1 = new MockMultipartFile("newImage1", "new1.jpg", "image/jpeg", "new image data 1".getBytes());
+        MockMultipartFile newImageFile2 = new MockMultipartFile("newImage2", "new2.png", "image/png", "new image data 2".getBytes());
+        List<MultipartFile> newImages = List.of(newImageFile1, newImageFile2);
+
+        // Mocking
+        given(clubRepository.findClubDetailById(1L)).willReturn(Optional.of(club));
+        given(clubImageRepository.findAllByClubId(1L)).willReturn(List.of(existingImage1, existingImage2, existingImage3));
+        given(s3Service.upload(newImageFile1)).willReturn("uploaded_new1.jpg");
+        given(s3Service.upload(newImageFile2)).willReturn("uploaded_new2.png");
 
         // when
-        SuccessResponseDto response = clubService.uploadClubImages(clubId, newImages);
+        SuccessResponseDto response = clubService.uploadClubImages(1L, keepImageIds, newImages);
 
         // then
         assertThat(response.success()).isTrue();
-        assertThat(club.getIntroduction().getImages()).hasSize(2);
-        assertThat(club.getIntroduction().getImages().get(0).getImageUrl()).isEqualTo("http://s3.amazon.com/new1.jpg");
-        assertThat(club.getIntroduction().getImages().get(1).getImageUrl()).isEqualTo("http://s3.amazon.com/new2.jpg");
-        verify(s3Service).upload(newImage1);
-        verify(s3Service).upload(newImage2);
+
+        // clubIntroduction의 이미지가 올바르게 업데이트되었는지 확인
+        List<ClubImage> updatedImages = club.getIntroduction().getImages();
+        assertThat(updatedImages).hasSize(3); // old1 + new1 + new2
+
+        assertThat(updatedImages).extracting(ClubImage::getImageUrl)
+                .containsExactlyInAnyOrder("old1.jpg", "uploaded_new1.jpg", "uploaded_new2.png");
+
+        // S3Service의 upload 메서드가 새 이미지 파일에 대해 호출되었는지 확인
+        verify(s3Service, times(1)).upload(newImageFile1);
+        verify(s3Service, times(1)).upload(newImageFile2);
+
+        // clubImageRepository의 deleteAllByClubIdAndIdNotIn 메서드가 호출되었는지 확인
+        verify(clubImageRepository, times(1)).deleteAllByClubIdAndIdNotIn(1L, keepImageIds);
+
+        // 이벤트 발행 확인 (old2.jpg, old3.jpg가 삭제 대상이므로)
+        verify(applicationEventPublisher, times(1)).publishEvent(any(ClubImageDeletedEvent.class));
     }
 
-    @DisplayName("동아리 운영진이 동아리 상세페이지에 이미지를 수정할 때, 동아리가 존재하지 않으면 예외가 발생한다.")
+    @DisplayName("이미지 수정 시, 모든 이미지를 삭제하고 새 이미지를 추가할 수 있다.")
     @Test
-    void uploadClubImages_shouldThrowException_whenClubNotFound() {
+    void updateClubImages_shouldDeleteAllAndAddNewOnes() {
         // given
-        Long clubId = 999L; // 존재하지 않는 클럽 ID
-        List<MultipartFile> newImages = List.of(
-                new MockMultipartFile("image1", "new1.jpg", "image/jpeg", "new image data 1".getBytes())
-        );
+        // 기존 클럽 이미지 설정
+        ClubImage existingImage1 = ClubImage.builder().imageUrl("old1.jpg").build();
+        ClubImage existingImage2 = ClubImage.builder().imageUrl("old2.jpg").build();
 
-        given(clubRepository.findClubDetailById(clubId)).willReturn(Optional.empty());
+        ReflectionTestUtils.setField(existingImage1, "id", 1L);
+        ReflectionTestUtils.setField(existingImage2, "id", 2L);
 
-        // when & then
-        assertThatThrownBy(() -> clubService.uploadClubImages(clubId, newImages))
-                .isInstanceOf(ClubNotFoundException.class)
-                .hasMessageContaining("해당 동아리가 존재하지 않습니다.");
+        ClubIntroduction clubIntroduction = ClubIntroduction.builder()
+                .overview("overview")
+                .activities("activities")
+                .ideal("ideal")
+                .build();
+        clubIntroduction.addImage(existingImage1);
+        clubIntroduction.addImage(existingImage2);
 
-        verify(s3Service, times(0)).deleteFile(anyString());
-        verify(s3Service, times(0)).upload(any(MultipartFile.class));
+        Club club = createClub(clubIntroduction, LocalDateTime.of(2025, 9, 3, 0, 0),
+                LocalDateTime.of(2025, 9, 20, 23, 59));
+        ReflectionTestUtils.setField(club, "id", 1L);
+
+        // 유지할 이미지 없음 (모두 삭제)
+        List<Long> keepImageIds = List.of();
+
+        // 새로 추가할 이미지
+        MockMultipartFile newImageFile1 = new MockMultipartFile("newImage1", "new1.jpg", "image/jpeg", "new image data 1".getBytes());
+        List<MultipartFile> newImages = List.of(newImageFile1);
+
+        // Mocking
+        given(clubRepository.findClubDetailById(1L)).willReturn(Optional.of(club));
+        given(clubImageRepository.findAllByClubId(1L)).willReturn(List.of(existingImage1, existingImage2));
+        given(s3Service.upload(newImageFile1)).willReturn("uploaded_new1.jpg");
+
+        // when
+        SuccessResponseDto response = clubService.uploadClubImages(1L, keepImageIds, newImages);
+
+        // then
+        assertThat(response.success()).isTrue();
+
+        // clubIntroduction의 이미지가 올바르게 업데이트되었는지 확인
+        List<ClubImage> updatedImages = club.getIntroduction().getImages();
+        assertThat(updatedImages).hasSize(1); // new1
+
+        assertThat(updatedImages).extracting(ClubImage::getImageUrl)
+                .containsExactlyInAnyOrder("uploaded_new1.jpg");
+
+        // S3Service의 upload 메서드가 새 이미지 파일에 대해 호출되었는지 확인
+        verify(s3Service, times(1)).upload(newImageFile1);
+
+        // clubImageRepository의 deleteAllByClubId 메서드가 호출되었는지 확인
+        verify(clubImageRepository, times(1)).deleteAllByClubId(1L);
+
+        // 이벤트 발행 확인 (old1.jpg, old2.jpg가 삭제 대상이므로)
+        verify(applicationEventPublisher, times(1)).publishEvent(any(ClubImageDeletedEvent.class));
     }
 
-    @DisplayName("동아리 운영진이 동아리 상세페이지에 이미지를 수정할 때, 이미지 확장자가 잘못된 경우 예외가 발생한다.")
+    @DisplayName("이미지 수정 시, S3 업로드 실패하면 보상 트랜잭션으로 업로드된 이미지 삭제")
     @Test
-    void uploadClubImages_shouldThrowException_whenInvalidImageExtension() {
+    void updateClubImages_shouldRollbackS3Upload_whenUploadFails() {
         // given
         Long clubId = 1L;
         Club club = sampleClubWithIntroduction(
@@ -441,19 +513,133 @@ public class ClubServiceMockTest {
         );
         ReflectionTestUtils.setField(club, "id", clubId);
 
-        MultipartFile invalidImage = new MockMultipartFile("image1", "invalid.gif", "image/gif", "invalid image data".getBytes());
+        List<Long> keepImageIds = List.of(); // 유지하지 않음
+
+        MockMultipartFile newImageFile1 = new MockMultipartFile("newImage1", "new1.jpg", "image/jpeg", "new image data 1".getBytes());
+        MockMultipartFile newImageFile2 = new MockMultipartFile("newImage2", "new2.png", "image/png", "new image data 2".getBytes());
+        List<MultipartFile> newImages = List.of(newImageFile1, newImageFile2);
+
+        given(clubRepository.findClubDetailById(clubId)).willReturn(Optional.of(club));
+        given(clubImageRepository.findAllByClubId(clubId)).willReturn(List.of()); // 기존 이미지 없음
+        given(s3Service.upload(newImageFile1)).willReturn("uploaded_new1.jpg");
+        given(s3Service.upload(newImageFile2)).willThrow(new RuntimeException("S3 upload failed")); // 두 번째 이미지 업로드 실패
+
+        // when & then
+        assertThatThrownBy(() -> clubService.uploadClubImages(clubId, keepImageIds, newImages))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("S3 upload failed");
+
+        // 첫 번째 이미지 업로드는 성공했으므로, 보상 트랜잭션으로 삭제 호출 확인
+        verify(s3Service, times(1)).upload(newImageFile1);
+        verify(s3Service, times(1)).upload(newImageFile2);
+        verify(s3Service, times(1)).deleteFile("uploaded_new1.jpg");
+        verify(clubImageRepository, times(1)).deleteAllByClubId(clubId);
+    }
+
+    @DisplayName("이미지 수정 시, 유지할 이미지가 null이면 모든 이미지를 삭제하고 새 이미지를 추가한다.")
+    @Test
+    void updateClubImages_shouldDeleteAllAndAddNewOnes_whenKeepImageIdIsNull() {
+        // given
+        // 기존 클럽 이미지 설정
+        ClubImage existingImage1 = ClubImage.builder().imageUrl("old1.jpg").build();
+        ClubImage existingImage2 = ClubImage.builder().imageUrl("old2.jpg").build();
+
+        ReflectionTestUtils.setField(existingImage1, "id", 1L);
+        ReflectionTestUtils.setField(existingImage2, "id", 2L);
+
+        ClubIntroduction clubIntroduction = ClubIntroduction.builder()
+                .overview("overview")
+                .activities("activities")
+                .ideal("ideal")
+                .build();
+        clubIntroduction.addImage(existingImage1);
+        clubIntroduction.addImage(existingImage2);
+
+        Club club = createClub(clubIntroduction, LocalDateTime.of(2025, 9, 3, 0, 0),
+                LocalDateTime.of(2025, 9, 20, 23, 59));
+        ReflectionTestUtils.setField(club, "id", 1L);
+
+        // 유지할 이미지 없음 (모두 삭제)
+        List<Long> keepImageIds = null;
+
+        // 새로 추가할 이미지
+        MockMultipartFile newImageFile1 = new MockMultipartFile("newImage1", "new1.jpg", "image/jpeg", "new image data 1".getBytes());
+        List<MultipartFile> newImages = List.of(newImageFile1);
+
+        // Mocking
+        given(clubRepository.findClubDetailById(1L)).willReturn(Optional.of(club));
+        given(clubImageRepository.findAllByClubId(1L)).willReturn(List.of(existingImage1, existingImage2));
+        given(s3Service.upload(newImageFile1)).willReturn("uploaded_new1.jpg");
+
+        // when
+        SuccessResponseDto response = clubService.uploadClubImages(1L, keepImageIds, newImages);
+
+        // then
+        assertThat(response.success()).isTrue();
+
+        // clubIntroduction의 이미지가 올바르게
+        // 업데이트되었는지 확인
+        List<ClubImage> updatedImages = club.getIntroduction().getImages();
+        assertThat(updatedImages).hasSize(1); // new1
+
+        assertThat(updatedImages).extracting(ClubImage::getImageUrl)
+                .containsExactlyInAnyOrder("uploaded_new1.jpg");
+
+        // S3Service의 upload 메서드가 새 이미지 파일에 대해 호출되었는지 확인
+        verify(s3Service, times(1)).upload(newImageFile1);
+
+        // clubImageRepository의 deleteAllByClubId 메서드가 호출되었는지 확인
+        verify(clubImageRepository, times(1)).deleteAllByClubId(1L);
+
+        // 이벤트 발행 확인 (old1.jpg, old2.jpg가 삭제 대상이므로)
+        verify(applicationEventPublisher, times(1)).publishEvent(any(ClubImageDeletedEvent.class));
+    }
+
+    @DisplayName("이미지 수정 시, 동아리가 존재하지 않으면 예외 발생")
+    @Test
+    void updateClubImages_shouldThrowException_whenClubNotFound() {
+        //given
+        Long clubId = 999L;
+        List<Long> keepImageIds = List.of(1L);
+        List<MultipartFile> newImages = List.of(
+                new MockMultipartFile("image1", "new1.jpg", "image/jpeg", "data".getBytes())
+        );
+
+        given(clubRepository.findClubDetailById(clubId)).willReturn(Optional.empty());
+
+        //when & then
+        assertThatThrownBy(() -> clubService.uploadClubImages(clubId, keepImageIds, newImages))
+                .isInstanceOf(ClubNotFoundException.class)
+                .hasMessageContaining("해당 동아리가 존재하지 않습니다.");
+
+        verify(s3Service, times(0)).upload(any());
+    }
+
+    @DisplayName("이미지 수정 시, 잘못된 확장자의 이미지가 포함되면 예외가 발생한다.")
+    @Test
+    void updateClubImages_shouldThrowException_whenInvalidImageExtension() {
+
+        Long clubId = 1L;
+        Club club = sampleClubWithIntroduction(
+                "기존동아리", Category.STUDY, "공대 1호관", "old short",
+                "old overview", "old activity", "old ideal",
+                List.of("old1.jpg")
+        );
+        ReflectionTestUtils.setField(club, "id", clubId);
+
+        List<Long> keepImageIds = List.of(); // 유지하지 않음
+
+        MultipartFile invalidImage = new MockMultipartFile("image", "invalid.gif", "image/gif", "data".getBytes());
         List<MultipartFile> newImages = List.of(invalidImage);
 
         given(clubRepository.findClubDetailById(clubId)).willReturn(Optional.of(club));
-        given(s3Service.upload(any(MultipartFile.class))).willThrow(new com.kakaotech.team18.backend_server.global.exception.exceptions.InvalidFileException("JPG 또는 PNG 파일만 업로드 가능합니다."));
+        given(s3Service.upload(invalidImage)).willThrow(new InvalidFileException("JPG 또는 PNG 파일만 업로드 가능합니다."));
 
-        // when & then
-        assertThatThrownBy(() -> clubService.uploadClubImages(clubId, newImages))
-                .isInstanceOf(com.kakaotech.team18.backend_server.global.exception.exceptions.InvalidFileException.class)
+        assertThatThrownBy(() -> clubService.uploadClubImages(clubId, keepImageIds, newImages))
+                .isInstanceOf(InvalidFileException.class)
                 .hasMessageContaining("잘못된 파일 형식입니다.");
 
-        verify(s3Service, times(1)).upload(invalidImage); // 잘못된 파일이라도 upload 시도는 한 번 발생
-        verify(s3Service, times(0)).deleteFile(anyString()); // 파일 업로드 실패 시 기존 파일 삭제는 일어나지 않음
+        verify(s3Service, times(1)).upload(invalidImage);
     }
 
 

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/club/service/ClubServiceMockTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/club/service/ClubServiceMockTest.java
@@ -415,7 +415,6 @@ public class ClubServiceMockTest {
 
         // Mocking
         given(clubRepository.findClubDetailById(1L)).willReturn(Optional.of(club));
-        given(clubImageRepository.findAllByClubId(1L)).willReturn(List.of(existingImage1, existingImage2, existingImage3));
         given(s3Service.upload(newImageFile1)).willReturn("uploaded_new1.jpg");
         given(s3Service.upload(newImageFile2)).willReturn("uploaded_new2.png");
 
@@ -435,9 +434,6 @@ public class ClubServiceMockTest {
         // S3Service의 upload 메서드가 새 이미지 파일에 대해 호출되었는지 확인
         verify(s3Service, times(1)).upload(newImageFile1);
         verify(s3Service, times(1)).upload(newImageFile2);
-
-        // clubImageRepository의 deleteAllByClubIdAndIdNotIn 메서드가 호출되었는지 확인
-        verify(clubImageRepository, times(1)).deleteAllByClubIdAndIdNotIn(1L, keepImageIds);
 
         // 이벤트 발행 확인 (old2.jpg, old3.jpg가 삭제 대상이므로)
         verify(applicationEventPublisher, times(1)).publishEvent(any(ClubImageDeletedEvent.class));
@@ -494,9 +490,6 @@ public class ClubServiceMockTest {
         // S3Service의 upload 메서드가 새 이미지 파일에 대해 호출되었는지 확인
         verify(s3Service, times(1)).upload(newImageFile1);
 
-        // clubImageRepository의 deleteAllByClubId 메서드가 호출되었는지 확인
-        verify(clubImageRepository, times(1)).deleteAllByClubId(1L);
-
         // 이벤트 발행 확인 (old1.jpg, old2.jpg가 삭제 대상이므로)
         verify(applicationEventPublisher, times(1)).publishEvent(any(ClubImageDeletedEvent.class));
     }
@@ -533,7 +526,6 @@ public class ClubServiceMockTest {
         verify(s3Service, times(1)).upload(newImageFile1);
         verify(s3Service, times(1)).upload(newImageFile2);
         verify(s3Service, times(1)).deleteFile("uploaded_new1.jpg");
-        verify(clubImageRepository, times(1)).deleteAllByClubId(clubId);
     }
 
     @DisplayName("이미지 수정 시, 유지할 이미지가 null이면 모든 이미지를 삭제하고 새 이미지를 추가한다.")
@@ -587,9 +579,6 @@ public class ClubServiceMockTest {
 
         // S3Service의 upload 메서드가 새 이미지 파일에 대해 호출되었는지 확인
         verify(s3Service, times(1)).upload(newImageFile1);
-
-        // clubImageRepository의 deleteAllByClubId 메서드가 호출되었는지 확인
-        verify(clubImageRepository, times(1)).deleteAllByClubId(1L);
 
         // 이벤트 발행 확인 (old1.jpg, old2.jpg가 삭제 대상이므로)
         verify(applicationEventPublisher, times(1)).publishEvent(any(ClubImageDeletedEvent.class));

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/club/service/ClubServiceMockTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/club/service/ClubServiceMockTest.java
@@ -415,6 +415,7 @@ public class ClubServiceMockTest {
 
         // Mocking
         given(clubRepository.findClubDetailById(1L)).willReturn(Optional.of(club));
+        given(clubImageRepository.findAllByClubId(1L)).willReturn(List.of(existingImage1, existingImage2, existingImage3));
         given(s3Service.upload(newImageFile1)).willReturn("uploaded_new1.jpg");
         given(s3Service.upload(newImageFile2)).willReturn("uploaded_new2.png");
 


### PR DESCRIPTION
## 🚀 작업 내용
이전에 PR 했던 이슈를 다시 작업해서 PR 올립니다. 
기존에는 클라이언트로부터 images (등록할 이미지 파일 목록) 만 받아서 이미지 전체를 삭제 후 저장하는 방식으로 진행했었는데 이렇게 하면 프론트가 모든 이미지 파일을 가지고 있어야합니다. 그런데 프론트는 이미 저장한 이미지의 경우 서버로부터 이미지 URL만 가지고 있기 때문에 파일을 전달해줄 수 없었습니다. 

이를 해결하고자, 동아리 상세페이지 조회시 응답 DTO에 이미지 id 를 함께 전달하고 이 값을 사용해서 이미지 변경시 클라이언트가 유지할 이미지 목록과 새로 등록할 파일을 서버에게 전달해주도록 했습니다. 이렇게 하면 유지할 이미지 id 를 기준으로 이에 해당하지 않은 이미지들을 제거해줄 수 있고, 이미지 파일들은 저장해주면 됩니다. 

## ⏱️ 소요 시간
5시간 

## 🤔 고민했던 내용
바뀐 API는 PATCH 메서드로 이 API를 통해 이미지 삭제와 수정이 동시에 이루어집니다. DELETE 메서드를 만들어서 삭제하는 로직을 구분할까 생각했는데 하나의 API로도 충분히 커버할 수 있을거라고 생각했습니다. 
새로 바뀐 이미지 수정 로직을 어떻게 구현할지 고민이 됐습니다. 이미지를 수정한다는게 기존 이미지를 제거하고 이미지를 추가하는 과정이기 때문에 이 흐름에 맞춰서 작성하려고 했습니다.

## 💬 리뷰 중점사항
새로 바뀐 이미지 수정방식이 이상하지 않은지 잘못된 부분은 없는지 체크 부탁드립니다. 
테스트 코드에 이상한 부분 없는지 확인 부탁드립니다.


## 🔗관련 이슈
- Close #151 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 이미지 업데이트에 유지할 이미지 ID(keepImageIds)와 새 이미지(newImages)를 함께 제출하는 PATCH 지원

* **개선**
  * 클럽 상세 응답에 각 이미지의 id와 URL 메타데이터 포함
  * 기존 이미지 선택적 보존·삭제와 새 이미지 추가 흐름 통합
  * 업로드 실패 시 새로 업로드된 파일 롤백 및 삭제 보장
  * 요청 JSON 유효성 검사 및 오류 로깅 강화
  * 저장 키 형식 변경(경로 접두사 제거)

* **테스트**
  * keepImageIds 유효성, 부분 보존·교체, 업로드 실패 복구 등 시나리오 보강
<!-- end of auto-generated comment: release notes by coderabbit.ai -->