### PR TITLE
[FIX] 동아리 후기 조회 API에 인가가 적용되지 않도록 수정

### DIFF
--- a/src/main/java/com/kakaotech/team18/backend_server/global/config/SecurityConfig.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/config/SecurityConfig.java
@@ -73,6 +73,8 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.GET, "/api/clubs/*/apply").permitAll()
                 // 지원서 제출 API (공개)
                 .requestMatchers(HttpMethod.POST, "/api/clubs/*/apply-submit").permitAll()
+                // 동아리 후기 조회 API (공개)
+                .requestMatchers(HttpMethod.GET, "/api/clubs/*/reviews").permitAll()
                 .anyRequest().authenticated()
         );
 


### PR DESCRIPTION
## 🚀 작업 내용
[FIX] 동아리 후기 조회 API에 인가가 적용되지 않도록 수정

## ⏱️ 소요 시간
10m


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* 인증 없이 클럽 리뷰 조회 가능 - 로그인하지 않은 사용자도 특정 클럽의 리뷰를 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->