### PR TITLE
[FIX] 동아리 상세 페이지 이미지 수정 관련 에러 수정 

### DIFF
--- a/src/main/java/com/kakaotech/team18/backend_server/domain/club/controller/ClubController.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/club/controller/ClubController.java
@@ -24,7 +24,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -82,7 +81,7 @@ public class ClubController{
             @ApiResponse(responseCode = "200", description = "수정 성공"),
             @ApiResponse(responseCode = "404", description = "해당 동아리를 찾을 수 없음")
     })
-    @PatchMapping("/{clubId}/images")
+    @PostMapping("/{clubId}/images")
     public ResponseEntity<SuccessResponseDto> updateClubImages(
             @PathVariable Long clubId,
             @RequestPart("keepImageIds") String keepImageIdsJson,

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/club/entity/Club.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/club/entity/Club.java
@@ -84,20 +84,12 @@ public class Club extends BaseEntity {
         this.shortIntroduction = dto.shortIntroduction();
         this.caution = dto.applicationNotice();
         this.regularMeetingInfo = dto.regularMeetingInfo();
-        this.introduction = buildNewIntroduction(dto);
+        this.introduction.update(dto);
     }
 
     public void updateRecruitDate(LocalDateTime recruitStart, LocalDateTime recruitEnd) {
         this.recruitStart = recruitStart;
         this.recruitEnd = recruitEnd;
         log.info("Updated recruit date for clubId: {} to start: {} end: {}", this.id, recruitStart, recruitEnd);
-    }
-
-    private ClubIntroduction buildNewIntroduction(ClubDetailRequestDto dto) {
-        return ClubIntroduction.builder()
-                .overview(dto.introductionOverview())
-                .activities(dto.introductionActivity())
-                .ideal(dto.introductionIdeal())
-                .build();
     }
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/club/entity/ClubIntroduction.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/club/entity/ClubIntroduction.java
@@ -1,6 +1,7 @@
 package com.kakaotech.team18.backend_server.domain.club.entity;
 
 import com.kakaotech.team18.backend_server.domain.BaseEntity;
+import com.kakaotech.team18.backend_server.domain.club.dto.ClubDetailRequestDto;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
@@ -38,6 +39,11 @@ public class ClubIntroduction extends BaseEntity {
         this.overview = overview;
         this.activities = activities;
         this.ideal = ideal;
+        if (images != null) {
+            for (ClubImage image : images) {
+                addImage(image);
+            }
+        }
     }
 
     public void addImage(ClubImage image) {
@@ -59,5 +65,11 @@ public class ClubIntroduction extends BaseEntity {
                     .build();
             this.addImage(image);
         }
+    }
+
+    public void update(ClubDetailRequestDto dto) {
+        this.overview = dto.introductionOverview();
+        this.activities = dto.introductionActivity();
+        this.ideal = dto.introductionIdeal();
     }
 }

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/club/controller/ClubControllerTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/club/controller/ClubControllerTest.java
@@ -343,7 +343,7 @@ class ClubControllerTest {
                         multipart("/api/clubs/{clubId}/images", clubId)
                                 .file(keepImageIdsPart)
                                 .file(newImage)
-                                .with(request -> { request.setMethod("PATCH"); return request; })
+                                .with(request -> { request.setMethod("POST"); return request; })
                 )
                 .andDo(print())
                 .andExpect(status().isOk());
@@ -377,7 +377,7 @@ class ClubControllerTest {
                         multipart("/api/clubs/{clubId}/images", clubId)
                                 .file(keepImageIdsPart)
                                 .file(newImage)
-                                .with(request -> { request.setMethod("PATCH"); return request; })
+                                .with(request -> { request.setMethod("POST"); return request; })
                 )
                 .andDo(print())
                 .andExpect(status().isBadRequest());
@@ -410,7 +410,7 @@ class ClubControllerTest {
                         multipart("/api/clubs/{clubId}/images", clubId)
                                 .file(keepImageIdsPart)
                                 .file(newImage)
-                                .with(request -> { request.setMethod("PATCH"); return request; })
+                                .with(request -> { request.setMethod("POST"); return request; })
                 )
                 .andDo(print())
                 .andExpect(status().isBadRequest());
@@ -428,7 +428,7 @@ class ClubControllerTest {
         //when
         mockMvc.perform(
                         multipart("/api/clubs/{clubId}/images", clubId)
-                                .with(request -> { request.setMethod("PATCH"); return request; })
+                                .with(request -> { request.setMethod("POST"); return request; })
                 )
                 .andDo(print())
                 .andExpect(status().isBadRequest());

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/club/controller/ClubRestClientTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/club/controller/ClubRestClientTest.java
@@ -96,7 +96,7 @@ public class ClubRestClientTest {
         body.add("keepImageIds", keepIdsResource);
 
         // when
-        var response = restClient.patch()
+        var response = restClient.post()
                 .uri("/api/clubs/1/images")
                 .contentType(MediaType.MULTIPART_FORM_DATA)
                 .body(body)

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/club/controller/ClubRestClientTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/club/controller/ClubRestClientTest.java
@@ -141,7 +141,7 @@ public class ClubRestClientTest {
 
         // when & then: Tomcat에서 연결을 끊기 때문에 ResourceAccessException 발생
         assertThatThrownBy(() ->
-                restClient.patch()
+                restClient.post()
                         .uri("/api/clubs/1/images")
                         .contentType(MediaType.MULTIPART_FORM_DATA)
                         .body(body)
@@ -188,7 +188,7 @@ public class ClubRestClientTest {
 
 
         assertThatThrownBy(() ->
-                restClient.patch()
+                restClient.post()
                         .uri("/api/clubs/1/images")
                         .contentType(MediaType.MULTIPART_FORM_DATA)
                         .body(body)

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/club/entity/ClubTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/club/entity/ClubTest.java
@@ -47,7 +47,7 @@ class ClubTest {
 
         club.updateDetail(dto);
 
-        assertThat(club.getName().equals(dto.clubName()));
+        assertThat(club.getName()).isEqualTo(dto.clubName());
         assertThat(club.getCategory()).isEqualTo(dto.category());
         assertThat(club.getLocation()).isEqualTo(dto.location());
         assertThat(club.getShortIntroduction()).isEqualTo(dto.shortIntroduction());

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/club/entity/ClubTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/club/entity/ClubTest.java
@@ -1,0 +1,66 @@
+package com.kakaotech.team18.backend_server.domain.club.entity;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.kakaotech.team18.backend_server.domain.club.dto.ClubDetailRequestDto;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ClubTest {
+
+    @DisplayName("updateDetail 메서드 테스트")
+    @Test
+    void updateDetailTest() {
+        ClubImage image1 = ClubImage.builder().imageUrl("image1.jpg").build();
+        ClubImage image2 = ClubImage.builder().imageUrl("image2.jpg").build();
+        Club club = Club.builder()
+                .name("Test Club")
+                .category(Category.STUDY)
+                .location("Test Location")
+                .shortIntroduction("Short intro")
+                .introduction(ClubIntroduction.builder()
+                        .overview("Overview")
+                        .activities("Activities")
+                        .images(List.of(image1,
+                                image2
+                        ))
+                        .ideal("Ideal")
+                        .build())
+                .caution("Caution")
+                .regularMeetingInfo("Regular meeting info")
+                .build();
+
+        ClubDetailRequestDto dto = ClubDetailRequestDto.builder()
+                .clubId(1L)
+                .clubName("Updated Club")
+                .category(Category.SPORTS)
+                .location("Updated Location")
+                .shortIntroduction("Updated short intro")
+                .introductionOverview("Updated overview")
+                .introductionActivity("Updated activities")
+                .introductionIdeal("Updated ideal")
+                .regularMeetingInfo("Updated regular meeting info")
+                .applicationNotice("Updated caution")
+                .build();
+
+        club.updateDetail(dto);
+
+        assertThat(club.getName().equals(dto.clubName()));
+        assertThat(club.getCategory()).isEqualTo(dto.category());
+        assertThat(club.getLocation()).isEqualTo(dto.location());
+        assertThat(club.getShortIntroduction()).isEqualTo(dto.shortIntroduction());
+        assertThat(club.getCaution()).isEqualTo(dto.applicationNotice());
+        assertThat(club.getRegularMeetingInfo()).isEqualTo(dto.regularMeetingInfo());
+        assertThat(club.getIntroduction().getOverview()).isEqualTo(dto.introductionOverview());
+        assertThat(club.getIntroduction().getActivities()).isEqualTo(dto.introductionActivity());
+        assertThat(club.getIntroduction().getIdeal()).isEqualTo(dto.introductionIdeal());
+        assertThat(club.getIntroduction().getImages())
+                .usingRecursiveComparison()
+                .isEqualTo(List.of(
+                        image1,
+                        image2
+                ));
+    }
+}


### PR DESCRIPTION
## 🚀 작업 내용
동아리 상세 페이지 수정시 이미지가 날라가는 경우가 있었는데 수정시 ClubIntroduction  객체를 새로 만드는 과정에서 이미지가 손실된 것이라 생각해 ClubIntroduction 객체를 새로 만들지 않고 update 메서드를 만들어 갱신하도록 했습니다. 
이미지 수정 API의 경우 multipart/form-data를 사용하는데 이 content-type이 GET, POST 메서드만 지원하고 이 메서드가 적절해 보여 POST 메서드로 변경했습니다. 

## ⏱️ 소요 시간


## 🤔 고민했던 내용


## 💬 리뷰 중점사항


## 🔗관련 이슈
- Close #이슈번호

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **리팩터링**
  * 클럽 소개(Overview/Activities/Ideal) 업데이트 로직을 내부적으로 간소화(도메인 객체의 업데이트 메서드 추가)하여 유지보수성 개선
  * 클럽 이미지 초기화/등록 처리 개선

* **변경**
  * 클럽 이미지 업로드 엔드포인트의 요청 방식이 PATCH에서 POST로 변경

* **테스트**
  * 클럽 상세 정보 업데이트 단위 테스트 추가
  * 클럽 이미지 업로드 관련 테스트 케이스를 PATCH→POST로 갱신
<!-- end of auto-generated comment: release notes by coderabbit.ai -->