### PR TITLE
[FEATURE] 테스트기간동안 사용할 registerDefaultClubMemberships 메서드 추가 (#245)

### DIFF
--- a/src/main/java/com/kakaotech/team18/backend_server/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/auth/service/AuthServiceImpl.java
@@ -10,11 +10,16 @@ import com.kakaotech.team18.backend_server.domain.auth.dto.RegistrationRequiredR
 import com.kakaotech.team18.backend_server.domain.auth.dto.ReissueResponseDto;
 import com.kakaotech.team18.backend_server.domain.auth.entity.RefreshToken;
 import com.kakaotech.team18.backend_server.domain.auth.repository.RefreshTokenRepository;
+import com.kakaotech.team18.backend_server.domain.club.entity.Club;
+import com.kakaotech.team18.backend_server.domain.club.repository.ClubRepository;
 import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubListInfoDto;
+import com.kakaotech.team18.backend_server.domain.clubMember.entity.ActiveStatus;
+import com.kakaotech.team18.backend_server.domain.clubMember.entity.ClubMember;
 import com.kakaotech.team18.backend_server.domain.clubMember.entity.Role;
 import com.kakaotech.team18.backend_server.domain.clubMember.repository.ClubMemberRepository;
 import com.kakaotech.team18.backend_server.domain.user.entity.User;
 import com.kakaotech.team18.backend_server.domain.user.repository.UserRepository;
+import com.kakaotech.team18.backend_server.global.exception.exceptions.ClubNotFoundException;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.DuplicateKakaoIdException;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.ExpiredRefreshTokenException;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.LoggedOutUserException;
@@ -62,6 +67,7 @@ public class AuthServiceImpl implements AuthService {
     private final RefreshTokenRepository refreshTokenRepository;
     private final JwtProperties jwtProperties;
     private final ClubMemberRepository clubMemberRepository;
+    private final ClubRepository clubRepository;
     private final RedisTemplate<String, String> redisTemplate;
 
     @Value("${spring.security.oauth2.client.registration.kakao.client-id}")
@@ -177,6 +183,8 @@ public class AuthServiceImpl implements AuthService {
                     .department(registerRequestDto.department())
                     .build();
             userRepository.save(user);
+            //TODO 테스트 기간 이후에는 제거 필요
+            registerDefaultClubMemberships(user);
         }
 
         //clubId, Role 전달
@@ -333,5 +341,25 @@ public class AuthServiceImpl implements AuthService {
     private boolean isSystemAdmin(User user) {
         return clubMemberRepository.findByUser(user).stream()
                 .anyMatch(cm -> cm.getRole() == Role.SYSTEM_ADMIN);
+    }
+
+    private void registerDefaultClubMemberships(User user) {
+        List<Long> defaultClubs = List.of(1L, 2L, 3L);
+
+        defaultClubs.forEach(clubId -> {
+            Club club = clubRepository.findById(clubId)
+                    .orElseThrow(() -> {
+                        log.error("Default club not found: {}", clubId);
+                        return new ClubNotFoundException("Default club not found: " + clubId);
+                    });
+
+            clubMemberRepository.save(ClubMember.builder()
+                    .user(user)
+                    .club(club)
+                    .activeStatus(ActiveStatus.ACTIVE)
+                    .role(Role.CLUB_EXECUTIVE)
+                    .build());
+            log.info("User {} registered as CLUB_EXECUTIVE in club {}", user.getId(), club.getName());
+        });
     }
 }

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/auth/service/AuthServiceImplTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/auth/service/AuthServiceImplTest.java
@@ -17,6 +17,8 @@ import com.kakaotech.team18.backend_server.domain.auth.dto.RegistrationRequiredR
 import com.kakaotech.team18.backend_server.domain.auth.dto.ReissueResponseDto;
 import com.kakaotech.team18.backend_server.domain.auth.entity.RefreshToken;
 import com.kakaotech.team18.backend_server.domain.auth.repository.RefreshTokenRepository;
+import com.kakaotech.team18.backend_server.domain.club.entity.Club;
+import com.kakaotech.team18.backend_server.domain.club.repository.ClubRepository;
 import com.kakaotech.team18.backend_server.domain.clubMember.repository.ClubMemberRepository;
 import com.kakaotech.team18.backend_server.domain.user.entity.User;
 import com.kakaotech.team18.backend_server.domain.user.repository.UserRepository;
@@ -53,6 +55,8 @@ class AuthServiceImplTest {
 
     @Mock
     private UserRepository userRepository;
+    @Mock
+    private ClubRepository clubRepository;
     @Mock
     private JwtProvider jwtProvider;
     @Mock
@@ -327,11 +331,29 @@ class AuthServiceImplTest {
         claims.setSubject(TokenType.TEMPORARY.name());
         claims.put("kakaoId", kakaoId);
 
+        User newUser = User.builder()
+                .kakaoId(kakaoId)
+                .name("newUser")
+                .email("new@example.com")
+                .studentId(studentId)
+                .phoneNumber("01011112222")
+                .department("컴퓨터공학과")
+                .build();
+        ReflectionTestUtils.setField(newUser, "id", 1L);
+
+        Club mockClub1 = Club.builder().build();
+        Club mockClub2 = Club.builder().build();
+        Club mockClub3 = Club.builder().build();
+
         given(jwtProvider.extractToken(bearerToken)).willReturn(temporaryToken);
         given(jwtProvider.verify(temporaryToken)).willReturn(claims);
         given(userRepository.findByStudentId(studentId)).willReturn(Optional.empty());
         given(jwtProvider.createAccessToken(any(User.class))).willReturn("newAccessToken");
         given(jwtProvider.createRefreshToken(any(User.class))).willReturn("newRefreshToken");
+        given(clubRepository.findById(1L)).willReturn(Optional.of(mockClub1));
+        given(clubRepository.findById(2L)).willReturn(Optional.of(mockClub2));
+        given(clubRepository.findById(3L)).willReturn(Optional.of(mockClub3));
+        given(clubMemberRepository.save(any())).willAnswer(invocation -> invocation.getArgument(0));
 
         // when
         LoginSuccessResponseDto result = authService.register(bearerToken, requestDto);


### PR DESCRIPTION
## 🚀 작업 내용
테스트, 채점 하기 편하게 회원가입 하는 유저에 대해서 registerDefaultClubMemberships 메서드를 통해 회원가입하는 유저를 club 1,2,3 의 운영진으로 등록하도록 했습니다. 
이 메서드는 테스트 기간 이후에는 삭제되어야 합니다. 


## ⏱️ 소요 시간
30분 


## 🤔 고민했던 내용
코드를 Auth 서비스의 register 메서드 내부 신규 User 생성 부분 조건문 안에 추가해 최초 회원가입 시에만 이 코드가 적용되도록 했습니다. 


## 💬 리뷰 중점사항
푸쉬하고 보니 브랜치 명을 이상하게 작성했었네요.. 죄송합니다. 

## 🔗관련 이슈
- Close #245

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리즈 노트

* **New Features**
  * 새로운 사용자 등록 시 기본 클럽에 자동으로 가입되는 기능을 추가했습니다.

* **Tests**
  * 기본 클럽 자동 가입 기능에 대한 테스트 커버리지를 확대했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->