### PR TITLE
[FIX] 인증이 필요없는 경로에도 JWT필터가 적용되던 문제 해결

### DIFF
--- a/src/main/java/com/kakaotech/team18/backend_server/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/security/JwtAuthenticationFilter.java
@@ -12,17 +12,22 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+
 import java.io.IOException;
+import java.util.List;
 import java.util.Collections;
 import java.util.Map;
+
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.web.servlet.HandlerExceptionResolver;
 
@@ -34,24 +39,45 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final HandlerExceptionResolver resolver;
     private final RedisTemplate<String, String> redisTemplate;
 
+    // 필터링을 건너뛸 경로 목록을 미리 정의합니다.
+    private final List<AntPathRequestMatcher> permitAllMatchers;
+
     // Qualifier 를 이용하기 위해서 RequiredArgsConstructor 사용 X
     public JwtAuthenticationFilter(JwtProvider jwtProvider, PrincipalDetailsService principalDetailsService, @Qualifier("handlerExceptionResolver") HandlerExceptionResolver resolver, RedisTemplate<String, String> redisTemplate) {
         this.jwtProvider = jwtProvider;
         this.principalDetailsService = principalDetailsService;
         this.resolver = resolver;
         this.redisTemplate = redisTemplate;
+        // SecurityConfig의 permitAll 규칙들을 여기에 명시적으로 정의합니다.
+        this.permitAllMatchers = List.of(
+                new AntPathRequestMatcher("/api/auth/**"),
+                new AntPathRequestMatcher("/swagger-ui.html"),
+                new AntPathRequestMatcher("/v3/api-docs/**"),
+                new AntPathRequestMatcher("/swagger-ui/**"),
+                new AntPathRequestMatcher("/api/notices", HttpMethod.GET.name()),
+                new AntPathRequestMatcher("/api/notices/*", HttpMethod.GET.name()),
+                new AntPathRequestMatcher("/api/clubs", HttpMethod.GET.name()),
+                new AntPathRequestMatcher("/api/clubs/*", HttpMethod.GET.name()),
+                new AntPathRequestMatcher("/api/clubs/*/apply", HttpMethod.GET.name()),
+                new AntPathRequestMatcher("/api/clubs/*/apply-submit", HttpMethod.POST.name()),
+                new AntPathRequestMatcher("/api/clubs/*/reviews")
+        );
+    }
+
+    /**
+     * 이 필터가 동작하지 않아야 할 경로인지 확인합니다.
+     * 생성자에서 정의된 permitAllMatchers 리스트와 현재 요청을 비교합니다.
+     * @return 필터를 건너뛰려면 true, 필터를 실행하려면 false
+     */
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+        return permitAllMatchers.stream()
+                .anyMatch(matcher -> matcher.matches(request));
     }
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
-
-        // 요청 URI를 확인하여 특정 경로의 요청은 필터를 그냥 통과시킨다.
-        String requestURI = request.getRequestURI();
-        if (requestURI.equals("/api/auth/reissue") || requestURI.equals("/api/auth/kakao/login")) {
-            filterChain.doFilter(request, response);
-            return;
-        }
 
         // 1. 헤더에서 "Authorization" 값을 가져온다.
         String bearerToken = request.getHeader("Authorization");

--- a/src/test/java/com/kakaotech/team18/backend_server/global/security/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/global/security/JwtAuthenticationFilterTest.java
@@ -96,7 +96,7 @@ class JwtAuthenticationFilterTest {
 
         // when
         ResultActions resultActions = mockMvc.perform(
-                get("/api/clubs")
+                get("/api/clubs/1/dashboard") // 인증이 필요한 경로로 변경
                         .header("Authorization", "Bearer " + invalidSignatureToken)
         );
 
@@ -115,7 +115,7 @@ class JwtAuthenticationFilterTest {
 
         // when
         ResultActions resultActions = mockMvc.perform(
-                get("/api/clubs")
+                get("/api/clubs/1/dashboard") // 인증이 필요한 경로로 변경
                         .header("Authorization", "Bearer " + malformedToken)
         );
 
@@ -146,7 +146,7 @@ class JwtAuthenticationFilterTest {
         // when
         // 만료된 토큰을 헤더에 담아 일반 API(/api/clubs)로 요청
         ResultActions resultActions = mockMvc.perform(
-                get("/api/clubs")
+                get("/api/clubs/1/dashboard") // 인증이 필요한 경로로 변경
                         .header("Authorization", "Bearer " + expiredToken)
         );
 


### PR DESCRIPTION
## 🚀 작업 내용
인증이 필요없는 GET api/clubs 같은 경로에도 JWT필터가 적용되어 401 응답이 던져지는 문제를 해결했습니다.
인증 및 인가가 필요한 경로를 명확하게 하고, 필요없는 경우는 필터가 적용되지 않도록 수정했습니다.
인증이 필요없는 경로는 shouldNotFilter 메소드를 오버라이드해서 제외하도록 했습니다.

## ⏱️ 소요 시간
1h 30m

## 🤔 고민했던 내용
필터 사이의 우선순위 및 왔다갔다(?) 를 명확하게 이해하지 못해 발생한 문제였습니다.
요청 -> JwtAuthenticationFilter의 doFilterInternal(인증) -> SecurityConfig의 filterChain의 authorizeHttpRequests(인가) -> 컨트롤러

## 💬 리뷰 중점사항
인증 및 인가가 필요없는 API 경로가 커버되지 않은게 있다면 말씀해주세요.

추가로 해당 작업 내용은 일반적인 사용자 흐름에서 발생하는 에러는 아닙니다.
저희가 서버를 껐다가 키는 경우 브라우저의 로컬스토리지에 액세스토큰이 남아있어서 생긴 문제였는데 
(서버 재시작하면서 액세스토큰을 검증하는 키가 바뀌기 때문 등)
일반적인 사용자 흐름에서 로컬스토리지에 액세스토큰이 남아있는 경우는 쉽게 생기지 않을 거 같습니다.
하지만 아무래도 지금 평가기간이다 보니 해당 PR이 머지 되었을때 문제가 생길까봐 두렵긴하네요. 
큰 작업 내용은 없어서 지장이 크진 않을 거 같은데 불안하시면 일단 읽어보시고 Merge는 평가 이후 진행해주셔도 좋습니다.