### PR TITLE
[BUG] S3 스케쥴러 동작시 Illegal character in path at index 에러 (#267)

### DIFF
--- a/src/main/java/com/kakaotech/team18/backend_server/global/service/S3Service.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/service/S3Service.java
@@ -5,7 +5,6 @@ import com.kakaotech.team18.backend_server.global.exception.exceptions.InputStre
 import com.kakaotech.team18.backend_server.global.exception.exceptions.InvalidFileException;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.AwsS3Exception;
 import java.io.IOException;
-import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -124,8 +123,15 @@ public class S3Service {
     }
 
     public void deleteFile(String fileUrl) {
-        String path = URI.create(fileUrl).getPath();
-        String key = path.startsWith("/") ? path.substring(1) : path;
+        String baseUrl = String.format("https://%s.s3.%s.amazonaws.com/", bucket, region);
+        String key;
+
+        if (fileUrl.startsWith(baseUrl)) {
+            key = fileUrl.substring(baseUrl.length());
+        } else {
+            throw new IllegalArgumentException("URL is not a valid S3 URL for this bucket: " + fileUrl);
+        }
+
         try {
             DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
                 .bucket(bucket)

--- a/src/main/java/com/kakaotech/team18/backend_server/global/service/S3Service.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/service/S3Service.java
@@ -129,7 +129,8 @@ public class S3Service {
         if (fileUrl.startsWith(baseUrl)) {
             key = fileUrl.substring(baseUrl.length());
         } else {
-            throw new IllegalArgumentException("URL is not a valid S3 URL for this bucket: " + fileUrl);
+            log.warn("Invalid S3 URL format for deletion: " + fileUrl);
+            throw new AwsS3Exception("URL is not a valid S3 URL for this bucket: " + fileUrl);
         }
 
         try {

--- a/src/test/java/com/kakaotech/team18/backend_server/global/service/S3ServiceTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/global/service/S3ServiceTest.java
@@ -56,8 +56,10 @@ class S3ServiceTest {
     void deleteFile_shouldDeleteObjectFromS3() {
         // given
         String bucket = "test-bucket";
-        String url = "https://test-bucket.s3.amazonaws.com/club_detail_image/test.png";
+        String region = "test-region";
+        ReflectionTestUtils.setField(s3Service, "region", region);
         ReflectionTestUtils.setField(s3Service, "bucket", bucket);
+        String url = String.format("https://%s.s3.%s.amazonaws.com/club_detail_image/test.png", bucket, region);
 
         // when
         s3Service.deleteFile(url);

--- a/src/test/java/com/kakaotech/team18/backend_server/global/service/S3ServiceTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/global/service/S3ServiceTest.java
@@ -86,8 +86,8 @@ class S3ServiceTest {
     }
 
     @Test
-    @DisplayName("S3 파일 삭제 시 URL 파싱에 실패하면 IllegalArgumentException을 던진다.")
-    void deleteFile_shouldThrowIllegalArgumentException_whenUrlParsingFails() {
+    @DisplayName("S3 파일 삭제 시 URL 파싱에 실패하면 AwsS3Exception 던진다.")
+    void deleteFile_shouldThrowAwsS3Exception_whenUrlParsingFails() {
         // given
         String invalidUrl = "invalid-url-format";
 

--- a/src/test/java/com/kakaotech/team18/backend_server/global/service/S3ServiceTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/global/service/S3ServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import com.kakaotech.team18.backend_server.global.exception.exceptions.AwsS3Exception;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.InputStreamException;
 import java.io.IOException;
 import org.assertj.core.api.Assertions;
@@ -83,4 +84,17 @@ class S3ServiceTest {
                 .isInstanceOf(InputStreamException.class)
                 .hasMessageContaining("파일 입출력 실패.");
     }
+
+    @Test
+    @DisplayName("S3 파일 삭제 시 URL 파싱에 실패하면 IllegalArgumentException을 던진다.")
+    void deleteFile_shouldThrowIllegalArgumentException_whenUrlParsingFails() {
+        // given
+        String invalidUrl = "invalid-url-format";
+
+        // when & then
+        Assertions.assertThatThrownBy(() -> s3Service.deleteFile(invalidUrl))
+                .isInstanceOf(AwsS3Exception.class)
+                .hasMessageContaining("AWS 에러 발생");
+    }
+
 }

--- a/src/test/java/com/kakaotech/team18/backend_server/global/service/S3ServiceTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/global/service/S3ServiceTest.java
@@ -97,4 +97,21 @@ class S3ServiceTest {
                 .hasMessageContaining("AWS 에러 발생");
     }
 
+    @Test
+    @DisplayName("S3 파일 삭제 시 URL에 공백이 포함되어 있어도 정상 처리된다")
+    void deleteFile_shouldHandleUrlWithSpaces() {
+        // given
+        String bucket = "test-bucket";
+        String region = "test-region";
+        ReflectionTestUtils.setField(s3Service, "region", region);
+        ReflectionTestUtils.setField(s3Service, "bucket", bucket);
+        // URL에 공백이 포함된 경우 (원본 버그 시나리오)
+        String url = String.format("https://%s.s3.%s.amazonaws.com/club_detail_image/test file.png", bucket, region);
+
+        // when
+        s3Service.deleteFile(url);
+
+        // then
+        verify(s3Client, times(1)).deleteObject(any(DeleteObjectRequest.class));
+    }
 }


### PR DESCRIPTION
## 🚀 작업 내용
S3Service의 deleteFile 메서드에서 공백이 포함된 URL을 다룰 때 에러가 발생해 이를 수정했습니다. 자세한 내용은 #267  이슈 참고해주시면 감사하겠습니다. 

이슈에 제안한것처럼 URI.create() 메서드를 사용하는 대신 
aws의 버킷 url이 `https://{bucket명}.s3.{region 명}.amazonaws.com/`를 따르기 때문에 이를 기반으로 적절한 URL인지 파악하고, key 값을 기준으로 S3 에서 이미지를 제거합니다. 

## ⏱️ 소요 시간
30분 


## 🤔 고민했던 내용
```
        if (fileUrl.startsWith(baseUrl)) {
            key = fileUrl.substring(baseUrl.length());
        } else {
            log.warn("Invalid S3 URL format for deletion: " + fileUrl);
            throw new AwsS3Exception("URL is not a valid S3 URL for this bucket: " + fileUrl);
        }
```
이부분에서 에러 반환을 500번대로 처리하는게 맞는 것 같아서 만들어준 만들어준 AwsS3Exception를 반환하게 했습니다. 

## 🔗관련 이슈
- Close #267 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * S3 파일 삭제 시 URL 검증을 강화해 잘못된 URL 입력으로 인한 실패 방지 및 안정성 향상
  * 잘못된 파일 경로에 대해 명확한 오류 처리와 경고 로깅을 추가하여 원인 파악 용이성 개선
  * 공백 등 특수문자가 포함된 URL도 정상 처리되도록 개선

* **테스트**
  * 잘못된 URL 입력 시 오류 발생을 검증하는 테스트 추가
  * 공백 포함 URL에 대한 정상 삭제 동작을 검증하는 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->