### PR TITLE
[FIX] 공지사항 조회, 동아리 리뷰 작성 인증 필요없도록 수정

### DIFF
--- a/src/main/java/com/kakaotech/team18/backend_server/global/config/SecurityConfig.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/config/SecurityConfig.java
@@ -67,14 +67,16 @@ public class SecurityConfig {
 
         http.authorizeHttpRequests(authorize -> authorize
                 .requestMatchers("/api/auth/**", "/swagger-ui.html", "/v3/api-docs/**", "/swagger-ui/**").permitAll()
+                // 공지사항 조회 관련 API (공개)
+                .requestMatchers(HttpMethod.GET, "/api/notices", "/api/notices/*").permitAll()
                 // 동아리 정보 조회 관련 API (공개)
                 .requestMatchers(HttpMethod.GET, "/api/clubs", "/api/clubs/*").permitAll()
                 // 지원서 양식 조회 API (공개)
                 .requestMatchers(HttpMethod.GET, "/api/clubs/*/apply").permitAll()
                 // 지원서 제출 API (공개)
                 .requestMatchers(HttpMethod.POST, "/api/clubs/*/apply-submit").permitAll()
-                // 동아리 후기 조회 API (공개)
-                .requestMatchers(HttpMethod.GET, "/api/clubs/*/reviews").permitAll()
+                // 동아리 후기 조회 및 등록 API (공개)
+                .requestMatchers("/api/clubs/*/reviews").permitAll()
                 .anyRequest().authenticated()
         );
 


### PR DESCRIPTION
[FIX] 공지사항 조회, 동아리 리뷰 작성 인증 필요없도록 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 공지사항 목록과 개별 공지 조회를 로그인 없이 이용할 수 있습니다. 비회원도 즉시 접근 가능합니다.
  - 동아리 리뷰 관련 엔드포인트가 모든 요청 방식에서 공개되었습니다. 기존에 제한되던 GET 전용 접근이 해제되어, 동일 경로의 모든 메서드가 인증 없이 처리됩니다. 다른 경로의 접근 정책은 기존과 동일하게 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->