### PR TITLE
[FIX] api/auth/reissue API 만 필터를 통과하도록 수정

### DIFF
--- a/src/main/java/com/kakaotech/team18/backend_server/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/security/JwtAuthenticationFilter.java
@@ -42,9 +42,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
 
-        // 요청 URI를 확인하여 /api/auth/** 경로의 요청은 필터를 그냥 통과시킨다.
+        // 요청 URI를 확인하여 /api/auth/reissue 경로의 요청은 필터를 그냥 통과시킨다.
         String requestURI = request.getRequestURI();
-        if (requestURI.startsWith("/api/auth/")) {
+        if (requestURI.equals("/api/auth/reissue")) {
             filterChain.doFilter(request, response);
             return;
         }


### PR DESCRIPTION
[FIX] api/auth/reissue API 만 필터를 통과하도록 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * JWT 인증 필터의 예외 경로를 정확히 제한하도록 수정되었습니다. 이제 특정 토큰 재발급 경로만 필터를 우회하며, 기타 모든 인증 관련 요청은 JWT 검증을 통과해야 합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->