### PR TITLE
[REFACTOR] 로그인시 응답 dto에 userId 추가(#243)

### DIFF
--- a/src/main/java/com/kakaotech/team18/backend_server/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/auth/controller/AuthController.java
@@ -57,7 +57,7 @@ public class AuthController {
                     .maxAge(jwtProperties.refreshTokenValidityInSeconds())
                     .build();
 
-            LoginSuccessResponseDto.Body body = new LoginSuccessResponseDto.Body(dto.status(), dto.accessToken(), dto.clubAndRoleList());
+            LoginSuccessResponseDto.Body body = new LoginSuccessResponseDto.Body(dto.status(), dto.accessToken(), dto.userId(), dto.clubAndRoleList());
 
             return ResponseEntity.ok()
                     .header(HttpHeaders.SET_COOKIE, responseCookie.toString())
@@ -88,7 +88,7 @@ public class AuthController {
                 .maxAge(jwtProperties.refreshTokenValidityInSeconds())
                 .build();
 
-        LoginSuccessResponseDto.Body body = new LoginSuccessResponseDto.Body(responseDto.status(), responseDto.accessToken(), responseDto.clubAndRoleList());
+        LoginSuccessResponseDto.Body body = new LoginSuccessResponseDto.Body(responseDto.status(), responseDto.accessToken(), responseDto.userId(), responseDto.clubAndRoleList());
 
         return ResponseEntity.status(HttpStatus.CREATED)
                 .header(HttpHeaders.SET_COOKIE, responseCookie.toString())

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/auth/dto/LoginSuccessResponseDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/auth/dto/LoginSuccessResponseDto.java
@@ -15,6 +15,9 @@ public record LoginSuccessResponseDto(
         @Schema(description = "Access Token 재발급을 위한 Refresh Token")
         String refreshToken,
 
+        @Schema(description = "사용자 ID", example = "1")
+        Long userId,
+
         @Schema(description = "clubId, ClubName, Role 정보를 담은 리스트")
         List<ClubListInfoDto> clubAndRoleList
 ) implements LoginResponse {

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/auth/dto/LoginSuccessResponseDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/auth/dto/LoginSuccessResponseDto.java
@@ -29,6 +29,9 @@ public record LoginSuccessResponseDto(
                 @Schema(description = "우리 서비스의 Access Token")
                 String accessToken,
 
+                @Schema(description = "사용자 ID", example = "1")
+                Long userId,
+
                 @Schema(description = "clubId, ClubName, Role 정보를 담은 리스트")
                 List<ClubListInfoDto> clubAndRoleList
         ) implements LoginResponse {

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/auth/service/AuthServiceImpl.java
@@ -48,7 +48,6 @@ import org.springframework.web.client.RestClient;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
 
-import java.util.Optional;
 import org.springframework.web.client.RestClientResponseException;
 
 @Slf4j

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/auth/service/AuthServiceImpl.java
@@ -116,7 +116,7 @@ public class AuthServiceImpl implements AuthService {
                 clubIdAndRoleList = List.of(new ClubListInfoDto(null, null, Role.SYSTEM_ADMIN));
             }
 
-            return new LoginSuccessResponseDto(AuthStatus.LOGIN_SUCCESS, accessToken, refreshToken, clubIdAndRoleList);
+            return new LoginSuccessResponseDto(AuthStatus.LOGIN_SUCCESS, accessToken, refreshToken, user.getId(), clubIdAndRoleList);
         } else {
             // 4-2. 신규 회원일 경우: 추가 정보 입력 필요
             log.info("신규 회원, 추가 정보 입력 필요");
@@ -196,7 +196,7 @@ public class AuthServiceImpl implements AuthService {
         refreshTokenRepository.save(new RefreshToken(user.getId(), refreshToken, jwtProperties.refreshTokenValidityInSeconds()));
         log.info("Redis에 Refresh Token 저장 완료: userId={}", user.getId());
 
-        return new LoginSuccessResponseDto(AuthStatus.REGISTER_SUCCESS, accessToken, refreshToken, clubIdAndRoleList);
+        return new LoginSuccessResponseDto(AuthStatus.REGISTER_SUCCESS, accessToken, refreshToken, user.getId(), clubIdAndRoleList);
     }
 
     @Override

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/auth/controller/AuthControllerTest.java
@@ -12,7 +12,6 @@ import com.kakaotech.team18.backend_server.global.exception.code.ErrorCode;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.CustomException;
 import com.kakaotech.team18.backend_server.global.config.SecurityConfig;
 import com.kakaotech.team18.backend_server.global.config.TestSecurityConfig;
-import com.kakaotech.team18.backend_server.global.exception.code.ErrorCode;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.KakaoApiException;
 import com.kakaotech.team18.backend_server.global.security.JwtAuthenticationFilter;
 import com.kakaotech.team18.backend_server.global.security.JwtProperties;
@@ -73,7 +72,7 @@ class AuthControllerTest {
         String refreshToken = "mockRefreshToken";
         KakaoLoginRequestDto requestDto = new KakaoLoginRequestDto(authorizationCode);
 
-        LoginSuccessResponseDto serviceResponse = new LoginSuccessResponseDto(AuthStatus.LOGIN_SUCCESS, accessToken, refreshToken, List.of());
+        LoginSuccessResponseDto serviceResponse = new LoginSuccessResponseDto(AuthStatus.LOGIN_SUCCESS, accessToken, refreshToken, 1L, List.of());
 
         given(authService.kakaoLogin(authorizationCode)).willReturn(serviceResponse);
 
@@ -123,7 +122,7 @@ class AuthControllerTest {
                 "testUser", "test@example.com", "123456", "컴퓨터공학과", "010-1234-5678"
         );
 
-        LoginSuccessResponseDto serviceResponse = new LoginSuccessResponseDto(AuthStatus.REGISTER_SUCCESS, accessToken, refreshToken, List.of());
+        LoginSuccessResponseDto serviceResponse = new LoginSuccessResponseDto(AuthStatus.REGISTER_SUCCESS, accessToken, refreshToken, 1L, List.of());
 
         given(authService.register(anyString(), any(RegisterRequestDto.class))).willReturn(serviceResponse);
 


### PR DESCRIPTION
## 🚀 작업 내용
로그인/ 회원가입 성공시 반환하는 응답 dto에 userId를 추가했습니다. 
추가한 이유는 지원자의 지원서에 코멘트를 작성하는 페이지에서 본인이 작성한 코멘트인지 확인할 수 있도록 userId가 필요하기 때문입니다. 

## ⏱️ 소요 시간
20분 

## 🤔 고민했던 내용
일단 userId 정보를 로그인 성공 dto에 담아서 전달하는데 이 값을 나중에는 엑세스 토큰에 넣어도 될 것 같습니다. 


## 💬 리뷰 중점사항


## 🔗관련 이슈
- Close #243

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 로그인 및 회원가입 응답에 사용자 ID(userId)가 추가되어 클라이언트에서 사용자 식별 정보를 받을 수 있습니다.
* **테스트**
  * 인증 관련 테스트들이 응답 구조 변경에 맞춰 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->