### PR TITLE
[FIX] 카카오 로그아웃 후 리다이렉트 오류 수정

### DIFF
--- a/src/main/java/com/kakaotech/team18/backend_server/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/auth/controller/AuthController.java
@@ -24,12 +24,12 @@ import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.CookieValue;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.view.RedirectView;
 
 @Tag(name = "인증 API", description = "카카오 소셜 로그인 및 회원가입 관련 API")
 @RestController
@@ -142,9 +142,8 @@ public class AuthController {
             @ApiResponse(responseCode = "302", description = "로그아웃 성공 및 메인 페이지로 리다이렉트")
     })
     @GetMapping("/kakao/logout")
-    public String kakaoLogout() {
-
-        // 최종적으로 프론트엔드의 메인 페이지로 리다이렉트
-        return "redirect:https://www.dongarium.co.kr/";
+    public RedirectView kakaoLogout() {
+        // 최종적으로 프론트엔드의 메인 페이지로 리다이렉트합니다.
+        return new RedirectView("https://www.dongarium.co.kr/");
     }
 }


### PR DESCRIPTION
## 🚀 작업 내용
카카오 로그아웃 콜백을 처리하는 `kakaoLogout` 메소드가 의도대로 리다이렉트되지 않고, "redirect:..." 문자열을 화면에 그대로 출력하는 문제를 해결합니다.

- **원인:** `@RestController`가 적용된 컨트롤러에서 `String` 타입으로 "redirect:URL"을 반환하면, Spring은 이를 View 이름으로 해석하지 않고 문자열 자체를 HTTP 응답 본문(Body)으로 전송합니다.

- **해결:** `kakaoLogout` 메소드의 반환 타입을 `String`에서 `RedirectView`로 변경했습니다. 이를 통해 Spring MVC가 HTTP 302 리다이렉트 응답을 생성하도록 명시적으로 지시하여, 클라이언트(브라우저)가 지정된 메인 페이지로 정상 이동하도록 수정했습니다.


## ⏱️ 소요 시간
15m

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 카카오 로그아웃 기능의 리다이렉트 처리가 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->