### PR TITLE
[chore]fixed wrong total applicant problem

### DIFF
--- a/src/main/java/com/kakaotech/team18/backend_server/domain/club/service/ClubServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/club/service/ClubServiceImpl.java
@@ -116,8 +116,9 @@ public class ClubServiceImpl implements ClubService {
                     log.warn("ClubApplyForm not found for id={}", clubId);
                     return new ClubApplyFormNotFoundException("clubId = " + clubId);
                 });
-        List<ClubMember> applicantList = clubMemberRepository.findByClubIdAndRole(clubId, Role.APPLICANT);//role이 applicant 이면서 status가 pending인 지원서 수를 세어야함
-        List<ClubMember> pendingApplications = clubMemberRepository.findByClubIdAndRoleAndApplicationStatus(clubId, Role.APPLICANT, Status.PENDING);
+        List<ClubMember> applicantList = clubMemberRepository
+                .findByClubIdAndRoleAndApplicationIsNotNull(clubId, Role.APPLICANT);
+        List<ClubMember> pendingApplications = clubMemberRepository.findByClubIdAndRoleAndApplicationStatus(clubId, Role.APPLICANT, Status.PENDING);//role이 applicant 이면서 status가 pending인 지원서 수를 세어야함
         log.info("동아리 대쉬보드를 조회합니다 clubId={}, applicantList={}", clubId, applicantList);
         return new ClubDashBoardResponseDto(
                 clubId,

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/repository/ClubMemberRepository.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/repository/ClubMemberRepository.java
@@ -29,6 +29,14 @@ public interface ClubMemberRepository extends JpaRepository<ClubMember, Long> {
     @Query("""
             select cm
             from ClubMember cm
+            join fetch cm.club
+            where cm.club.id = :clubId and cm.role = :role and cm.application IS NOT NULL
+            """)
+    List<ClubMember> findByClubIdAndRoleAndApplicationIsNotNull(Long clubId, Role role);
+
+    @Query("""
+            select cm
+            from ClubMember cm
             join fetch cm.application a
             join fetch cm.user
             where cm.club.id = :clubId and cm.role = :role and a.stage = :stage
@@ -95,4 +103,5 @@ public interface ClubMemberRepository extends JpaRepository<ClubMember, Long> {
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("update ClubMember cm set cm.application = null where cm.application.id = :applicationId")
     int clearApplicationByApplicationId(Long applicationId);
+
 }

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/club/service/ClubServiceMockTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/club/service/ClubServiceMockTest.java
@@ -101,7 +101,7 @@ public class ClubServiceMockTest {
 
         given(clubRepository.findById(eq(clubId))).willReturn(Optional.of(club));
         given(clubApplyFormRepository.findByClubId(eq(club.getId()))).willReturn(Optional.of(clubApplyForm));
-        given(clubMemberRepository.findByClubIdAndRole(eq(clubId), eq(Role.APPLICANT))).willReturn(List.of(clubMember));
+        given(clubMemberRepository.findByClubIdAndRoleAndApplicationIsNotNull(eq(clubId), eq(Role.APPLICANT))).willReturn(List.of(clubMember));
         given(clubMemberRepository.findByClubIdAndRoleAndApplicationStatus(eq(clubId), eq(Role.APPLICANT), eq(Status.PENDING))).willReturn(List.of(clubMember));
         ClubDashBoardResponseDto expect = new ClubDashBoardResponseDto(1L,1, 1,
                 LocalDate.of(2025, 9, 3),
@@ -114,7 +114,7 @@ public class ClubServiceMockTest {
         assertThat(actual).isEqualTo(expect);
         verify(clubRepository).findById(eq(clubId));
         verify(clubApplyFormRepository).findByClubId(club.getId());
-        verify(clubMemberRepository).findByClubIdAndRole(1L, Role.APPLICANT);
+        verify(clubMemberRepository).findByClubIdAndRoleAndApplicationIsNotNull(1L, Role.APPLICANT);
         verify(clubMemberRepository).findByClubIdAndRoleAndApplicationStatus(1L, Role.APPLICANT, Status.PENDING);
         verifyNoInteractions(applicationRepository);
     }
@@ -137,7 +137,7 @@ public class ClubServiceMockTest {
 
         given(clubRepository.findById(eq(clubId))).willReturn(Optional.of(club));
         given(clubApplyFormRepository.findByClubId(eq(club.getId()))).willReturn(Optional.of(clubApplyForm));
-        given(clubMemberRepository.findByClubIdAndRole(eq(clubId), eq(Role.APPLICANT))).willReturn(List.of());
+        given(clubMemberRepository.findByClubIdAndRoleAndApplicationIsNotNull(eq(clubId), eq(Role.APPLICANT))).willReturn(List.of());
         given(clubMemberRepository.findByClubIdAndRoleAndApplicationStatus(eq(1L), eq(Role.APPLICANT), eq(Status.PENDING))).willReturn(List.of());
 
         ClubDashBoardResponseDto expect = new ClubDashBoardResponseDto(1L, 0, 0, LocalDate.of(2025, 9, 3),
@@ -151,7 +151,7 @@ public class ClubServiceMockTest {
         assertThat(actual).isEqualTo(expect);
         verify(clubRepository).findById(eq(clubId));
         verify(clubApplyFormRepository).findByClubId(club.getId());
-        verify(clubMemberRepository).findByClubIdAndRole(1L, Role.APPLICANT);
+        verify(clubMemberRepository).findByClubIdAndRoleAndApplicationIsNotNull(1L, Role.APPLICANT);
         verify(clubMemberRepository).findByClubIdAndRoleAndApplicationStatus(1L, Role.APPLICANT, Status.PENDING);
         verifyNoInteractions(applicationRepository);
 


### PR DESCRIPTION
## 🚀 작업 내용
findByClubIdAndRole로 잘못된 총 지원자 수 반환문제
findByClubIdAndRoleAndApplicationIsNotNull로 수정

## ⏱️ 소요 시간
5m

## 🤔 고민했던 내용


## 💬 리뷰 중점사항


## 🔗관련 이슈
- Close #이슈번호

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 동아리 대시보드에 표시되는 지원자 목록을 개선했습니다. 이제 실제 지원서를 제출한 회원만 정확하게 필터링되어 표시됩니다.

* **Tests**
  * 지원자 필터링 로직의 정확성을 검증하는 테스트를 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->