### PR TITLE
[REFACTOR] 동아리 지원폼 수정시 발생하는 문제 해결 (#249)

### DIFF
--- a/src/main/java/com/kakaotech/team18/backend_server/domain/answer/repository/AnswerRepository.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/answer/repository/AnswerRepository.java
@@ -3,6 +3,7 @@ package com.kakaotech.team18.backend_server.domain.answer.repository;
 import com.kakaotech.team18.backend_server.domain.application.entity.Application;
 import com.kakaotech.team18.backend_server.domain.answer.entity.Answer;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -18,4 +19,9 @@ public interface AnswerRepository extends JpaRepository<Answer, Long> {
     List<Answer> findByApplicationWithFormQuestion(@Param("application") Application application);
 
     long deleteByApplication(Application application);
+
+
+    @Modifying
+    @Query("DELETE FROM Answer a WHERE a.formQuestion.id IN :formQuestionIds")
+    void deleteAllByFormQuestionIds(@Param("formQuestionIds") List<Long> formQuestionIds);
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/service/ClubApplyFormServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/service/ClubApplyFormServiceImpl.java
@@ -1,5 +1,6 @@
 package com.kakaotech.team18.backend_server.domain.clubApplyForm.service;
 
+import com.kakaotech.team18.backend_server.domain.answer.repository.AnswerRepository;
 import com.kakaotech.team18.backend_server.domain.clubApplyForm.dto.UserClubApplyFormResponseDto;
 import com.kakaotech.team18.backend_server.domain.formQuestion.dto.FormQuestionBaseDto;
 import com.kakaotech.team18.backend_server.domain.formQuestion.dto.FormQuestionResponseDto;
@@ -39,6 +40,7 @@ public class ClubApplyFormServiceImpl implements ClubApplyFormService {
     private final FormQuestionRepository formQuestionRepository;
     private final ClubApplyFormRepository clubApplyFormRepository;
     private final ClubRepository clubRepository;
+    private final AnswerRepository answerRepository;
 
     @Transactional(readOnly = true)
     public UserClubApplyFormResponseDto getUserQuestionForm(Long clubId){
@@ -131,13 +133,16 @@ public class ClubApplyFormServiceImpl implements ClubApplyFormService {
             ClubApplyForm findClubApplyForm
     ) {
         for (FormQuestionUpdateDto dto : request.formQuestions()) {
-            if (dto.questionNum() != null && existingMap.containsKey(dto.questionNum())) {
-                existingMap.get(dto.questionNum()).updateFrom(dto);
-                log.info("Updated FormQuestionNum: {}", dto.questionNum());
-                incomingIds.add(dto.questionNum());
+            if (dto.questionId() != null && existingMap.containsKey(dto.questionId())) {
+                FormQuestion existing = existingMap.get(dto.questionId());
+                log.info("Updating FormQuestion: id={}, oldQuestion={}, newQuestion={}", existing.getId(), existing.getQuestion(), dto.question());
+                existing.updateFrom(dto);
+                incomingIds.add(dto.questionId());
+                log.info("Updated FormQuestionId: {}", dto.questionId());
             } else {
                 FormQuestion newQuestion = createFormQuestion(dto, findClubApplyForm);
                 FormQuestion savedFormQuestion = formQuestionRepository.save(newQuestion);
+                log.info("New FormQuestion created: id={}, question={}", savedFormQuestion.getId(), savedFormQuestion.getQuestion());
                 log.info("Created new FormQuestionId: {}", savedFormQuestion.getId());
             }
         }
@@ -148,6 +153,7 @@ public class ClubApplyFormServiceImpl implements ClubApplyFormService {
                 .filter(existingId -> !incomingIds.contains(existingId))
                 .toList();
         if (!idsToDelete.isEmpty()) {
+            answerRepository.deleteAllByFormQuestionIds(idsToDelete);
             formQuestionRepository.deleteAllByIdInBatch(idsToDelete);
             log.info("Deleted FormQuestionIds: {}", idsToDelete);
         }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/service/ClubApplyFormServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/service/ClubApplyFormServiceImpl.java
@@ -154,6 +154,7 @@ public class ClubApplyFormServiceImpl implements ClubApplyFormService {
                 .toList();
         if (!idsToDelete.isEmpty()) {
             answerRepository.deleteAllByFormQuestionIds(idsToDelete);
+            log.info("Deleted Answers for FormQuestionIds: {}", idsToDelete);
             formQuestionRepository.deleteAllByIdInBatch(idsToDelete);
             log.info("Deleted FormQuestionIds: {}", idsToDelete);
         }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/formQuestion/dto/FormQuestionUpdateDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/formQuestion/dto/FormQuestionUpdateDto.java
@@ -13,6 +13,7 @@ import java.util.List;
 @Schema(description = "지원서 양식 개별 질문 수정 정보")
 public record FormQuestionUpdateDto(
         @Schema(description = "질문 ID", example = "1")
+        Long questionId,
         Long questionNum,
 
         @Schema(description = "질문 내용", example = "가장 자신 있는 프로그래밍 언어는 무엇인가요?")

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/controller/ClubApplyFormControllerTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/controller/ClubApplyFormControllerTest.java
@@ -415,7 +415,7 @@ class ClubApplyFormControllerTest {
                 "테스트 지원서",
                 "테스트 설명",
                 "2025-10-01 ~ 2025-10-31",
-                List.of(new FormQuestionUpdateDto(1L, "질문 1", FieldType.TEXT, true, 1L, null, null)
+                List.of(new FormQuestionUpdateDto(1L,1L, "질문 1", FieldType.TEXT, true, 1L, null, null)
                 ));
 
         doNothing().when(clubApplyFormService).updateClubApplyForm(clubId, clubApplyFormUpdateDto);
@@ -440,7 +440,7 @@ class ClubApplyFormControllerTest {
                 "테스트 지원서",
                 "테스트 설명",
                 "2025-10-01 ~ 2025-10-31",
-                List.of(new FormQuestionUpdateDto(1L, "질문 1", FieldType.TEXT, true, 1L, null, null)
+                List.of(new FormQuestionUpdateDto(1L, 1L,"질문 1", FieldType.TEXT, true, 1L, null, null)
                 ));
 
         doThrow(new ClubNotFoundException("clubId")).when(clubApplyFormService).updateClubApplyForm(clubId, clubApplyFormUpdateDto);
@@ -466,7 +466,7 @@ class ClubApplyFormControllerTest {
                 "테스트 지원서",
                 "테스트 설명",
                 "2025-10-01 ~ 2025-10-31",
-                List.of(new FormQuestionUpdateDto(1L, "", FieldType.TEXT, true, 1L, null, null)));
+                List.of(new FormQuestionUpdateDto(1L, 1L,"", FieldType.TEXT, true, 1L, null, null)));
 
         //when & then
         mockMvc.perform(patch("/api/clubs/{clubId}/dashboard/apply-form", clubId)
@@ -488,7 +488,7 @@ class ClubApplyFormControllerTest {
                 "테스트 지원서",
                 "설명",
                 "2025-10-01 ~ 2025-10-31",
-                List.of(new FormQuestionUpdateDto(1L, "면접 가능한 시간대를 선택해 주세요.", FieldType.TIME_SLOT, true, 1L, null, null))
+                List.of(new FormQuestionUpdateDto(1L, 1L,"면접 가능한 시간대를 선택해 주세요.", FieldType.TIME_SLOT, true, 1L, null, null))
         );
 
         mockMvc.perform(patch("/api/clubs/{clubId}/dashboard/apply-form", clubId)
@@ -508,7 +508,7 @@ class ClubApplyFormControllerTest {
                 "테스트 지원서",
                 "설명",
                 "2025-10-01 ~ 2025-10-31",
-                List.of(new FormQuestionUpdateDto(1L, "성별을 선택해 주세요.", FieldType.RADIO, true, 1L, null, null))
+                List.of(new FormQuestionUpdateDto(1L, 1L,"성별을 선택해 주세요.", FieldType.RADIO, true, 1L, null, null))
         );
 
         mockMvc.perform(patch("/api/clubs/{clubId}/dashboard/apply-form", clubId)
@@ -528,7 +528,7 @@ class ClubApplyFormControllerTest {
                 "", // Blank title
                 "설명",
                 "2025-10-01 ~ 2025-10-31",
-                List.of(new FormQuestionUpdateDto(1L, "질문", FieldType.TEXT, true, 1L, null, null))
+                List.of(new FormQuestionUpdateDto(1L, 1L, "질문", FieldType.TEXT, true, 1L, null, null))
         );
 
         mockMvc.perform(patch("/api/clubs/{clubId}/dashboard/apply-form", clubId)
@@ -548,7 +548,7 @@ class ClubApplyFormControllerTest {
                 "제목",
                 "", // Blank description
                 "2025-10-01 ~ 2025-10-31",
-                List.of(new FormQuestionUpdateDto(1L, "질문", FieldType.TEXT, true, 1L, null, null))
+                List.of(new FormQuestionUpdateDto(1L, 1L,"질문", FieldType.TEXT, true, 1L, null, null))
         );
 
         mockMvc.perform(patch("/api/clubs/{clubId}/dashboard/apply-form", clubId)
@@ -569,7 +569,7 @@ class ClubApplyFormControllerTest {
                 longTitle,
                 "설명",
                 "2025-10-01 ~ 2025-10-31",
-                List.of(new FormQuestionUpdateDto(1L, "질문", FieldType.TEXT, true, 1L, null, null))
+                List.of(new FormQuestionUpdateDto(1L, 1L,"질문", FieldType.TEXT, true, 1L, null, null))
         );
 
         mockMvc.perform(patch("/api/clubs/{clubId}/dashboard/apply-form", clubId)
@@ -590,7 +590,7 @@ class ClubApplyFormControllerTest {
                 "제목",
                 longDescription,
                 "2025-10-01 ~ 2025-10-31",
-                List.of(new FormQuestionUpdateDto(1L, "질문", FieldType.TEXT, true, 1L, null, null))
+                List.of(new FormQuestionUpdateDto(1L, 1L,"질문", FieldType.TEXT, true, 1L, null, null))
         );
 
         mockMvc.perform(patch("/api/clubs/{clubId}/dashboard/apply-form", clubId)
@@ -610,7 +610,7 @@ class ClubApplyFormControllerTest {
                 "제목",
                 "설명",
                 "2025-10-01 ~ 2025-10-31",
-                List.of(new FormQuestionUpdateDto(1L, "", FieldType.TEXT, true, 1L, null, null)) // Blank question
+                List.of(new FormQuestionUpdateDto(1L, 1L,"", FieldType.TEXT, true, 1L, null, null)) // Blank question
         );
 
         mockMvc.perform(patch("/api/clubs/{clubId}/dashboard/apply-form", clubId)
@@ -631,7 +631,7 @@ class ClubApplyFormControllerTest {
                 "제목",
                 "설명",
                 "2025-10-01 ~ 2025-10-31",
-                List.of(new FormQuestionUpdateDto(1L, longQuestion, FieldType.TEXT, true, 1L, null, null))
+                List.of(new FormQuestionUpdateDto(1L, 1L,longQuestion, FieldType.TEXT, true, 1L, null, null))
         );
 
         mockMvc.perform(patch("/api/clubs/{clubId}/dashboard/apply-form", clubId)

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/service/ClubApplyFormServiceImplMockTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/service/ClubApplyFormServiceImplMockTest.java
@@ -9,6 +9,7 @@ import static org.mockito.BDDMockito.then;
 import static org.mockito.BDDMockito.times;
 import static org.mockito.Mockito.mock;
 
+import com.kakaotech.team18.backend_server.domain.answer.repository.AnswerRepository;
 import com.kakaotech.team18.backend_server.domain.club.entity.Club;
 import com.kakaotech.team18.backend_server.domain.club.repository.ClubRepository;
 import com.kakaotech.team18.backend_server.domain.clubApplyForm.dto.ClubApplyFormRequestDto;
@@ -48,6 +49,8 @@ class ClubApplyFormServiceImplMockTest {
     private ClubApplyFormRepository clubApplyFormRepository;
     @Mock
     private ClubRepository clubRepository;
+    @Mock
+    private AnswerRepository answerRepository;
     @InjectMocks
     private ClubApplyFormServiceImpl clubApplyFormService;
 
@@ -209,6 +212,7 @@ class ClubApplyFormServiceImplMockTest {
                 List.of(
                         new FormQuestionUpdateDto(
                                 1L,
+                                1L,
                                 "수정된 질문 1",
                                 FieldType.TEXT,
                                 false,
@@ -218,6 +222,7 @@ class ClubApplyFormServiceImplMockTest {
                         ),
                         new FormQuestionUpdateDto(
                                 null,
+                                1L,
                                 "새로운 질문 3",
                                 FieldType.CHECKBOX,
                                 true,
@@ -246,7 +251,7 @@ class ClubApplyFormServiceImplMockTest {
         Long clubId = 1L;
         Club club = mock(Club.class);
         ReflectionTestUtils.setField(club, "id", 1L);
-        FormQuestionUpdateDto question1 = new FormQuestionUpdateDto(1L, "질문 1", FieldType.TEXT, true, 1L, null, null);
+        FormQuestionUpdateDto question1 = new FormQuestionUpdateDto(1L, 1L,"질문 1", FieldType.TEXT, true, 1L, null, null);
         ClubApplyFormUpdateDto requestDto = new ClubApplyFormUpdateDto(
                 "테스트 지원서",
                 "테스트 설명",

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/formQuestion/entity/FormQuestionTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/formQuestion/entity/FormQuestionTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.kakaotech.team18.backend_server.domain.formQuestion.dto.FormQuestionUpdateDto;
 import com.kakaotech.team18.backend_server.domain.formQuestion.dto.TimeSlotOptionRequestDto;
 import com.kakaotech.team18.backend_server.domain.formQuestion.dto.TimeSlotOptionRequestDto.TimeRange;
-import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -21,7 +20,7 @@ class FormQuestionTest {
         ReflectionTestUtils.setField(formQuestion, "id", 1L);
 
         FormQuestionUpdateDto dto = new FormQuestionUpdateDto(
-                1L, "오늘 먹기 싫은 메뉴는?", FieldType.TEXT, true, 1L, null, null
+                1L, 1L,"오늘 먹기 싫은 메뉴는?", FieldType.TEXT, true, 1L, null, null
         );
 
         formQuestion.updateFrom(dto);
@@ -37,7 +36,7 @@ class FormQuestionTest {
         ReflectionTestUtils.setField(formQuestion, "id", 2L);
 
         FormQuestionUpdateDto dto = new FormQuestionUpdateDto(
-                2L, "먹기 싫은 메뉴는?", FieldType.CHECKBOX, false, 2L, List.of("피자", "치킨"), null
+                2L, 2L,"먹기 싫은 메뉴는?", FieldType.CHECKBOX, false, 2L, List.of("피자", "치킨"), null
         );
 
         formQuestion.updateFrom(dto);
@@ -53,7 +52,7 @@ class FormQuestionTest {
         ReflectionTestUtils.setField(formQuestion, "id", 4L);
 
         FormQuestionUpdateDto dto = new FormQuestionUpdateDto(
-                2L, "성별?", FieldType.RADIO, false, 4L, List.of("남", "여", "응답안함"), null
+                2L, 2L,"성별?", FieldType.RADIO, false, 4L, List.of("남", "여", "응답안함"), null
         );
 
         formQuestion.updateFrom(dto);
@@ -74,7 +73,7 @@ class FormQuestionTest {
         TimeSlotOptionRequestDto newOption = new TimeSlotOptionRequestDto("2025-10-01 ~ 2025-10-31", newTimeRange);
 
         FormQuestionUpdateDto dto = new FormQuestionUpdateDto(
-                3L, "면접 불가능한 시간대는?", FieldType.TIME_SLOT, true, 3L, null, List.of(newOption)
+                3L, 3L,"면접 불가능한 시간대는?", FieldType.TIME_SLOT, true, 3L, null, List.of(newOption)
         );
 
         formQuestion.updateFrom(dto);


### PR DESCRIPTION
## 🚀 작업 내용
지원폼 수정시 지원폼을 추가하는데도 지원폼을 삭제하는 경우가 있었고, 삭제할 때 지원폼과 관련된 answer 엔티티가 존재해서 fk 에러가 500에러로 발생하고 있었습니다. 
일단 지원폼 삭제시 관련된 answer도 삭제하는게 맞다고 생각해서 지우기 전에 관련된 answer를 지우는 로직을 추가했습니다. 
그리고 지원폼에서 질문을 추가했는데 삭제되는 경우에 대해서 updateClubApplyForm 메서드 내부의 syncFormQuestions가 정상적으로 동작하지 않는 것 같다는 생각을 했고 updateDTO 스펙이 프론트랑 차이가 있다는 것을 알게 됐습니다. 그래서 프론트는 업데이트 메서드 요청시 questionId를 넘겨주는데 백엔드 요청 dto에는 questionId가 존재하지 않고, questionNum을 questionId의 용도로 사용하고 있었습니다. 그래서 questionId를 정상적으로 받기 위해 이 필드를 추가해보았습니다. 



## ⏱️ 소요 시간
2시간 


## 🤔 고민했던 내용
왜 update 로직이 정상적으로 수행되지 않는지 생각해봤을 때 눈에 띄눈 문제들이라서 수정했는데 이후로도 문제가 발생하면 다시 디버깅 해봐야할 것 같습니다. 


## 💬 리뷰 중점사항


## 🔗관련 이슈
- Close #249 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선사항**
  * 폼 질문 삭제 시 관련 답변이 자동으로 정리되어 데이터 무결성 강화
  * 폼 질문 업데이트 및 동기화 로직 개선으로 더욱 안정적인 양식 관리 제공
  * 폼 질문 추적 및 관리 기능 향상으로 더 정확한 데이터 처리

<!-- end of auto-generated comment: release notes by coderabbit.ai -->