### PR TITLE
[chore] 지원서 제출시 exception 추가(#231)

### DIFF
--- a/src/main/java/com/kakaotech/team18/backend_server/domain/application/controller/ApplicationController.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/application/controller/ApplicationController.java
@@ -72,7 +72,8 @@ public class ApplicationController {
     )
     @ApiResponses({
             @ApiResponse(responseCode = "201", description = "신규 제출 완료"),
-            @ApiResponse(responseCode = "202", description = "기존 제출이 있어 덮어쓰기 확인 필요")
+            @ApiResponse(responseCode = "202", description = "기존 제출이 있어 덮어쓰기 확인 필요"),
+            @ApiResponse(responseCode = "409", description = "user 생성오류")
     })
     @PostMapping("/{clubId}/apply-submit")
     public ResponseEntity<ApplicationApplyResponseDto> submitApplication(

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/application/service/ApplicationServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/application/service/ApplicationServiceImpl.java
@@ -33,6 +33,10 @@ import com.kakaotech.team18.backend_server.domain.user.repository.UserRepository
 import com.kakaotech.team18.backend_server.global.dto.SuccessResponseDto;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.ApplicationNotFoundException;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.ClubApplyFormNotFoundException;
+import com.kakaotech.team18.backend_server.global.exception.exceptions.ExistingUserEmailException;
+import com.kakaotech.team18.backend_server.global.exception.exceptions.ExistingUserNameException;
+import com.kakaotech.team18.backend_server.global.exception.exceptions.ExistingUserPhoneNumberException;
+import com.kakaotech.team18.backend_server.global.exception.exceptions.ExistingUserStudentIdException;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.InvalidAnswerException;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -143,18 +147,36 @@ public class ApplicationServiceImpl implements ApplicationService {
         //1. applicationForm 찾기
         ClubApplyForm form = clubApplyFormRepository.findByClubId(clubId)
                 .orElseThrow(() -> new ClubApplyFormNotFoundException("clubId:"+clubId));
+        //근데 이 exception이 현실적으로 발생 가능한가?
+        //만약 제출폼을 작성하는 사이에 폼이 수정되었다면?
 
         //2. 유저 정보생성(없으면 생성)
         User user = userRepository.findByStudentId(request.studentId())
                 .orElseGet(() -> {
-                    User newUser = User.builder()
-                            .studentId(request.studentId())
-                            .email(request.email())
-                            .name(request.name())
-                            .phoneNumber(request.phoneNumber())
-                            .department(request.department())
-                            .build();
-                    return userRepository.save(newUser);
+                    if (userRepository.existsByName(request.name())) {
+                        log.warn("학번이 다른데, 이미존재하는 이름으로 접수. 학번 : "+request.studentId()+"이름 : "+request.name());
+                        throw new ExistingUserNameException("학번이 다른데, 이미존재하는 이름으로 접수. 이름 : "+request.name());
+                    }
+                    if (userRepository.existsByEmail(request.email())) {
+                        log.warn("학번이 다른데, 이미 존재하는 이메일로 접수. 학번 : "+request.studentId()+"이메일 : "+request.email());
+                        throw new ExistingUserEmailException("학번이 다른데, 이미존재하는 이메일로 접수. 이메일 : "+request.email());
+                    }
+                    if (userRepository.existsByPhoneNumber(request.phoneNumber())) {
+                        log.warn("학번이 다른데, 이미 존재하는 번호로 접수. 학번 : "+request.studentId()+"번호 : "+request.phoneNumber());
+                        throw new ExistingUserPhoneNumberException("학번이 다른데, 이미존재하는 전화번호로 접수. 전화번호 : "+request.phoneNumber());
+                    }
+                    try {
+                        User newUser = User.builder()
+                                .studentId(request.studentId())
+                                .email(request.email())
+                                .name(request.name())
+                                .phoneNumber(request.phoneNumber())
+                                .department(request.department())
+                                .build();
+                        return userRepository.save(newUser);
+                    } catch (Exception e) {
+                        log.warn("나머지 정보가 다른데, 이미 존재하는 학번으로 접수. 학번 : "+request.studentId());
+                        throw new ExistingUserStudentIdException("나머지 정보가 다른데, 이미존재하는 학번으로 접수, 학번 : "+request.studentId());}
                 });
 
         //3. (폼+학번)으로 지원내역이 있는지 찾기

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/user/repository/UserRepository.java
@@ -1,6 +1,9 @@
 package com.kakaotech.team18.backend_server.domain.user.repository;
 
 import com.kakaotech.team18.backend_server.domain.user.entity.User;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -24,4 +27,10 @@ public interface UserRepository extends JpaRepository<User, Long> {
      * @return Optional<User> 사용자 정보 또는 빈 Optional
      */
     Optional<User> findByStudentId(String studentId);
+
+    boolean existsByName(@NotBlank(message = "이름은 필수입니다.") String name);
+
+    boolean existsByEmail(@NotBlank(message = "이메일은 필수입니다.") @Email(message = "유효한 이메일 형식이 아닙니다.") String email);
+
+    boolean existsByPhoneNumber(@Pattern(regexp = "^010-\\d{4}-\\d{4}$", message = "전화번호는 010-xxxx-xxxx 형식이어야 합니다.") String s);
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/user/repository/UserRepository.java
@@ -28,9 +28,9 @@ public interface UserRepository extends JpaRepository<User, Long> {
      */
     Optional<User> findByStudentId(String studentId);
 
-    boolean existsByName(@NotBlank(message = "이름은 필수입니다.") String name);
+    boolean existsByName(String name);
 
-    boolean existsByEmail(@NotBlank(message = "이메일은 필수입니다.") @Email(message = "유효한 이메일 형식이 아닙니다.") String email);
+    boolean existsByEmail(String email);
 
-    boolean existsByPhoneNumber(@Pattern(regexp = "^010-\\d{4}-\\d{4}$", message = "전화번호는 010-xxxx-xxxx 형식이어야 합니다.") String s);
+    boolean existsByPhoneNumber(String s);
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/global/exception/code/ErrorCode.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/exception/code/ErrorCode.java
@@ -71,7 +71,7 @@ public enum ErrorCode {
     USER_ALREADY_EXISTS("이미 존재하는 유저입니다.", HttpStatus.CONFLICT),
     TEMPORARY_SERVER_CONFLICT("일시적인 요청 충돌이 발생했습니다. 잠시 후 다시 시도해주세요.", HttpStatus.CONFLICT),
     EXISTING_USER_NAME("학번이 다른데, 이미존재하는 이름으로 접수.", HttpStatus.CONFLICT),
-    Existing_USER_EMAIL("학번이 다른데, 이미존재하는 이메일로 접수.", HttpStatus.CONFLICT),
+    EXISTING_USER_EMAIL("학번이 다른데, 이미존재하는 이메일로 접수.", HttpStatus.CONFLICT),
     EXISTING_USER_PHONE_NUMBER("학번이 다른데, 이미존재하는 전화번호로 접수.", HttpStatus.CONFLICT),
     EXISTING_USER_STUDENT_ID("나머지 정보가 다른데, 이미존재하는 학번으로 접수.",  HttpStatus.CONFLICT),
 

--- a/src/main/java/com/kakaotech/team18/backend_server/global/exception/code/ErrorCode.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/exception/code/ErrorCode.java
@@ -70,6 +70,10 @@ public enum ErrorCode {
     // 409 CONFLICT: 리소스 충돌
     USER_ALREADY_EXISTS("이미 존재하는 유저입니다.", HttpStatus.CONFLICT),
     TEMPORARY_SERVER_CONFLICT("일시적인 요청 충돌이 발생했습니다. 잠시 후 다시 시도해주세요.", HttpStatus.CONFLICT),
+    EXISTING_USER_NAME("학번이 다른데, 이미존재하는 이름으로 접수.", HttpStatus.CONFLICT),
+    Existing_USER_EMAIL("학번이 다른데, 이미존재하는 이메일로 접수.", HttpStatus.CONFLICT),
+    EXISTING_USER_PHONE_NUMBER("학번이 다른데, 이미존재하는 전화번호로 접수.", HttpStatus.CONFLICT),
+    EXISTING_USER_STUDENT_ID("나머지 정보가 다른데, 이미존재하는 학번으로 접수.",  HttpStatus.CONFLICT),
 
     // 422 UNPROCESSABLE_ENTITY
     EMAIL_RECIPIENT_INVALID ("수신자 주소가 존재하지 않음", HttpStatus.UNPROCESSABLE_ENTITY),

--- a/src/main/java/com/kakaotech/team18/backend_server/global/exception/exceptions/ExistingUserEmailException.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/exception/exceptions/ExistingUserEmailException.java
@@ -1,0 +1,9 @@
+package com.kakaotech.team18.backend_server.global.exception.exceptions;
+
+import com.kakaotech.team18.backend_server.global.exception.code.ErrorCode;
+
+public class ExistingUserEmailException extends CustomException {
+    public ExistingUserEmailException(String message) {
+        super(ErrorCode.Existing_USER_EMAIL, message);
+    }
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/global/exception/exceptions/ExistingUserEmailException.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/exception/exceptions/ExistingUserEmailException.java
@@ -4,6 +4,6 @@ import com.kakaotech.team18.backend_server.global.exception.code.ErrorCode;
 
 public class ExistingUserEmailException extends CustomException {
     public ExistingUserEmailException(String message) {
-        super(ErrorCode.Existing_USER_EMAIL, message);
+        super(ErrorCode.EXISTING_USER_EMAIL, message);
     }
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/global/exception/exceptions/ExistingUserNameException.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/exception/exceptions/ExistingUserNameException.java
@@ -1,0 +1,9 @@
+package com.kakaotech.team18.backend_server.global.exception.exceptions;
+
+import com.kakaotech.team18.backend_server.global.exception.code.ErrorCode;
+
+public class ExistingUserNameException extends CustomException {
+    public ExistingUserNameException(String message) {
+        super(ErrorCode.EXISTING_USER_NAME, message);
+    }
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/global/exception/exceptions/ExistingUserPhoneNumberException.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/exception/exceptions/ExistingUserPhoneNumberException.java
@@ -1,0 +1,9 @@
+package com.kakaotech.team18.backend_server.global.exception.exceptions;
+
+import com.kakaotech.team18.backend_server.global.exception.code.ErrorCode;
+
+public class ExistingUserPhoneNumberException extends CustomException {
+    public ExistingUserPhoneNumberException(String message) {
+        super(ErrorCode.EXISTING_USER_PHONE_NUMBER, message);
+    }
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/global/exception/exceptions/ExistingUserStudentIdException.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/exception/exceptions/ExistingUserStudentIdException.java
@@ -1,0 +1,9 @@
+package com.kakaotech.team18.backend_server.global.exception.exceptions;
+
+import com.kakaotech.team18.backend_server.global.exception.code.ErrorCode;
+
+public class ExistingUserStudentIdException extends CustomException {
+    public ExistingUserStudentIdException(String message) {
+        super(ErrorCode.EXISTING_USER_STUDENT_ID, message);
+    }
+}


### PR DESCRIPTION
## 🚀 작업 내용
지원서 제출시 exception을 추가했습니다

ExistingUserNameException("학번이 다른데, 이미존재하는 이름으로 접수. 이름 : "+request.name())
ExistingUserEmailException("학번이 다른데, 이미존재하는 이메일로 접수. 이메일 : "+request.email())
ExistingUserPhoneNumberException("학번이 다른데, 이미존재하는 전화번호로 접수. 전화번호 : "+request.phoneNumber())
ExistingUserStudentIdException("나머지 정보가 다른데, 이미존재하는 학번으로 접수, 학번 : "+request.studentId())



## ⏱️ 소요 시간
30m

## 🤔 고민했던 내용


## 💬 리뷰 중점사항


## 🔗관련 이슈
- Close #231

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 중복 이름·이메일·휴대폰으로 가입되는 경우를 차단하는 유효성 검사 추가
  * 사용자 생성 중 발생하는 오류에 대한 예외 처리 강화

* **New Features**
  * 학번·이름·이메일·전화번호 충돌 상황에 대한 구체적인 409 응답(충돌) 메시지 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->