### PR TITLE
[REFACTOR] 지원폼 등록/수정 DTO 모집 일정 필드 수정 (#156)

### DIFF
--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/dto/ClubApplyFormResponseDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/dto/ClubApplyFormResponseDto.java
@@ -2,6 +2,7 @@ package com.kakaotech.team18.backend_server.domain.clubApplyForm.dto;
 
 import com.kakaotech.team18.backend_server.domain.formQuestion.dto.FormQuestionResponseDto;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Schema(description = "지원서 양식 조회 응답 데이터")
@@ -10,14 +11,19 @@ public record ClubApplyFormResponseDto(
         String title,
         @Schema(description = "지원서 양식 설명", example = "함께 성장할 열정적인 신입 부원을 모집합니다!")
         String description,
+        @Schema(description = "모집 기간", example = "2024-09-01 ~ 2024-09-30")
+        String recruitDate,
         @Schema(description = "질문 목록")
-        List<FormQuestionResponseDto> questions
+        List<FormQuestionResponseDto> formQuestions
 ) {
     public static ClubApplyFormResponseDto of(
             String title,
             String description,
+            LocalDateTime recruitStart,
+            LocalDateTime recruitEnd,
             List<FormQuestionResponseDto> questions
     ) {
-        return new ClubApplyFormResponseDto(title, description, questions);
+        String recruitDate = String.format("%s ~ %s", recruitStart.toLocalDate().toString(), recruitEnd.toLocalDate().toString());
+        return new ClubApplyFormResponseDto(title, description, recruitDate, questions);
     }
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/dto/ClubApplyFormResponseDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/dto/ClubApplyFormResponseDto.java
@@ -23,7 +23,9 @@ public record ClubApplyFormResponseDto(
             LocalDateTime recruitEnd,
             List<FormQuestionResponseDto> questions
     ) {
-        String recruitDate = String.format("%s ~ %s", recruitStart.toLocalDate().toString(), recruitEnd.toLocalDate().toString());
+        String recruitDate = (recruitStart != null && recruitEnd != null)
+                ? String.format("%s ~ %s", recruitStart.toLocalDate(), recruitEnd.toLocalDate())
+                : null;
         return new ClubApplyFormResponseDto(title, description, recruitDate, questions);
     }
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/service/ClubApplyFormServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/service/ClubApplyFormServiceImpl.java
@@ -45,6 +45,7 @@ public class ClubApplyFormServiceImpl implements ClubApplyFormService {
                     log.warn("ClubApplyForm not found for clubId: {}", clubId);
                     return new ClubApplyFormNotFoundException("clubId = " + clubId);
                 });
+        Club club = findClub(clubId);
 
         Long formId = clubApplyForm.getId();
         String title = clubApplyForm.getTitle();
@@ -56,7 +57,7 @@ public class ClubApplyFormServiceImpl implements ClubApplyFormService {
                         .map(FormQuestionResponseDto::from)
                         .toList();
 
-        return ClubApplyFormResponseDto.of(title, description, questions);
+        return ClubApplyFormResponseDto.of(title, description, club.getRecruitStart(), club.getRecruitEnd(), questions);
     }
 
     @Override

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/formQuestion/dto/FormQuestionResponseDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/formQuestion/dto/FormQuestionResponseDto.java
@@ -15,13 +15,13 @@ public record FormQuestionResponseDto(
         Long questionNum,
 
         @Schema(description = "질문 유형", example = "CHECK_BOX")
-        FieldType questionType,
+        FieldType fieldType,
 
         @Schema(description = "질문 내용", example = "가장 자신 있는 프로그래밍 언어는 무엇인가요?")
         String question,
 
         @Schema(description = "필수 응답 여부", example = "true")
-        Boolean required,
+        Boolean isRequired,
 
         @Schema(description = "선택지 목록 (객관식, 체크박스 유형일 경우에만 존재)", example = "[\"JAVA\", \"C\", \"C++\"]")
         List<String> optionList,

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/formQuestion/entity/TimeSlotOption.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/formQuestion/entity/TimeSlotOption.java
@@ -1,5 +1,6 @@
 package com.kakaotech.team18.backend_server.domain.formQuestion.entity;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.Embedded;
@@ -7,6 +8,7 @@ import java.time.LocalTime;
 
 @Embeddable
 public record TimeSlotOption(
+        @Schema(description = "날짜 (YYYY-MM-DD ~ YYYY-MM-DD)", example = "2024-10-01 ~ 2024-10-27")
         String date,
         @Embedded
         TimeRange availableTime

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/controller/ClubApplyFormControllerTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/controller/ClubApplyFormControllerTest.java
@@ -69,6 +69,8 @@ class ClubApplyFormControllerTest {
         ClubApplyFormResponseDto mockResponse = ClubApplyFormResponseDto.of(
                 "테스트 동아리 지원서",
                 "테스트 동아리 지원서 설명입니다.",
+                LocalDateTime.of(2024, 9, 1, 0, 0),
+                LocalDateTime.of(2024, 9, 30, 23, 59, 59),
                 List.of(question1, question2)
         );
 
@@ -80,9 +82,10 @@ class ClubApplyFormControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.title").value("테스트 동아리 지원서"))
                 .andExpect(jsonPath("$.description").value("테스트 동아리 지원서 설명입니다."))
-                .andExpect(jsonPath("$.questions[0].question").value("이름"))
-                .andExpect(jsonPath("$.questions[1].question").value("성별"))
-                .andExpect(jsonPath("$.questions[1].optionList[0]").value("남"));
+                .andExpect(jsonPath("$.formQuestions[0].question").value("이름"))
+                .andExpect(jsonPath("$.formQuestions[1].question").value("성별"))
+                .andExpect(jsonPath("$.recruitDate").value("2024-09-01 ~ 2024-09-30"))
+                .andExpect(jsonPath("$.formQuestions[1].optionList[0]").value("남"));
 
         verify(clubApplyFormService, times(1)).getQuestionForm(clubId);
     }
@@ -96,6 +99,8 @@ class ClubApplyFormControllerTest {
         ClubApplyFormResponseDto mockResponse = ClubApplyFormResponseDto.of(
                 "테스트 동아리 지원서",
                 "테스트 동아리 지원서 설명입니다.",
+                LocalDateTime.of(2024, 9, 1, 0, 0),
+                LocalDateTime.of(2024, 9, 30, 23, 59, 59),
                 List.of(question1, question2)
         );
 
@@ -107,9 +112,10 @@ class ClubApplyFormControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.title").value("테스트 동아리 지원서"))
                 .andExpect(jsonPath("$.description").value("테스트 동아리 지원서 설명입니다."))
-                .andExpect(jsonPath("$.questions[0].question").value("이름"))
-                .andExpect(jsonPath("$.questions[1].question").value("성별"))
-                .andExpect(jsonPath("$.questions[1].optionList[0]").value("남"));
+                .andExpect(jsonPath("$.formQuestions[0].question").value("이름"))
+                .andExpect(jsonPath("$.formQuestions[1].question").value("성별"))
+                .andExpect(jsonPath("$.recruitDate").value("2024-09-01 ~ 2024-09-30"))
+                .andExpect(jsonPath("$.formQuestions[1].optionList[0]").value("남"));
 
         verify(clubApplyFormService, times(1)).getQuestionForm(clubId);
     }

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/service/ClubApplyFormServiceImplMockTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/service/ClubApplyFormServiceImplMockTest.java
@@ -26,6 +26,7 @@ import com.kakaotech.team18.backend_server.domain.formQuestion.entity.TimeSlotOp
 import com.kakaotech.team18.backend_server.domain.formQuestion.repository.FormQuestionRepository;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.ClubApplyFormNotFoundException;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.ClubNotFoundException;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
@@ -56,17 +57,23 @@ class ClubApplyFormServiceImplMockTest {
     void getQuestionForm() {
         //given
         Long clubId = 1L;
-        Club club = mock(Club.class);
+        Club club = Club.builder().
+                recruitStart(LocalDateTime.of(2024, 9, 1, 0, 0))
+                .recruitEnd(LocalDateTime.of(2024, 9, 30, 23, 59, 59))
+                .build();
         ClubApplyForm clubApplyForm = createClubApplyForm(club);
         ReflectionTestUtils.setField(clubApplyForm, "id", 1L);
         FormQuestion formQuestion = createFormQuestion(clubApplyForm);
 
         given(clubApplyFormRepository.findByClubId(clubId)).willReturn(Optional.of(clubApplyForm));
         given(formQuestionRepository.findByClubApplyFormIdOrderByDisplayOrderAsc(clubApplyForm.getId())).willReturn(List.of(formQuestion));
+        given(clubRepository.findById(clubId)).willReturn(Optional.of(club));
 
         ClubApplyFormResponseDto expected = ClubApplyFormResponseDto.of(
                 clubApplyForm.getTitle(),
                 clubApplyForm.getDescription(),
+                LocalDateTime.of(2024, 9, 1, 0, 0),
+                LocalDateTime.of(2024, 9, 30, 23, 59, 59),
                 List.of(formQuestion).stream().map(
                                 fq -> new FormQuestionResponseDto(
                                         fq.getId(),

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/service/ClubApplyFormServiceImplTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/service/ClubApplyFormServiceImplTest.java
@@ -7,15 +7,15 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
-import com.kakaotech.team18.backend_server.domain.application.entity.Stage;
-import com.kakaotech.team18.backend_server.domain.application.entity.Status;
+import com.kakaotech.team18.backend_server.domain.club.entity.Club;
+import com.kakaotech.team18.backend_server.domain.club.repository.ClubRepository;
+import com.kakaotech.team18.backend_server.domain.clubApplyForm.entity.ClubApplyForm;
+import com.kakaotech.team18.backend_server.domain.clubApplyForm.repository.ClubApplyFormRepository;
 import com.kakaotech.team18.backend_server.domain.formQuestion.entity.FieldType;
 import com.kakaotech.team18.backend_server.domain.formQuestion.entity.FormQuestion;
 import com.kakaotech.team18.backend_server.domain.formQuestion.repository.FormQuestionRepository;
-import com.kakaotech.team18.backend_server.domain.club.entity.Club;
-import com.kakaotech.team18.backend_server.domain.clubApplyForm.entity.ClubApplyForm;
-import com.kakaotech.team18.backend_server.domain.clubApplyForm.repository.ClubApplyFormRepository;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.ClubApplyFormNotFoundException;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -36,6 +36,9 @@ class ClubApplyFormServiceImplTest {
 
     @Mock
     private FormQuestionRepository formQuestionRepository;
+
+    @Mock
+    private ClubRepository clubRepository;
 
     @InjectMocks
     private ClubApplyFormServiceImpl applicationFormServiceImpl;
@@ -99,7 +102,12 @@ class ClubApplyFormServiceImplTest {
 
                 //given
                 Long clubId = 100L;
+                Club club = Club.builder()
+                        .recruitStart(LocalDateTime.of(2024, 9, 1, 0, 0))
+                        .recruitEnd(LocalDateTime.of(2024, 9, 30, 23, 59, 59))
+                        .build();
 
+                when(clubRepository.findById(clubId)).thenReturn(Optional.of(club));
                 when(clubApplyFormRepository.findByClubId(clubId)).thenReturn(Optional.of(
                         clubApplyForm));
                 when(formQuestionRepository.findByClubApplyFormIdOrderByDisplayOrderAsc(
@@ -111,22 +119,24 @@ class ClubApplyFormServiceImplTest {
                 //then
                 assertThat(result.title()).isEqualTo("카카오 동아리 지원서");
                 assertThat(result.description()).isEqualTo("함께 성장할 팀원을 찾습니다.");
-                assertThat(result.questions()).hasSize(3);
+                assertThat(result.recruitDate()).isEqualTo("2024-09-01 ~ 2024-09-30");
+                assertThat(result.formQuestions()).hasSize(3);
 
-                var firstQuestion = result.questions().get(0);
+                var firstQuestion = result.formQuestions().get(0);
                 assertThat(firstQuestion.questionNum()).isEqualTo(1L);
                 assertThat(firstQuestion.question()).isEqualTo("이름");
 
-                var secondQuestion = result.questions().get(1);
+                var secondQuestion = result.formQuestions().get(1);
                 assertThat(secondQuestion.questionNum()).isEqualTo(2L);
                 assertThat(secondQuestion.question()).isEqualTo("성별");
                 assertThat(secondQuestion.optionList()).containsExactly("남", "여");
 
-                var thirdQuestion = result.questions().get(2);
+                var thirdQuestion = result.formQuestions().get(2);
                 assertThat(thirdQuestion.questionNum()).isEqualTo(3L);
                 assertThat(thirdQuestion.question()).isEqualTo("면접가능 요일");
                 assertThat(thirdQuestion.optionList()).containsExactly("월", "화", "수", "목", "금", "토");
 
+                verify(clubRepository, times(1)).findById(clubId);
                 verify(clubApplyFormRepository, times(1)).findByClubId(clubId);
                 verify(formQuestionRepository, times(1)).findByClubApplyFormIdOrderByDisplayOrderAsc(
                         clubApplyForm.getId());
@@ -138,6 +148,12 @@ class ClubApplyFormServiceImplTest {
                 // given
                 Long clubId = 100L;
 
+                Club club = Club.builder()
+                        .recruitStart(LocalDateTime.of(2024, 9, 1, 0, 0))
+                        .recruitEnd(LocalDateTime.of(2024, 9, 30, 23, 59, 59))
+                        .build();
+
+                when(clubRepository.findById(clubId)).thenReturn(Optional.of(club));
                 when(clubApplyFormRepository.findByClubId(clubId))
                         .thenReturn(Optional.of(clubApplyForm));
                 when(formQuestionRepository
@@ -150,8 +166,10 @@ class ClubApplyFormServiceImplTest {
                 // then
                 assertThat(result.title()).isEqualTo("카카오 동아리 지원서");
                 assertThat(result.description()).isEqualTo("함께 성장할 팀원을 찾습니다.");
-                assertThat(result.questions()).isEmpty();
+                assertThat(result.recruitDate()).isEqualTo("2024-09-01 ~ 2024-09-30");
+                assertThat(result.formQuestions()).isEmpty();
 
+                verify(clubRepository).findById(clubId);
                 verify(clubApplyFormRepository).findByClubId(clubId);
                 verify(formQuestionRepository)
                         .findByClubApplyFormIdOrderByDisplayOrderAsc(clubApplyForm.getId());


### PR DESCRIPTION
## 🚀 작업 내용

프론트 측에서 지원폼 조회 응답 값에도 recruitDate를 추가해달라고 하셨습니다.
- 이 값은 Club의 recruitStart, recruitEnd 값을 받아서 문자열로 파싱해 생성합니다. 

등록/수정 DTO 필드 명이랑 조회 DTO 필드명이 달라서 통일시켜달라고 하셨습니다.
- questionType -> fieldType
- required -> isRequired



## ⏱️ 소요 시간
1시간 반 

## 🤔 고민했던 내용


## 💬 리뷰 중점사항


## 🔗관련 이슈
- Close #156 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 동아리 지원 응답에 모집 기간 표시 추가 (YYYY-MM-DD ~ YYYY-MM-DD 형식)

* **개선 사항**
  * 응답 필드명 명확화: questions → formQuestions
  * 질문 항목 속성명 변경: questionType → fieldType, required → isRequired
  * 모집 기간 필드에 API 문서용 설명·예시 추가 (Swagger 메타데이터)

* **테스트**
  * 변경된 응답 형식에 맞춰 테스트 케이스 및 목 설정 업데이트
<!-- end of auto-generated comment: release notes by coderabbit.ai -->