### PR TITLE
[FEATURE] 지원자 면접 시간 선택 기능 - 지원폼 작성시 면접 필수 여부 확인 (#275)

### DIFF
--- a/src/main/java/com/kakaotech/team18/backend_server/domain/club/entity/Club.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/club/entity/Club.java
@@ -14,6 +14,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -53,6 +54,14 @@ public class Club extends BaseEntity {
 
     private LocalDateTime recruitEnd;
 
+    private LocalDateTime interviewStartDate;
+
+    private LocalDateTime interviewEndDate;
+
+    private LocalTime interviewStartTime;
+
+    private LocalTime interviewEndTime;
+
     private String regularMeetingInfo;
 
     @Builder
@@ -65,6 +74,10 @@ public class Club extends BaseEntity {
             String caution,
             LocalDateTime recruitStart,
             LocalDateTime recruitEnd,
+            LocalDateTime interviewStartDate,
+            LocalDateTime interviewEndDate,
+            LocalTime interviewStartTime,
+            LocalTime interviewEndTime,
             String regularMeetingInfo) {
         this.name = name;
         this.category = category;
@@ -74,6 +87,10 @@ public class Club extends BaseEntity {
         this.caution = caution;
         this.recruitStart = recruitStart;
         this.recruitEnd = recruitEnd;
+        this.interviewStartDate = interviewStartDate;
+        this.interviewEndDate = interviewEndDate;
+        this.interviewStartTime = interviewStartTime;
+        this.interviewEndTime = interviewEndTime;
         this.regularMeetingInfo = regularMeetingInfo;
     }
 
@@ -91,5 +108,15 @@ public class Club extends BaseEntity {
         this.recruitStart = recruitStart;
         this.recruitEnd = recruitEnd;
         log.info("Updated recruit date for clubId: {} to start: {} end: {}", this.id, recruitStart, recruitEnd);
+    }
+
+    public void updateInterviewDate(LocalDateTime interviewStartDate, LocalDateTime interviewEndDate, LocalTime interviewStartTime, LocalTime interviewEndTime) {
+        this.interviewStartDate = interviewStartDate;
+        this.interviewEndDate = interviewEndDate;
+        this.interviewStartTime = interviewStartTime;
+        this.interviewEndTime = interviewEndTime;
+        log.info("Updated interview date for clubId: {} to interviewStartDate: {}, interviewEndDate: {}, interviewStartTime: {}, interviewEndTime: {}", this.id,
+            interviewStartDate, interviewEndDate, interviewStartTime,
+            interviewEndTime);
     }
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/club/entity/Club.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/club/entity/Club.java
@@ -54,6 +54,9 @@ public class Club extends BaseEntity {
 
     private LocalDateTime recruitEnd;
 
+    @Column(nullable = false)
+    private Boolean isInterviewRequired;
+
     private LocalDateTime interviewStartDate;
 
     private LocalDateTime interviewEndDate;
@@ -74,6 +77,7 @@ public class Club extends BaseEntity {
             String caution,
             LocalDateTime recruitStart,
             LocalDateTime recruitEnd,
+            Boolean isInterviewRequired,
             LocalDateTime interviewStartDate,
             LocalDateTime interviewEndDate,
             LocalTime interviewStartTime,
@@ -87,6 +91,7 @@ public class Club extends BaseEntity {
         this.caution = caution;
         this.recruitStart = recruitStart;
         this.recruitEnd = recruitEnd;
+        this.isInterviewRequired = (isInterviewRequired != null) ? isInterviewRequired : false;
         this.interviewStartDate = interviewStartDate;
         this.interviewEndDate = interviewEndDate;
         this.interviewStartTime = interviewStartTime;
@@ -110,13 +115,16 @@ public class Club extends BaseEntity {
         log.info("Updated recruit date for clubId: {} to start: {} end: {}", this.id, recruitStart, recruitEnd);
     }
 
-    public void updateInterviewDate(LocalDateTime interviewStartDate, LocalDateTime interviewEndDate, LocalTime interviewStartTime, LocalTime interviewEndTime) {
+    public void updateInterviewDate(Boolean isInterviewRequired, LocalDateTime interviewStartDate, LocalDateTime interviewEndDate, LocalTime interviewStartTime, LocalTime interviewEndTime) {
+        this.isInterviewRequired = isInterviewRequired;
         this.interviewStartDate = interviewStartDate;
         this.interviewEndDate = interviewEndDate;
         this.interviewStartTime = interviewStartTime;
         this.interviewEndTime = interviewEndTime;
-        log.info("Updated interview date for clubId: {} to interviewStartDate: {}, interviewEndDate: {}, interviewStartTime: {}, interviewEndTime: {}", this.id,
-            interviewStartDate, interviewEndDate, interviewStartTime,
-            interviewEndTime);
+        log.info(
+                "Updated interview date for clubId: {} to interviewStartDate: {}, interviewEndDate: {}, interviewStartTime: {}, interviewEndTime: {}",
+                this.id,
+                interviewStartDate, interviewEndDate, interviewStartTime,
+                interviewEndTime);
     }
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/dto/ClubApplyFormResponseDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/dto/ClubApplyFormResponseDto.java
@@ -13,6 +13,8 @@ public record ClubApplyFormResponseDto(
         String description,
         @Schema(description = "모집 기간", example = "2024-09-01 ~ 2024-09-30")
         String recruitDate,
+        @Schema(description = "면접 필수 여부", example = "true")
+        boolean interviewRequired,
         @Schema(description = "질문 목록")
         List<FormQuestionResponseDto> formQuestions
 ) {
@@ -21,11 +23,12 @@ public record ClubApplyFormResponseDto(
             String description,
             LocalDateTime recruitStart,
             LocalDateTime recruitEnd,
+            boolean interviewRequired,
             List<FormQuestionResponseDto> questions
     ) {
         String recruitDate = (recruitStart != null && recruitEnd != null)
                 ? String.format("%s ~ %s", recruitStart.toLocalDate(), recruitEnd.toLocalDate())
                 : null;
-        return new ClubApplyFormResponseDto(title, description, recruitDate, questions);
+        return new ClubApplyFormResponseDto(title, description, recruitDate, interviewRequired, questions);
     }
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/dto/ClubApplyFormUpdateDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/dto/ClubApplyFormUpdateDto.java
@@ -1,12 +1,14 @@
 package com.kakaotech.team18.backend_server.domain.clubApplyForm.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.kakaotech.team18.backend_server.domain.formQuestion.dto.FormQuestionBaseDto;
 import com.kakaotech.team18.backend_server.domain.formQuestion.dto.FormQuestionUpdateDto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -30,6 +32,10 @@ public record ClubApplyFormUpdateDto(
         @Schema(description = "모집 일정", example = "2025-03-01 ~ 2025-03-31")
         @NotBlank(message = "모집 일정은 필수입니다.")
         String recruitDate,
+
+        @Schema(description = "면접 필수 여부", example = "true")
+        @NotNull(message = "면접 필수 여부는 필수 값입니다.")
+        Boolean interviewRequired,
 
         @Schema(description = "질문 목록")
         @NotEmpty(message = "질문 목록은 최소 1개 이상이어야 합니다.")
@@ -62,5 +68,25 @@ public record ClubApplyFormUpdateDto(
                         log.warn("Invalid recruitDate format: '{}'", recruitDate, e);
                         return false;
                 }
+        }
+
+        @AssertTrue(message = "면접이 필수인 경우 면접 시간 선택 질문이 포함되어야 합니다.")
+        @JsonIgnore
+        @Schema(hidden = true)
+        public boolean isInterviewRequirementValid() {
+                if (Boolean.TRUE.equals(interviewRequired)) {
+                        return formQuestions.stream().anyMatch(FormQuestionBaseDto::isTimeSlot);
+                }
+                return true;
+        }
+
+        @AssertTrue(message = "면접이 필수가 아닌 경우 면접 시간 선택 질문을 포함할 수 없습니다.")
+        @JsonIgnore
+        @Schema(hidden = true)
+        public boolean isTimeSlotIncludedWhenNotRequired() {
+                if (Boolean.FALSE.equals(interviewRequired)) {
+                        return formQuestions.stream().noneMatch(FormQuestionBaseDto::isTimeSlot);
+                }
+                return true;
         }
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/service/ClubApplyFormServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/service/ClubApplyFormServiceImpl.java
@@ -137,15 +137,7 @@ public class ClubApplyFormServiceImpl implements ClubApplyFormService {
             ClubApplyForm findClubApplyForm
     ) {
         for (FormQuestionUpdateDto dto : request.formQuestions()) {
-            if (dto.questionId() != null && existingMap.containsKey(dto.questionId())) {
-                if (isTimeSlot(dto)) {
-                    List<TimeSlotOptionRequestDto> timeSlots = dto.timeSlotOptions();
-                    for (TimeSlotOptionRequestDto timeSlot : timeSlots) {
-                        if (!timeSlot.availableTime().start().isBefore(timeSlot.availableTime().end())) {
-                            throw new InvalidTimeSlotException("면접 시작 시간은 마감 시간보다 이전이어야 합니다.");
-                        }
-                    }
-                }
+            if (questionForUpdate(existingMap, dto)) {
                 FormQuestion existing = existingMap.get(dto.questionId());
                 log.info("Updating FormQuestion: id={}, oldQuestion={}, newQuestion={}", existing.getId(), existing.getQuestion(), dto.question());
                 existing.updateFrom(dto);
@@ -158,6 +150,11 @@ public class ClubApplyFormServiceImpl implements ClubApplyFormService {
                 log.info("Created new FormQuestionId: {}", savedFormQuestion.getId());
             }
         }
+    }
+
+    private boolean questionForUpdate(Map<Long, FormQuestion> existingMap,
+            FormQuestionUpdateDto dto) {
+        return dto.questionId() != null && existingMap.containsKey(dto.questionId());
     }
 
     private void removeLegacyQuestions(Map<Long, FormQuestion> existingMap, Set<Long> incomingIds) {

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/service/ClubApplyFormServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/service/ClubApplyFormServiceImpl.java
@@ -86,7 +86,7 @@ public class ClubApplyFormServiceImpl implements ClubApplyFormService {
                         .map(FormQuestionResponseDto::from)
                         .toList();
 
-        return ClubApplyFormResponseDto.of(title, description, club.getRecruitStart(), club.getRecruitEnd(), questions);
+        return ClubApplyFormResponseDto.of(title, description, club.getRecruitStart(), club.getRecruitEnd(), club.getIsInterviewRequired(), questions);
     }
 
     @Override

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/service/ClubApplyFormServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/service/ClubApplyFormServiceImpl.java
@@ -1,5 +1,7 @@
 package com.kakaotech.team18.backend_server.domain.clubApplyForm.service;
 
+import static com.kakaotech.team18.backend_server.global.util.DateUtil.changeToDate;
+
 import com.kakaotech.team18.backend_server.domain.answer.repository.AnswerRepository;
 import com.kakaotech.team18.backend_server.domain.clubApplyForm.dto.UserClubApplyFormResponseDto;
 import com.kakaotech.team18.backend_server.domain.formQuestion.dto.FormQuestionBaseDto;
@@ -218,22 +220,6 @@ public class ClubApplyFormServiceImpl implements ClubApplyFormService {
 
     private boolean isTimeSlot(FormQuestionBaseDto dto) {
         return dto.fieldType() == FieldType.TIME_SLOT;
-    }
-
-    private LocalDateTime[] changeToDate(String recruitDate) {
-        String[] recruitDates = recruitDate.replaceAll("\\s+", "").split("~");
-
-        // 날짜 형식 지정 (yyyy-MM-dd)
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
-
-        // 문자열 → LocalDate 변환
-        LocalDate startDate = LocalDate.parse(recruitDates[0], formatter);
-        LocalDate endDate = LocalDate.parse(recruitDates[1], formatter);
-
-        LocalDateTime recruitStart = startDate.atStartOfDay();
-        LocalDateTime recruitEnd = endDate.atTime(23, 59, 59);
-
-        return new LocalDateTime[]{recruitStart, recruitEnd};
     }
 
     public static List<Map<String, Object>> expandDateRange(String dateRange, LocalTime startTime, LocalTime endTime) {

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/service/ClubApplyFormServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/service/ClubApplyFormServiceImpl.java
@@ -3,23 +3,22 @@ package com.kakaotech.team18.backend_server.domain.clubApplyForm.service;
 import static com.kakaotech.team18.backend_server.global.util.DateUtil.changeToDate;
 
 import com.kakaotech.team18.backend_server.domain.answer.repository.AnswerRepository;
-import com.kakaotech.team18.backend_server.domain.clubApplyForm.dto.UserClubApplyFormResponseDto;
-import com.kakaotech.team18.backend_server.domain.formQuestion.dto.FormQuestionBaseDto;
-import com.kakaotech.team18.backend_server.domain.formQuestion.dto.FormQuestionResponseDto;
-import com.kakaotech.team18.backend_server.domain.formQuestion.dto.FormQuestionUpdateDto;
-import com.kakaotech.team18.backend_server.domain.formQuestion.dto.TimeSlotOptionRequestDto;
-import com.kakaotech.team18.backend_server.domain.formQuestion.dto.UserFormQuestionResponseDto;
-import com.kakaotech.team18.backend_server.domain.formQuestion.entity.FieldType;
-import com.kakaotech.team18.backend_server.domain.formQuestion.entity.FormQuestion;
-import com.kakaotech.team18.backend_server.domain.formQuestion.entity.TimeSlotOption;
-import com.kakaotech.team18.backend_server.domain.formQuestion.repository.FormQuestionRepository;
 import com.kakaotech.team18.backend_server.domain.club.entity.Club;
 import com.kakaotech.team18.backend_server.domain.club.repository.ClubRepository;
 import com.kakaotech.team18.backend_server.domain.clubApplyForm.dto.ClubApplyFormRequestDto;
 import com.kakaotech.team18.backend_server.domain.clubApplyForm.dto.ClubApplyFormResponseDto;
 import com.kakaotech.team18.backend_server.domain.clubApplyForm.dto.ClubApplyFormUpdateDto;
+import com.kakaotech.team18.backend_server.domain.clubApplyForm.dto.UserClubApplyFormResponseDto;
 import com.kakaotech.team18.backend_server.domain.clubApplyForm.entity.ClubApplyForm;
 import com.kakaotech.team18.backend_server.domain.clubApplyForm.repository.ClubApplyFormRepository;
+import com.kakaotech.team18.backend_server.domain.formQuestion.dto.FormQuestionBaseDto;
+import com.kakaotech.team18.backend_server.domain.formQuestion.dto.FormQuestionResponseDto;
+import com.kakaotech.team18.backend_server.domain.formQuestion.dto.FormQuestionUpdateDto;
+import com.kakaotech.team18.backend_server.domain.formQuestion.dto.TimeSlotOptionRequestDto;
+import com.kakaotech.team18.backend_server.domain.formQuestion.dto.UserFormQuestionResponseDto;
+import com.kakaotech.team18.backend_server.domain.formQuestion.entity.FormQuestion;
+import com.kakaotech.team18.backend_server.domain.formQuestion.entity.TimeSlotOption;
+import com.kakaotech.team18.backend_server.domain.formQuestion.repository.FormQuestionRepository;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.ClubApplyFormNotFoundException;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.ClubNotFoundException;
 import java.time.LocalDate;
@@ -32,8 +31,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-
-import com.kakaotech.team18.backend_server.global.exception.exceptions.InvalidTimeSlotException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -110,6 +107,14 @@ public class ClubApplyFormServiceImpl implements ClubApplyFormService {
         });
     }
 
+    private ClubApplyForm createClubApplyForm(ClubApplyFormRequestDto request, Club findClub) {
+        return ClubApplyForm.builder()
+                .club(findClub)
+                .title(request.title())
+                .description(request.description())
+                .build();
+    }
+
     @Override
     @Transactional
     public void updateClubApplyForm(Long clubId, ClubApplyFormUpdateDto request) {
@@ -119,6 +124,7 @@ public class ClubApplyFormServiceImpl implements ClubApplyFormService {
                     log.warn("ClubApplyForm not found for clubId: {}", clubId);
                     return new ClubApplyFormNotFoundException("clubId = " + findClub.getId());
                 });
+
         LocalDateTime[] recruitDates = changeToDate(request.recruitDate());
         findClub.updateRecruitDate(recruitDates[0], recruitDates[1]);
         findClubApplyForm.update(request.title(), request.description());
@@ -130,6 +136,9 @@ public class ClubApplyFormServiceImpl implements ClubApplyFormService {
         Set<Long> incomingIds = new HashSet<>(); // 삭제할 FormQuestion을 찾기 위함
         syncFormQuestions(request, existingMap, incomingIds, findClubApplyForm);
         removeLegacyQuestions(existingMap, incomingIds);
+
+        // 면접 시간 정보 업데이트
+        updateClubInterviewInfo(findClub, request.formQuestions());
     }
 
     private void syncFormQuestions(
@@ -171,19 +180,31 @@ public class ClubApplyFormServiceImpl implements ClubApplyFormService {
         }
     }
 
+    private void updateClubInterviewInfo(Club club, List<FormQuestionUpdateDto> questions) {
+        FormQuestionUpdateDto interviewQuestion = questions.stream()
+                .filter(FormQuestionBaseDto::isTimeSlot)
+                .findFirst()
+                .orElse(null);
+
+        if (interviewQuestion != null) {
+            if (interviewQuestion.timeSlotOptions() != null && !interviewQuestion.timeSlotOptions().isEmpty()) {
+                TimeSlotOptionRequestDto interviewInformation = interviewQuestion.timeSlotOptions().get(0);
+                LocalDateTime[] interviewPeriod = changeToDate(interviewInformation.date());
+                club.updateInterviewDate(true, interviewPeriod[0], interviewPeriod[1],
+                        interviewInformation.availableTime().start(),
+                        interviewInformation.availableTime().end());
+            }
+        } else {
+            // 면접 질문이 없으면 정보 초기화
+            club.updateInterviewDate(false,null, null, null, null);
+        }
+    }
+
     private Club findClub(Long clubId) {
         return clubRepository.findById(clubId).orElseThrow(() -> {
             log.warn("Club not found for clubId: {}", clubId);
             return new ClubNotFoundException("clubId = " + clubId);
         });
-    }
-
-    private ClubApplyForm createClubApplyForm(ClubApplyFormRequestDto request, Club findClub) {
-        return ClubApplyForm.builder()
-                .club(findClub)
-                .title(request.title())
-                .description(request.description())
-                .build();
     }
 
     private FormQuestion createFormQuestion(FormQuestionBaseDto dto, ClubApplyForm savedForm) {
@@ -194,32 +215,35 @@ public class ClubApplyFormServiceImpl implements ClubApplyFormService {
                 .isRequired(dto.isRequired())
                 .displayOrder(dto.displayOrder());
 
-        if (isTimeSlot(dto)) {
-            List<TimeSlotOptionRequestDto> timeSlots = dto.timeSlotOptions();
-            for(TimeSlotOptionRequestDto timeSlot : timeSlots) {
-                if(!timeSlot.availableTime().start().isBefore(timeSlot.availableTime().end())) {
-                    throw new InvalidTimeSlotException("면접 시작 시간은 마감 시간보다 이전이어야 합니다.");
-                }
-            }
-            builder.timeSlotOptions(timeSlots != null
-                    ? timeSlots.stream()
-                    .map(tsoDto -> new TimeSlotOption(
-                            tsoDto.date(),
-                            new TimeSlotOption.TimeRange(
-                                    tsoDto.availableTime().start(),
-                                    tsoDto.availableTime().end()
-                            )
-                    ))
-                    .toList()
-                    : List.of());
-        } else {
-            builder.options(dto.optionList());  // RADIO, CHECKBOX 등에서 사용
-        }
+        setQuestionOptions(builder, dto);
         return builder.build();
     }
 
-    private boolean isTimeSlot(FormQuestionBaseDto dto) {
-        return dto.fieldType() == FieldType.TIME_SLOT;
+    private void setQuestionOptions(FormQuestion.FormQuestionBuilder builder, FormQuestionBaseDto dto) {
+        if (dto.isTimeSlot()) {
+            builder.timeSlotOptions(createTimeSlotOptions(dto.timeSlotOptions()));
+        } else {
+            builder.options(dto.optionList());
+        }
+    }
+
+    private List<TimeSlotOption> createTimeSlotOptions(List<TimeSlotOptionRequestDto> timeSlots) {
+        if (timeSlots == null) {
+            return List.of();
+        }
+        return timeSlots.stream()
+                .map(this::mapToTimeSlotOption)
+                .toList();
+    }
+
+    private TimeSlotOption mapToTimeSlotOption(TimeSlotOptionRequestDto dto) {
+        return new TimeSlotOption(
+                dto.date(),
+                new TimeSlotOption.TimeRange(
+                        dto.availableTime().start(),
+                        dto.availableTime().end()
+                )
+        );
     }
 
     public static List<Map<String, Object>> expandDateRange(String dateRange, LocalTime startTime, LocalTime endTime) {

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/formQuestion/dto/FormQuestionBaseDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/formQuestion/dto/FormQuestionBaseDto.java
@@ -10,4 +10,8 @@ public interface FormQuestionBaseDto {
     Long displayOrder();
     List<String> optionList();
     List<TimeSlotOptionRequestDto> timeSlotOptions();
+
+    default boolean isTimeSlot() {
+        return fieldType() == FieldType.TIME_SLOT;
+    }
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/formQuestion/dto/FormQuestionUpdateDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/formQuestion/dto/FormQuestionUpdateDto.java
@@ -39,7 +39,8 @@ public record FormQuestionUpdateDto(
         List<String> optionList,
 
         @Schema(description = "(Time Slot)선택지")
-        List<TimeSlotOptionRequestDto> timeSlotOptions
+        @Valid
+        List<@Valid TimeSlotOptionRequestDto> timeSlotOptions
 ) implements FormQuestionBaseDto{
 
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/formQuestion/dto/TimeSlotOptionRequestDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/formQuestion/dto/TimeSlotOptionRequestDto.java
@@ -1,12 +1,12 @@
 package com.kakaotech.team18.backend_server.domain.formQuestion.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotNull;
-import lombok.extern.slf4j.Slf4j;
-
 import java.time.LocalTime;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Schema(description = "동아리의 면접 가능 날짜")
@@ -21,8 +21,13 @@ public record TimeSlotOptionRequestDto(
         TimeRange availableTime
 ) {
     @AssertTrue(message = "면접 시작 시간은 마감 시간보다 이전이어야 합니다.")
+    @JsonIgnore
+    @Schema(hidden = true)
     public boolean isValid() {
-        return !this.availableTime.start().isAfter(this.availableTime.end());
+        if (this.availableTime == null || this.availableTime.start() == null || this.availableTime.end() == null) {
+            return true; // @NotNull보다 이 검증이 먼저 실행돼서 null 체크를 해줌
+        }
+        return this.availableTime.start().isBefore(this.availableTime.end());
     }
 
     @Schema(description = "동아리의 면접 가능 시간")

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/formQuestion/dto/TimeSlotOptionRequestDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/formQuestion/dto/TimeSlotOptionRequestDto.java
@@ -2,6 +2,7 @@ package com.kakaotech.team18.backend_server.domain.formQuestion.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotNull;
 import lombok.extern.slf4j.Slf4j;
 
@@ -19,6 +20,11 @@ public record TimeSlotOptionRequestDto(
         @NotNull(message = "면접 가능 시간은 필수 입니다.")
         TimeRange availableTime
 ) {
+    @AssertTrue(message = "면접 시작 시간은 마감 시간보다 이전이어야 합니다.")
+    public boolean isValid() {
+        return !this.availableTime.start().isAfter(this.availableTime.end());
+    }
+
     @Schema(description = "동아리의 면접 가능 시간")
     public record TimeRange(
             @Schema(description = "면접 시작 시간", example = "10:00")
@@ -30,5 +36,3 @@ public record TimeSlotOptionRequestDto(
             LocalTime end
     ) {}
 }
-
-

--- a/src/main/java/com/kakaotech/team18/backend_server/global/util/DateUtil.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/util/DateUtil.java
@@ -1,0 +1,25 @@
+package com.kakaotech.team18.backend_server.global.util;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+public class DateUtil {
+
+    public static LocalDateTime[] changeToDate(String recruitDate) {
+        String[] recruitDates = recruitDate.replaceAll("\\s+", "").split("~");
+
+        // 날짜 형식 지정 (yyyy-MM-dd)
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+        // 문자열 → LocalDate 변환
+        LocalDate startDate = LocalDate.parse(recruitDates[0], formatter);
+        LocalDate endDate = LocalDate.parse(recruitDates[1], formatter);
+
+        LocalDateTime recruitStart = startDate.atStartOfDay();
+        LocalDateTime recruitEnd = endDate.atTime(23, 59, 59);
+
+        return new LocalDateTime[]{recruitStart, recruitEnd};
+    }
+
+}

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/club/entity/ClubTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/club/entity/ClubTest.java
@@ -92,8 +92,9 @@ class ClubTest {
         LocalTime newStartTime = LocalTime.of(10, 0);
         LocalTime newEndTime = LocalTime.of(17, 0);
 
-        club.updateInterviewDate(newStartDate, newEndDate, newStartTime, newEndTime);
+        club.updateInterviewDate(true, newStartDate, newEndDate, newStartTime, newEndTime);
 
+        assertThat(club.getIsInterviewRequired()).isTrue();
         assertThat(club.getInterviewStartDate()).isEqualTo(newStartDate);
         assertThat(club.getInterviewEndDate()).isEqualTo(newEndDate);
         assertThat(club.getInterviewStartTime()).isEqualTo(newStartTime);

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/club/entity/ClubTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/club/entity/ClubTest.java
@@ -4,6 +4,8 @@ package com.kakaotech.team18.backend_server.domain.club.entity;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.kakaotech.team18.backend_server.domain.club.dto.ClubDetailRequestDto;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -63,4 +65,40 @@ class ClubTest {
                         image2
                 ));
     }
+
+    @DisplayName("updateInterview 메서드 테스트")
+    @Test
+    void updateInterviewTest() {
+        Club club = Club.builder()
+                .name("Test Club")
+                .category(Category.STUDY)
+                .location("Test Location")
+                .shortIntroduction("Short intro")
+                .introduction(ClubIntroduction.builder()
+                        .overview("Overview")
+                        .activities("Activities")
+                        .ideal("Ideal")
+                        .build())
+                .caution("Caution")
+                .regularMeetingInfo("Regular meeting info")
+                .interviewStartDate(LocalDateTime.of(2024, 10, 1, 0, 0))
+                .interviewEndDate(LocalDateTime.of(2024, 10, 3, 23, 59, 59))
+                .interviewStartTime(LocalTime.of(9, 0))
+                .interviewEndTime(LocalTime.of(18, 0))
+                .build();
+
+        LocalDateTime newStartDate = LocalDateTime.of(2024, 11, 1, 0, 0);
+        LocalDateTime newEndDate = LocalDateTime.of(2024, 11, 5, 23, 59, 59);
+        LocalTime newStartTime = LocalTime.of(10, 0);
+        LocalTime newEndTime = LocalTime.of(17, 0);
+
+        club.updateInterviewDate(newStartDate, newEndDate, newStartTime, newEndTime);
+
+        assertThat(club.getInterviewStartDate()).isEqualTo(newStartDate);
+        assertThat(club.getInterviewEndDate()).isEqualTo(newEndDate);
+        assertThat(club.getInterviewStartTime()).isEqualTo(newStartTime);
+        assertThat(club.getInterviewEndTime()).isEqualTo(newEndTime);
+
+    }
+
 }

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/controller/ClubApplyFormControllerTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/controller/ClubApplyFormControllerTest.java
@@ -102,6 +102,7 @@ class ClubApplyFormControllerTest {
                 "테스트 동아리 지원서 설명입니다.",
                 LocalDateTime.of(2024, 9, 1, 0, 0),
                 LocalDateTime.of(2024, 9, 30, 23, 59, 59),
+                false,
                 List.of(question1, question2)
         );
 
@@ -116,6 +117,7 @@ class ClubApplyFormControllerTest {
                 .andExpect(jsonPath("$.formQuestions[0].question").value("이름"))
                 .andExpect(jsonPath("$.formQuestions[1].question").value("성별"))
                 .andExpect(jsonPath("$.recruitDate").value("2024-09-01 ~ 2024-09-30"))
+                .andExpect(jsonPath("$.interviewRequired").value(false))
                 .andExpect(jsonPath("$.formQuestions[1].optionList[0]").value("남"));
 
         verify(clubApplyFormService, times(1)).getQuestionForm(clubId);

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/controller/ClubApplyFormControllerTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/controller/ClubApplyFormControllerTest.java
@@ -22,6 +22,7 @@ import com.kakaotech.team18.backend_server.domain.clubApplyForm.service.ClubAppl
 import com.kakaotech.team18.backend_server.domain.formQuestion.dto.FormQuestionRequestDto;
 import com.kakaotech.team18.backend_server.domain.formQuestion.dto.FormQuestionResponseDto;
 import com.kakaotech.team18.backend_server.domain.formQuestion.dto.FormQuestionUpdateDto;
+import com.kakaotech.team18.backend_server.domain.formQuestion.dto.TimeSlotOptionRequestDto;
 import com.kakaotech.team18.backend_server.domain.formQuestion.dto.UserFormQuestionResponseDto;
 import com.kakaotech.team18.backend_server.domain.formQuestion.entity.FieldType;
 import com.kakaotech.team18.backend_server.global.config.SecurityConfig;
@@ -30,6 +31,7 @@ import com.kakaotech.team18.backend_server.global.exception.exceptions.ClubApply
 import com.kakaotech.team18.backend_server.global.exception.exceptions.ClubNotFoundException;
 import com.kakaotech.team18.backend_server.global.security.JwtAuthenticationFilter;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -415,6 +417,7 @@ class ClubApplyFormControllerTest {
                 "테스트 지원서",
                 "테스트 설명",
                 "2025-10-01 ~ 2025-10-31",
+                false,
                 List.of(new FormQuestionUpdateDto(1L,1L, "질문 1", FieldType.TEXT, true, 1L, null, null)
                 ));
 
@@ -440,6 +443,7 @@ class ClubApplyFormControllerTest {
                 "테스트 지원서",
                 "테스트 설명",
                 "2025-10-01 ~ 2025-10-31",
+                false,
                 List.of(new FormQuestionUpdateDto(1L, 1L,"질문 1", FieldType.TEXT, true, 1L, null, null)
                 ));
 
@@ -466,6 +470,7 @@ class ClubApplyFormControllerTest {
                 "테스트 지원서",
                 "테스트 설명",
                 "2025-10-01 ~ 2025-10-31",
+                false,
                 List.of(new FormQuestionUpdateDto(1L, 1L,"", FieldType.TEXT, true, 1L, null, null)));
 
         //when & then
@@ -488,6 +493,7 @@ class ClubApplyFormControllerTest {
                 "테스트 지원서",
                 "설명",
                 "2025-10-01 ~ 2025-10-31",
+                false,
                 List.of(new FormQuestionUpdateDto(1L, 1L,"면접 가능한 시간대를 선택해 주세요.", FieldType.TIME_SLOT, true, 1L, null, null))
         );
 
@@ -508,6 +514,7 @@ class ClubApplyFormControllerTest {
                 "테스트 지원서",
                 "설명",
                 "2025-10-01 ~ 2025-10-31",
+                false,
                 List.of(new FormQuestionUpdateDto(1L, 1L,"성별을 선택해 주세요.", FieldType.RADIO, true, 1L, null, null))
         );
 
@@ -528,6 +535,7 @@ class ClubApplyFormControllerTest {
                 "", // Blank title
                 "설명",
                 "2025-10-01 ~ 2025-10-31",
+                false,
                 List.of(new FormQuestionUpdateDto(1L, 1L, "질문", FieldType.TEXT, true, 1L, null, null))
         );
 
@@ -548,6 +556,7 @@ class ClubApplyFormControllerTest {
                 "제목",
                 "", // Blank description
                 "2025-10-01 ~ 2025-10-31",
+                false,
                 List.of(new FormQuestionUpdateDto(1L, 1L,"질문", FieldType.TEXT, true, 1L, null, null))
         );
 
@@ -569,6 +578,7 @@ class ClubApplyFormControllerTest {
                 longTitle,
                 "설명",
                 "2025-10-01 ~ 2025-10-31",
+                false,
                 List.of(new FormQuestionUpdateDto(1L, 1L,"질문", FieldType.TEXT, true, 1L, null, null))
         );
 
@@ -590,6 +600,7 @@ class ClubApplyFormControllerTest {
                 "제목",
                 longDescription,
                 "2025-10-01 ~ 2025-10-31",
+                false,
                 List.of(new FormQuestionUpdateDto(1L, 1L,"질문", FieldType.TEXT, true, 1L, null, null))
         );
 
@@ -610,6 +621,7 @@ class ClubApplyFormControllerTest {
                 "제목",
                 "설명",
                 "2025-10-01 ~ 2025-10-31",
+                false,
                 List.of(new FormQuestionUpdateDto(1L, 1L,"", FieldType.TEXT, true, 1L, null, null)) // Blank question
         );
 
@@ -631,6 +643,7 @@ class ClubApplyFormControllerTest {
                 "제목",
                 "설명",
                 "2025-10-01 ~ 2025-10-31",
+                false,
                 List.of(new FormQuestionUpdateDto(1L, 1L,longQuestion, FieldType.TEXT, true, 1L, null, null))
         );
 
@@ -643,4 +656,97 @@ class ClubApplyFormControllerTest {
                 .andExpect(jsonPath("$.message").exists());
     }
 
+    @DisplayName("동아리 지원서 수정 API 호출 - 실패(면접 필수인데 면접 시간 질문이 없는 경우 400 응답)")
+    @Test
+    void updateClubApplyForm_interviewRequiredButNoTimeSlot_shouldFailValidation() throws Exception {
+        Long clubId = 1L;
+        ClubApplyFormUpdateDto invalidRequestDto = new ClubApplyFormUpdateDto(
+                "제목",
+                "설명",
+                "2025-10-01 ~ 2025-10-31",
+                true, // 면접 필수
+                List.of(new FormQuestionUpdateDto(1L, 1L,"질문", FieldType.TEXT, true, 1L, null, null)) // TIME_SLOT 질문 없음
+        );
+
+        mockMvc.perform(patch("/api/clubs/{clubId}/dashboard/apply-form", clubId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(invalidRequestDto))
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").exists());
+    }
+
+    @DisplayName("동아리 지원서 수정 API 호출 - 성공(면접 필수이고 면접 시간 질문이 있는 경우)")
+    @Test
+    void updateClubApplyForm_interviewRequiredWithTimeSlot_shouldSucceed() throws Exception {
+        Long clubId = 1L;
+        ClubApplyFormUpdateDto validRequestDto = new ClubApplyFormUpdateDto(
+                "제목",
+                "설명",
+                "2025-10-01 ~ 2025-10-31",
+                true, // 면접 필수
+                List.of(new FormQuestionUpdateDto(1L, 1L,"면접 시간", FieldType.TIME_SLOT, true, 1L, null,
+                        List.of(new TimeSlotOptionRequestDto("2025-10-01 ~ 2025-10-31", new TimeSlotOptionRequestDto.TimeRange(
+                                LocalTime.of(10, 0), LocalTime.of(21, 0))))
+                ))
+        );
+
+        doNothing().when(clubApplyFormService).updateClubApplyForm(clubId, validRequestDto);
+
+        mockMvc.perform(patch("/api/clubs/{clubId}/dashboard/apply-form", clubId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(validRequestDto))
+                )
+                .andDo(print())
+                .andExpect(status().isAccepted());
+    }
+
+    @DisplayName("동아리 지원서 수정 API 호출 - 실패(면접 필수 아님, 면접 시간 질문 있음)")
+    @Test
+    void updateClubApplyForm_interviewNotRequiredWithTimeSlot_shouldFailValidation() throws Exception {
+        Long clubId = 1L;
+        ClubApplyFormUpdateDto invalidRequestDto = new ClubApplyFormUpdateDto(
+                "제목",
+                "설명",
+                "2025-10-01 ~ 2025-10-31",
+                false, // 면접 필수 아님
+                List.of(new FormQuestionUpdateDto(1L, 1L,"면접 시간", FieldType.TIME_SLOT, true, 1L, null,
+                        List.of(new TimeSlotOptionRequestDto("2025-10-01 ~ 2025-10-31", new TimeSlotOptionRequestDto.TimeRange(
+                                LocalTime.of(10, 0), LocalTime.of(21, 0))))
+                ))
+        );
+
+        mockMvc.perform(patch("/api/clubs/{clubId}/dashboard/apply-form", clubId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(invalidRequestDto))
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").exists());
+    }
+
+    @DisplayName("동아리 지원서 수정 API 호출 - 실패(면접 시간 질문의 availableTime.start가 availableTime.end보다 늦은 경우 400 응답)")
+    @Test
+    void updateClubApplyForm_timeSlotInvalidTimeRange_shouldFailValidation() throws Exception {
+        Long clubId = 1L;
+        ClubApplyFormUpdateDto invalidRequestDto = new ClubApplyFormUpdateDto(
+                "제목",
+                "설명",
+                "2025-10-01 ~ 2025-10-31",
+                true, // 면접 필수
+                List.of(new FormQuestionUpdateDto(1L, 1L,"면접 시간", FieldType.TIME_SLOT, true, 1L, null,
+                        List.of(new TimeSlotOptionRequestDto("2025-10-01 ~ 2025-10-31", new TimeSlotOptionRequestDto.TimeRange(
+                                LocalTime.of(21, 0), LocalTime.of(10, 0)))) // Start time after end time
+                ))
+        );
+
+        mockMvc.perform(patch("/api/clubs/{clubId}/dashboard/apply-form", clubId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(invalidRequestDto))
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").exists());
+    }
 }

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/service/ClubApplyFormServiceImplMockTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/service/ClubApplyFormServiceImplMockTest.java
@@ -77,6 +77,7 @@ class ClubApplyFormServiceImplMockTest {
                 clubApplyForm.getDescription(),
                 LocalDateTime.of(2024, 9, 1, 0, 0),
                 LocalDateTime.of(2024, 9, 30, 23, 59, 59),
+                false,
                 List.of(formQuestion).stream().map(
                                 fq -> new FormQuestionResponseDto(
                                         fq.getId(),

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/service/ClubApplyFormServiceImplMockTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/service/ClubApplyFormServiceImplMockTest.java
@@ -209,6 +209,7 @@ class ClubApplyFormServiceImplMockTest {
                 "수정된 지원서 제목",
                 "수정된 지원서 설명",
                 "2025-10-01 ~ 2025-10-31",
+                false,
                 List.of(
                         new FormQuestionUpdateDto(
                                 1L,
@@ -256,6 +257,7 @@ class ClubApplyFormServiceImplMockTest {
                 "테스트 지원서",
                 "테스트 설명",
                 "2025-10-01 ~ 2025-10-31",
+                false,
                 List.of(question1));
 
         given(club.getId()).willReturn(1L);
@@ -271,6 +273,88 @@ class ClubApplyFormServiceImplMockTest {
         then(clubApplyFormRepository).should(times(1)).findByClubId(clubId);
         then(clubApplyFormRepository).should(never()).save(any(ClubApplyForm.class));
         then(formQuestionRepository).should(never()).save(any(FormQuestion.class));
+    }
+
+    @DisplayName("지원폼 수정 - 면접 필수인데 면접 시간 질문이 있는 경우 성공")
+    @Test
+    void updateClubApplyForm_interviewRequiredWithTimeSlot_success() {
+        //given
+        Long clubId = 1L;
+        Club club = mock(Club.class);
+        ReflectionTestUtils.setField(club, "id", 1L);
+        ClubApplyForm clubApplyForm = createClubApplyForm(club);
+        ReflectionTestUtils.setField(clubApplyForm, "id", 1L);
+
+        given(club.getId()).willReturn(1L);
+        given(clubRepository.findById(clubId)).willReturn(Optional.of(club));
+        given(clubApplyFormRepository.findByClubId(clubId)).willReturn(Optional.of(clubApplyForm));
+        given(formQuestionRepository.findByClubApplyForm(clubApplyForm)).willReturn(List.of());
+        given(formQuestionRepository.save(any(FormQuestion.class))).willAnswer(invocation -> {
+            FormQuestion savedQuestion = invocation.getArgument(0);
+            ReflectionTestUtils.setField(savedQuestion, "id", 1L); // Simulate ID generation
+            return savedQuestion;
+        });
+
+        LocalTime startTime = LocalTime.of(10, 0);
+        LocalTime endTime = LocalTime.of(21, 0);
+        String dateRange = "2025-10-01 ~ 2025-10-31";
+
+        ClubApplyFormUpdateDto requestDto = new ClubApplyFormUpdateDto(
+                "테스트 지원서",
+                "테스트 설명",
+                "2025-10-01 ~ 2025-10-31",
+                true, // 면접 필수
+                List.of(new FormQuestionUpdateDto(
+                        null, 1L, "면접 시간", FieldType.TIME_SLOT, true, 1L, null,
+                        List.of(new TimeSlotOptionRequestDto(dateRange, new TimeSlotOptionRequestDto.TimeRange(startTime, endTime)))
+                ))
+        );
+
+        //when
+        clubApplyFormService.updateClubApplyForm(clubId, requestDto);
+
+        //then
+        LocalDateTime expectedStart = LocalDateTime.of(2025, 10, 1, 0, 0, 0);
+        LocalDateTime expectedEnd = LocalDateTime.of(2025, 10, 31, 23, 59, 59);
+
+        then(club).should(times(1)).updateInterviewDate(true, expectedStart, expectedEnd, startTime, endTime);
+    }
+
+    @DisplayName("지원폼 수정 - 면접 필수 아님, 면접 시간 질문 없음 - 성공")
+    @Test
+    void updateClubApplyForm_interviewNotRequiredNoTimeSlot_success() {
+        //given
+        Long clubId = 1L;
+        Club club = mock(Club.class);
+        ReflectionTestUtils.setField(club, "id", 1L);
+        ClubApplyForm clubApplyForm = createClubApplyForm(club);
+        ReflectionTestUtils.setField(clubApplyForm, "id", 1L);
+
+        given(club.getId()).willReturn(1L);
+        given(clubRepository.findById(clubId)).willReturn(Optional.of(club));
+        given(clubApplyFormRepository.findByClubId(clubId)).willReturn(Optional.of(clubApplyForm));
+        given(formQuestionRepository.findByClubApplyForm(clubApplyForm)).willReturn(List.of());
+        given(formQuestionRepository.save(any(FormQuestion.class))).willAnswer(invocation -> {
+            FormQuestion savedQuestion = invocation.getArgument(0);
+            ReflectionTestUtils.setField(savedQuestion, "id", 1L); // Simulate ID generation
+            return savedQuestion;
+        });
+
+        ClubApplyFormUpdateDto requestDto = new ClubApplyFormUpdateDto(
+                "테스트 지원서",
+                "테스트 설명",
+                "2025-10-01 ~ 2025-10-31",
+                false, // 면접 필수 아님
+                List.of(new FormQuestionUpdateDto(
+                        null, 1L, "일반 질문", FieldType.TEXT, true, 1L, null, null
+                ))
+        );
+
+        //when
+        clubApplyFormService.updateClubApplyForm(clubId, requestDto);
+
+        //then
+        then(club).should(times(1)).updateInterviewDate(false, null, null, null, null);
     }
 
 


### PR DESCRIPTION
## 🚀 작업 내용
면접 여부를 체크받고 면접을 본다면 면접 시간 관련 타임 슬롯 질문을 필수로 받기로 했는데 이와 관련한 기능을 구현했습니다. 

면접 여부와 관련한 데이터를 받도록 관련 DTO들을 수정하였고, DTO에서 검증할 수 있는 검증 로직들은 DTO에서 검증하도록 수정하였습니다. 

동아리 면접 관련 정보는 Club 엔티티에 저장되는게 이상적이라고 생각해 Club 엔티티에 면접과 관련한 필드를 추가했습니다. 지원자들의 면접 선호 시간이나 면접 확정 시간은 추후  클래스를 만들거나 Appliaction 엔티티에 필드를 추가해볼 생각입니다. 

지원폼 수정과 관련한 메서드들을 리팩토링해봤습니다. 가독성이 좋아지도록 바꿔보았는데,, 더 복잡해진건 아닌가 싶어서 읽어보시면서 모르겠는 부분 있으면 말씀해주세요. 

## ⏱️ 소요 시간
7시간

## 🤔 고민했던 내용
면접 관련 기능을 어떻게 구현할까 하다가 일단 나눠서 구현해보려고 했습니다. 

기존 로직이 너무 가독성이 안좋아보여서 검증 로직을 분리하고 리팩토링해보려고 했는데 효과가 있는지 모르겠습니다.

## 💬 리뷰 중점사항
면접 관련 정보를 어떻게 주고 받을지 고민이 되었는데 DTO가 적절하게 수정되었는지 확인 부탁드립니다. 
동아리의 면접 관련 기능을 먼저 구현하고 지원자와 관련한 면접 관련 기능을 구현해보려고 합니다. 제가 생각하고 있는 방향이 이해가 안되거나 또 다른 좋은 방법이 있으시면 조언 부탁드립니다. 

## 🔗관련 이슈
- Close #275 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 동아리 모집 폼에 인터뷰 일정 관리가 추가되었습니다: 인터뷰 필수 여부, 인터뷰 기간(시작/종료 날짜) 및 시간대를 설정할 수 있습니다.
  * 모집 기간 문자열을 날짜범위로 변환하는 기능이 추가되어 입력 범위 처리가 표준화되었습니다.
  * 폼/응답 DTO에 인터뷰 필드가 반영되어 응답 출력에 인터뷰 정보가 포함됩니다.

* **테스트**
  * 인터뷰 일정 및 시간대 유효성(시작 < 종료)과 인터뷰 필수 여부 관련 테스트가 추가/확장되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->