### PR TITLE
[FIX] 지원서 상세 페이지에 rating 노출되도록 수정

### DIFF
--- a/src/main/java/com/kakaotech/team18/backend_server/domain/application/dto/ApplicationDetailResponseDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/application/dto/ApplicationDetailResponseDto.java
@@ -11,6 +11,9 @@ public record ApplicationDetailResponseDto(
     @Schema(description = "지원서 상태 (예: PENDING, APPROVED, REJECTED)", example = "PENDING")
     String status,
 
+    @Schema(description = "평균 평점", example = "3.5")
+    Double rating,
+
     @Schema(description = "지원자 정보")
     ApplicantInfo applicantInfo,
 

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/application/service/ApplicationServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/application/service/ApplicationServiceImpl.java
@@ -104,6 +104,7 @@ public class ApplicationServiceImpl implements ApplicationService {
         return new ApplicationDetailResponseDto(
                 application.getId(),
                 application.getStatus().name(),
+                application.getAverageRating(),
                 applicantInfo,
                 questionsAndAnswers
         );

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/application/controller/ApplicationControllerTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/application/controller/ApplicationControllerTest.java
@@ -73,7 +73,7 @@ class ApplicationControllerTest {
                 applicantId, "김지원", "컴퓨터공학과", "20230001", "test@test.com", "010-1234-5678"
         );
         ApplicationDetailResponseDto responseDto = new ApplicationDetailResponseDto(
-                100L, "PENDING", applicantInfo, Collections.emptyList()
+                100L, "PENDING", 3.5, applicantInfo, Collections.emptyList()
         );
 
         given(applicationService.getApplicationDetail(clubId, applicantId)).willReturn(responseDto);
@@ -88,6 +88,7 @@ class ApplicationControllerTest {
         resultActions.andExpect(status().isOk())
                 .andExpect(jsonPath("$.applicationId").value(100L))
                 .andExpect(jsonPath("$.status").value("PENDING"))
+                .andExpect(jsonPath("$.rating").value(3.5))
                 .andExpect(jsonPath("$.applicantInfo.name").value("김지원"))
                 .andExpect(jsonPath("$.applicantInfo.department").value("컴퓨터공학과"));
     }


### PR DESCRIPTION
[FIX] 지원서 상세 페이지에 rating 노출되도록 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 지원서 상세 정보 조회 응답에 평균 평점 필드가 추가되었습니다. 사용자는 이제 지원서 상세 정보를 조회할 때 해당 지원서의 평균 평점을 함께 확인할 수 있으며, 이를 통해 더욱 완전한 정보를 기반으로 의사결정할 수 있게 되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->