### PR TITLE
[FEATURE] 관리자 기능 - 동아리 관리자와 동아리를 연결하는 api

### DIFF
--- a/src/main/java/com/kakaotech/team18/backend_server/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/admin/controller/AdminController.java
@@ -4,6 +4,7 @@ import com.kakaotech.team18.backend_server.domain.admin.dto.LinkClubRequestDto;
 import com.kakaotech.team18.backend_server.domain.admin.service.AdminService;
 import com.kakaotech.team18.backend_server.global.dto.SuccessResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -12,9 +13,11 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "System Admin", description = "system_admin 전용 API")
@@ -53,9 +56,10 @@ public class AdminController {
                     content = @Content
             )
     })
-    @PreAuthorize("hasRole('SYSTEM_ADMIN')")
+    @PreAuthorize("@customSecurityService.isSystemAdmin()")
     @PostMapping("/linkClub")
     public ResponseEntity<SuccessResponseDto> linkClubPresident(
+            @Parameter(description = "요청을 보내는 사용자의 ID", example = "15") @RequestParam("userId")Long userId,
             @Valid @RequestBody LinkClubRequestDto requestDto
     ) {
         SuccessResponseDto response = adminService.linkClubPresident(requestDto);

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/admin/controller/AdminController.java
@@ -1,0 +1,64 @@
+package com.kakaotech.team18.backend_server.domain.admin.controller;
+
+import com.kakaotech.team18.backend_server.domain.admin.dto.LinkClubRequestDto;
+import com.kakaotech.team18.backend_server.domain.admin.service.AdminService;
+import com.kakaotech.team18.backend_server.global.dto.SuccessResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "System Admin", description = "system_admin 전용 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin")
+public class AdminController {
+
+    private final AdminService adminService;
+
+    @Operation(
+            summary = "동아리장/임원과 동아리 연결",
+            description = """
+                    system_admin 계정이 학번, 동아리 이름, 직책(Role)을 입력해서
+                    club_member 레코드를 생성합니다.
+
+                    - 학번으로 User 조회 (없으면 InvalidStudentIdException)
+                    - 동아리명으로 Club 조회 (없으면 InvalidClubNameException)
+                    - 동일 User/Club/Role/ACTIVE 이미 존재 시 DuplicateClubMemberException
+                    - 회장(CLUB_ADMIN)인데 이미 해당 클럽에 회장이 있으면 DuplicateClubAdminException
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "동아리장/임원 연결 성공"
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "유효하지 않은 입력 값 (InvalidStudentIdException, InvalidClubNameException)",
+                    content = @Content
+            ),
+            @ApiResponse(
+                    responseCode = "409",
+                    description = "이미 존재하는 동아리원/동아리 회장 (DuplicateClubMemberException, DuplicateClubAdminException)",
+                    content = @Content
+            )
+    })
+    @PreAuthorize("hasRole('SYSTEM_ADMIN')")
+    @PostMapping("/linkClub")
+    public ResponseEntity<SuccessResponseDto> linkClubPresident(
+            @Valid @RequestBody LinkClubRequestDto requestDto
+    ) {
+        SuccessResponseDto response = adminService.linkClubPresident(requestDto);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/admin/dto/LinkClubRequestDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/admin/dto/LinkClubRequestDto.java
@@ -1,0 +1,23 @@
+package com.kakaotech.team18.backend_server.domain.admin.dto;
+
+import com.kakaotech.team18.backend_server.domain.clubMember.entity.Role;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "동아리장(임원) - 동아리 연결 요청 DTO")
+public record LinkClubRequestDto(
+
+        @Schema(description = "동아리장 학번", example = "202312345")
+        @NotBlank(message = "학번은 필수 값입니다.")
+        String studentId,
+
+        @Schema(description = "동아리 이름", example = "인터엑스")
+        @NotBlank(message = "동아리 이름은 필수 값입니다.")
+        String clubName,
+
+        @Schema(description = "동아리 내 직책", example = "CLUB_ADMIN")
+        @NotNull(message = "직책은 필수 값입니다.")
+        Role role
+) {
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/admin/service/AdminService.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/admin/service/AdminService.java
@@ -1,0 +1,7 @@
+package com.kakaotech.team18.backend_server.domain.admin.service;
+
+import com.kakaotech.team18.backend_server.domain.admin.dto.LinkClubRequestDto;
+
+public interface AdminService {
+    void linkClubPresident(LinkClubRequestDto requestDto);
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/admin/service/AdminService.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/admin/service/AdminService.java
@@ -1,7 +1,8 @@
 package com.kakaotech.team18.backend_server.domain.admin.service;
 
 import com.kakaotech.team18.backend_server.domain.admin.dto.LinkClubRequestDto;
+import com.kakaotech.team18.backend_server.global.dto.SuccessResponseDto;
 
 public interface AdminService {
-    void linkClubPresident(LinkClubRequestDto requestDto);
+    SuccessResponseDto linkClubPresident(LinkClubRequestDto requestDto);
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/admin/service/AdminServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/admin/service/AdminServiceImpl.java
@@ -1,0 +1,58 @@
+package com.kakaotech.team18.backend_server.domain.admin.service;
+
+import com.kakaotech.team18.backend_server.domain.admin.dto.LinkClubRequestDto;
+import com.kakaotech.team18.backend_server.domain.club.entity.Club;
+import com.kakaotech.team18.backend_server.domain.club.repository.ClubRepository;
+import com.kakaotech.team18.backend_server.domain.clubMember.entity.ActiveStatus;
+import com.kakaotech.team18.backend_server.domain.clubMember.entity.ClubMember;
+import com.kakaotech.team18.backend_server.domain.clubMember.entity.Role;
+import com.kakaotech.team18.backend_server.domain.clubMember.repository.ClubMemberRepository;
+import com.kakaotech.team18.backend_server.domain.user.entity.User;
+import com.kakaotech.team18.backend_server.domain.user.repository.UserRepository;
+import com.kakaotech.team18.backend_server.global.exception.exceptions.DuplicateClubAdminException;
+import com.kakaotech.team18.backend_server.global.exception.exceptions.DuplicateClubMemberException;
+import com.kakaotech.team18.backend_server.global.exception.exceptions.InvalidClubNameException;
+import com.kakaotech.team18.backend_server.global.exception.exceptions.InvalidStudentIdException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class AdminServiceImpl implements AdminService {
+
+    private final UserRepository userRepository;
+    private final ClubRepository clubRepository;
+    private final ClubMemberRepository clubMemberRepository;
+
+    @Override
+    public void linkClubPresident(LinkClubRequestDto requestDto) {
+
+        User user = userRepository.findByStudentId(requestDto.studentId())
+                .orElseThrow(() -> new InvalidStudentIdException("등록되지 않은 학번입니다. 학번 : "+ requestDto.studentId()));
+
+        Club club = clubRepository.findByName(requestDto.clubName())
+                .orElseThrow(() -> new InvalidClubNameException("해당 이름의 동아리가 존재하지 않습니다. 동아리 :"+ requestDto.clubName()));
+
+        if (clubMemberRepository.existsByUserAndClubAndClubRoleAndActiveStatus(user, club, requestDto.role(), ActiveStatus.ACTIVE)) {
+             throw new DuplicateClubMemberException("이미 해당 동아리원이 존재합니다. 이름 : "+user.getName()+"동아리 : "+club.getName());
+        }
+
+        if (requestDto.role() == Role.CLUB_ADMIN){
+            if (clubMemberRepository.existsByClubAndRole(club, requestDto.role())) {
+                throw new DuplicateClubAdminException("이미 해당 동아리의 회장이 존재합니다. 동아리 : "+club.getName());
+            }
+        }
+
+        ClubMember clubMember = ClubMember.builder()
+                .user(user)
+                .club(club)
+                .application(null)
+                .role(requestDto.role())
+                .activeStatus(ActiveStatus.ACTIVE)
+                .build();
+
+        clubMemberRepository.save(clubMember);
+    }
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/admin/service/AdminServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/admin/service/AdminServiceImpl.java
@@ -15,9 +15,11 @@ import com.kakaotech.team18.backend_server.global.exception.exceptions.Duplicate
 import com.kakaotech.team18.backend_server.global.exception.exceptions.InvalidClubNameException;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.InvalidStudentIdException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -32,19 +34,23 @@ public class AdminServiceImpl implements AdminService {
 
         User user = userRepository.findByStudentId(requestDto.studentId())
                 .orElseThrow(() -> new InvalidStudentIdException("등록되지 않은 학번입니다. 학번 : "+ requestDto.studentId()));
+        log.info("User checked successfully");
 
         Club club = clubRepository.findByName(requestDto.clubName())
                 .orElseThrow(() -> new InvalidClubNameException("해당 이름의 동아리가 존재하지 않습니다. 동아리 :"+ requestDto.clubName()));
+        log.info("Club checked successfully");
 
         if (clubMemberRepository.existsByUserAndClubAndClubRoleAndActiveStatus(user, club, requestDto.role(), ActiveStatus.ACTIVE)) {
              throw new DuplicateClubMemberException("이미 해당 동아리원이 존재합니다. 이름 : "+user.getName()+"동아리 : "+club.getName());
         }
+        log.info("duplicate ClubMember checked successfully");
 
         if (requestDto.role() == Role.CLUB_ADMIN){
             if (clubMemberRepository.existsByClubAndRole(club, requestDto.role())) {
                 throw new DuplicateClubAdminException("이미 해당 동아리의 회장이 존재합니다. 동아리 : "+club.getName());
             }
         }
+        log.info("duplicate president checked successfully");
 
         ClubMember clubMember = ClubMember.builder()
                 .user(user)
@@ -55,6 +61,7 @@ public class AdminServiceImpl implements AdminService {
                 .build();
 
         clubMemberRepository.save(clubMember);
+        log.info("ClubMember added successfully");
 
         return new SuccessResponseDto(true);
     }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/admin/service/AdminServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/admin/service/AdminServiceImpl.java
@@ -9,6 +9,7 @@ import com.kakaotech.team18.backend_server.domain.clubMember.entity.Role;
 import com.kakaotech.team18.backend_server.domain.clubMember.repository.ClubMemberRepository;
 import com.kakaotech.team18.backend_server.domain.user.entity.User;
 import com.kakaotech.team18.backend_server.domain.user.repository.UserRepository;
+import com.kakaotech.team18.backend_server.global.dto.SuccessResponseDto;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.DuplicateClubAdminException;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.DuplicateClubMemberException;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.InvalidClubNameException;
@@ -27,7 +28,7 @@ public class AdminServiceImpl implements AdminService {
     private final ClubMemberRepository clubMemberRepository;
 
     @Override
-    public void linkClubPresident(LinkClubRequestDto requestDto) {
+    public SuccessResponseDto linkClubPresident(LinkClubRequestDto requestDto) {
 
         User user = userRepository.findByStudentId(requestDto.studentId())
                 .orElseThrow(() -> new InvalidStudentIdException("등록되지 않은 학번입니다. 학번 : "+ requestDto.studentId()));
@@ -54,5 +55,7 @@ public class AdminServiceImpl implements AdminService {
                 .build();
 
         clubMemberRepository.save(clubMember);
+
+        return new SuccessResponseDto(true);
     }
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/admin/service/AdminServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/admin/service/AdminServiceImpl.java
@@ -61,7 +61,7 @@ public class AdminServiceImpl implements AdminService {
                 .build();
 
         clubMemberRepository.save(clubMember);
-        log.info("ClubMember added successfully");
+        log.info("ClubMember added successfully 이름 : "+user.getName()+"동아리 : "+club.getName());
 
         return new SuccessResponseDto(true);
     }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/repository/ClubMemberRepository.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/repository/ClubMemberRepository.java
@@ -2,6 +2,7 @@ package com.kakaotech.team18.backend_server.domain.clubMember.repository;
 
 import com.kakaotech.team18.backend_server.domain.application.entity.Stage;
 import com.kakaotech.team18.backend_server.domain.application.entity.Status;
+import com.kakaotech.team18.backend_server.domain.club.entity.Club;
 import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMembershipInfo;
 import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubListInfoDto;
 import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMembershipInfo;
@@ -11,6 +12,8 @@ import com.kakaotech.team18.backend_server.domain.clubMember.entity.Role;
 import com.kakaotech.team18.backend_server.domain.user.entity.User;
 import java.util.List;
 import java.util.Optional;
+
+import jakarta.validation.constraints.NotNull;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -95,4 +98,8 @@ public interface ClubMemberRepository extends JpaRepository<ClubMember, Long> {
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("update ClubMember cm set cm.application = null where cm.application.id = :applicationId")
     int clearApplicationByApplicationId(Long applicationId);
+
+    boolean existsByUserAndClubAndClubRoleAndActiveStatus(User user, Club club, @NotNull(message = "직책은 필수 값입니다.") Role role, ActiveStatus activeStatus);
+
+    boolean existsByClubAndRole(Club club, @NotNull(message = "직책은 필수 값입니다.") Role role);
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/global/exception/code/ErrorCode.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/exception/code/ErrorCode.java
@@ -35,6 +35,8 @@ public enum ErrorCode {
     ILLEGAL_ARGUMENT_JWT("토큰의 인자가 잘못되었습니다.", HttpStatus.BAD_REQUEST),
     INVALID_FILE("잘못된 파일 형식입니다.", HttpStatus.BAD_REQUEST),
     TOO_LARGE_FILE("업로드 하려는 파일 크기가 너무 큽니다", HttpStatus.BAD_REQUEST),
+    INVALID_STUDENT_ID("등록되지 않은 학번입니다.", HttpStatus.BAD_REQUEST),
+    INVALID_CLUB_NAME("해당 이름의 동아리가 존재하지 않습니다.", HttpStatus.BAD_REQUEST),
 
     // 401 UNAUTHORIZED: 인증되지 않은 사용자
     UNAUTHENTICATED_USER("인증되지 않은 사용자입니다.", HttpStatus.UNAUTHORIZED),
@@ -70,6 +72,8 @@ public enum ErrorCode {
     // 409 CONFLICT: 리소스 충돌
     USER_ALREADY_EXISTS("이미 존재하는 유저입니다.", HttpStatus.CONFLICT),
     TEMPORARY_SERVER_CONFLICT("일시적인 요청 충돌이 발생했습니다. 잠시 후 다시 시도해주세요.", HttpStatus.CONFLICT),
+    DUPLICATE_CLUB_MEMBER("이미 해당 동아리원이 존재합니다.", HttpStatus.CONFLICT),
+    DUPLICATE_CLUB_ADMIN("이미 해당 동아리의 회장이 존재합니다.", HttpStatus.CONFLICT),
 
     // 422 UNPROCESSABLE_ENTITY
     EMAIL_RECIPIENT_INVALID ("수신자 주소가 존재하지 않음", HttpStatus.UNPROCESSABLE_ENTITY),

--- a/src/main/java/com/kakaotech/team18/backend_server/global/exception/exceptions/DuplicateClubAdminException.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/exception/exceptions/DuplicateClubAdminException.java
@@ -1,0 +1,10 @@
+package com.kakaotech.team18.backend_server.global.exception.exceptions;
+
+import com.kakaotech.team18.backend_server.global.exception.code.ErrorCode;
+
+public class DuplicateClubAdminException extends CustomException {
+
+    public DuplicateClubAdminException(String detail) {
+        super(ErrorCode.DUPLICATE_CLUB_ADMIN, detail);
+    }
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/global/exception/exceptions/DuplicateClubMemberException.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/exception/exceptions/DuplicateClubMemberException.java
@@ -1,0 +1,10 @@
+package com.kakaotech.team18.backend_server.global.exception.exceptions;
+
+import com.kakaotech.team18.backend_server.global.exception.code.ErrorCode;
+
+public class DuplicateClubMemberException extends CustomException {
+
+    public DuplicateClubMemberException(String detail) {
+        super(ErrorCode.DUPLICATE_CLUB_MEMBER, detail);
+    }
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/global/exception/exceptions/InvalidClubNameException.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/exception/exceptions/InvalidClubNameException.java
@@ -1,0 +1,10 @@
+package com.kakaotech.team18.backend_server.global.exception.exceptions;
+
+import com.kakaotech.team18.backend_server.global.exception.code.ErrorCode;
+
+public class InvalidClubNameException extends CustomException {
+
+  public InvalidClubNameException(String detail) {
+    super(ErrorCode.INVALID_CLUB_NAME, detail);
+  }
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/global/exception/exceptions/InvalidStudentIdException.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/exception/exceptions/InvalidStudentIdException.java
@@ -1,0 +1,10 @@
+package com.kakaotech.team18.backend_server.global.exception.exceptions;
+
+import com.kakaotech.team18.backend_server.global.exception.code.ErrorCode;
+
+public class InvalidStudentIdException extends CustomException {
+
+    public InvalidStudentIdException(String detail) {
+        super(ErrorCode.INVALID_STUDENT_ID, detail);
+    }
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/global/security/CustomSecurityService.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/security/CustomSecurityService.java
@@ -85,4 +85,15 @@ public class CustomSecurityService {
         return Objects.equals(userRoleForClub, Role.CLUB_ADMIN.name()) ||
                Objects.equals(userRoleForClub, Role.CLUB_EXECUTIVE.name());
     }
+
+    public boolean isSystemAdmin() {
+        // 1. 현재 인증된 사용자 정보 가져오기
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !(authentication.getPrincipal() instanceof PrincipalDetails principalDetails)) {
+            return false; // 인증되지 않았거나, Principal 타입이 다르면 거부
+        }
+
+        // 2. SYSTEM_ADMIN 인지 검사
+        return principalDetails.getAuthorities().stream().anyMatch(a -> a.getAuthority().equals(Role.SYSTEM_ADMIN.name()));
+    }
 }

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/admin/service/AdminServiceImplTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/admin/service/AdminServiceImplTest.java
@@ -1,0 +1,202 @@
+package com.kakaotech.team18.backend_server.domain.admin.service;
+
+import com.kakaotech.team18.backend_server.domain.admin.dto.LinkClubRequestDto;
+import com.kakaotech.team18.backend_server.domain.club.entity.Club;
+import com.kakaotech.team18.backend_server.domain.club.repository.ClubRepository;
+import com.kakaotech.team18.backend_server.domain.clubMember.entity.ActiveStatus;
+import com.kakaotech.team18.backend_server.domain.clubMember.entity.ClubMember;
+import com.kakaotech.team18.backend_server.domain.clubMember.entity.Role;
+import com.kakaotech.team18.backend_server.domain.clubMember.repository.ClubMemberRepository;
+import com.kakaotech.team18.backend_server.domain.user.entity.User;
+import com.kakaotech.team18.backend_server.domain.user.repository.UserRepository;
+import com.kakaotech.team18.backend_server.global.exception.exceptions.DuplicateClubAdminException;
+import com.kakaotech.team18.backend_server.global.exception.exceptions.DuplicateClubMemberException;
+import com.kakaotech.team18.backend_server.global.exception.exceptions.InvalidClubNameException;
+import com.kakaotech.team18.backend_server.global.exception.exceptions.InvalidStudentIdException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AdminServiceImplTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private ClubRepository clubRepository;
+
+    @Mock
+    private ClubMemberRepository clubMemberRepository;
+
+    @InjectMocks
+    private AdminServiceImpl adminService;
+
+    @DisplayName("동아리장/임원 연결 - 성공")
+    @Test
+    void linkClubPresident_success() {
+        // given
+        String studentId = "202312345";
+        String clubName = "인터엑스";
+        Role role = Role.CLUB_EXECUTIVE;
+
+        LinkClubRequestDto requestDto = new LinkClubRequestDto(studentId, clubName, role);
+
+        User user = User.builder()
+                .studentId(studentId)
+                .name("홍길동")
+                .build();
+
+        Club club = Club.builder()
+                .name(clubName)
+                .build();
+
+        when(userRepository.findByStudentId(studentId)).thenReturn(Optional.of(user));
+        when(clubRepository.findByName(clubName)).thenReturn(Optional.of(club));
+        when(clubMemberRepository.existsByUserAndClubAndClubRoleAndActiveStatus(
+                user, club, role, ActiveStatus.ACTIVE
+        )).thenReturn(false);
+
+        // when
+        adminService.linkClubPresident(requestDto);
+
+        // then
+        ArgumentCaptor<ClubMember> captor = ArgumentCaptor.forClass(ClubMember.class);
+        verify(clubMemberRepository).save(captor.capture());
+
+        ClubMember saved = captor.getValue();
+        assertThat(saved.getUser()).isEqualTo(user);
+        assertThat(saved.getClub()).isEqualTo(club);
+        assertThat(saved.getRole()).isEqualTo(role);
+        assertThat(saved.getActiveStatus()).isEqualTo(ActiveStatus.ACTIVE);
+        assertThat(saved.getApplication()).isNull();
+
+        verify(clubMemberRepository, never()).existsByClubAndRole(club, Role.CLUB_ADMIN);
+    }
+
+    @DisplayName("동아리장/임원 연결 - 학번이 존재하지 않으면 InvalidStudentIdException 발생")
+    @Test
+    void linkClubPresident_invalidStudentId() {
+        // given
+        String studentId = "999999999";
+        String clubName = "인터엑스";
+
+        LinkClubRequestDto requestDto = new LinkClubRequestDto(studentId, clubName, Role.CLUB_ADMIN);
+
+        when(userRepository.findByStudentId(studentId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> adminService.linkClubPresident(requestDto))
+                .isInstanceOf(InvalidStudentIdException.class)
+                .hasMessageContaining("등록되지 않은 학번입니다.");
+
+        verify(clubRepository, never()).findByName(clubName);
+        verify(clubMemberRepository, never()).save(any());
+    }
+
+    @DisplayName("동아리장/임원 연결 - 동아리 이름이 존재하지 않으면 InvalidClubNameException 발생")
+    @Test
+    void linkClubPresident_invalidClubName() {
+        // given
+        String studentId = "202312345";
+        String clubName = "없는동아리";
+
+        LinkClubRequestDto requestDto = new LinkClubRequestDto(studentId, clubName, Role.CLUB_ADMIN);
+
+        User user = User.builder()
+                .studentId(studentId)
+                .name("홍길동")
+                .build();
+
+        when(userRepository.findByStudentId(studentId)).thenReturn(Optional.of(user));
+        when(clubRepository.findByName(clubName)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> adminService.linkClubPresident(requestDto))
+                .isInstanceOf(InvalidClubNameException.class)
+                .hasMessageContaining("해당 이름의 동아리가 존재하지 않습니다.");
+
+        verify(clubMemberRepository, never()).save(any());
+    }
+
+    @DisplayName("동아리장/임원 연결 - 이미 동일한 ACTIVE 동아리원이 존재하면 DuplicateClubMemberException 발생")
+    @Test
+    void linkClubPresident_duplicateClubMember() {
+        // given
+        String studentId = "202312345";
+        String clubName = "인터엑스";
+        Role role = Role.CLUB_EXECUTIVE;
+
+        LinkClubRequestDto requestDto = new LinkClubRequestDto(studentId, clubName, role);
+
+        User user = User.builder()
+                .studentId(studentId)
+                .name("홍길동")
+                .build();
+
+        Club club = Club.builder()
+                .name(clubName)
+                .build();
+
+        when(userRepository.findByStudentId(studentId)).thenReturn(Optional.of(user));
+        when(clubRepository.findByName(clubName)).thenReturn(Optional.of(club));
+        when(clubMemberRepository.existsByUserAndClubAndClubRoleAndActiveStatus(
+                user, club, role, ActiveStatus.ACTIVE
+        )).thenReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> adminService.linkClubPresident(requestDto))
+                .isInstanceOf(DuplicateClubMemberException.class)
+                .hasMessageContaining("이미 해당 동아리원이 존재합니다.");
+
+        verify(clubMemberRepository, never()).save(any());
+    }
+
+    @DisplayName("동아리장 연결 - 회장(CLUB_ADMIN) 추가 시 이미 회장이 있으면 DuplicateClubAdminException 발생")
+    @Test
+    void linkClubPresident_duplicateClubAdmin() {
+        // given
+        String studentId = "202312345";
+        String clubName = "인터엑스";
+        Role role = Role.CLUB_ADMIN;
+
+        LinkClubRequestDto requestDto = new LinkClubRequestDto(studentId, clubName, role);
+
+        User user = User.builder()
+                .studentId(studentId)
+                .name("홍길동")
+                .build();
+
+        Club club = Club.builder()
+                .name(clubName)
+                .build();
+
+        when(userRepository.findByStudentId(studentId)).thenReturn(Optional.of(user));
+        when(clubRepository.findByName(clubName)).thenReturn(Optional.of(club));
+        when(clubMemberRepository.existsByUserAndClubAndClubRoleAndActiveStatus(
+                user, club, role, ActiveStatus.ACTIVE
+        )).thenReturn(false);
+        when(clubMemberRepository.existsByClubAndRole(club, role)).thenReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> adminService.linkClubPresident(requestDto))
+                .isInstanceOf(DuplicateClubAdminException.class)
+                .hasMessageContaining("이미 해당 동아리의 회장이 존재합니다.");
+
+        verify(clubMemberRepository, never()).save(any());
+    }
+}


### PR DESCRIPTION
## 🚀 작업 내용
시스템 관리자가 동아리관리자와 동아리를 연결하는 api 를 만들었습니다. 

/api/admin/linkClub으로 post

백에서는 해당 학번으로 user_id 조회
동아리 이름으로 club_id 조회
active_status = ACTIVE
applicaiton_id = null
club_role = 직책
이렇게 club_member 생성 삽입

성공으로 boolean successResponseDto true 반환
실패 시나리오:
존재하지 않는 동아리 이름 -> InvalidClubNameException(잘못된 요청400) 으로 에러반환 message:해당 이름의 동아리가 존재하지 않습니다.
존재하지 않는 학번 -> InvalidStudentIdException(잘못된 요청 400) 으로 에러반환 message:등록되지 않은 학번입니다.
이미 등록된 club_member ->DuplicateClubMemberException(409) 이미 등록된 동아리원입니다
회장을 등록하는데, 이미 회장이 있는 경우 ->DuplicateClubAdminException(409) 이미 회장이 있습니다

🙋🏻 참고 자료

## ⏱️ 소요 시간
1h

## 🤔 고민했던 내용


## 💬 리뷰 중점사항
인증 인가 문제없는지 확인 부탁드려요

## 🔗관련 이슈
- Close #226 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 시스템 관리자 전용으로 학생과 동아리를 연결하는 관리자용 API 추가
  * 연결 요청을 위한 입력 DTO와 표준화된 성공 응답 포맷 제공
  * 시스템 관리자 권한 확인 로직 강화

* **버그 수정 / 검증**
  * 중복 동아리원 및 중복 회장 등록 방지 검증 추가
  * 유효하지 않은 학번·동아리명에 대한 명확한 오류 처리 및 코드 추가

* **테스트**
  * 연결 흐름의 성공 및 오류 경로를 다루는 단위 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->