### PR TITLE
[FEATURE] 동아리 지원자의 면접 정보 관련 기능 구현 (#280)

### DIFF
--- a/src/main/java/com/kakaotech/team18/backend_server/domain/application/controller/ApplicationController.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/application/controller/ApplicationController.java
@@ -4,6 +4,7 @@ import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationApp
 import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationApplyResponseDto;
 import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationApprovedRequestDto;
 import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationDetailResponseDto;
+import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationFixedInterviewRequestDto;
 import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationStatusUpdateRequestDto;
 import com.kakaotech.team18.backend_server.domain.application.entity.Stage;
 import com.kakaotech.team18.backend_server.domain.application.service.ApplicationService;
@@ -65,6 +66,23 @@ public class ApplicationController {
         SuccessResponseDto responseDto = applicationService.updateApplicationStatus(applicationId, requestDto);
         return ResponseEntity.ok(responseDto);
     }
+
+    @Operation(summary = "지원자의 면접 일정 변경", description = "동아리 운영진이 지원자의 면접 일정을 변경합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "상태 변경 성공"),
+            @ApiResponse(responseCode = "404", description = "상태를 변경할 지원서를 찾을 수 없음")
+    })
+    @PreAuthorize("@customSecurityService.isClubAdminOrExecutiveForApplication(#applicationId)")
+    @PatchMapping("/{clubId}/applications/{applicationId}/interview")
+    public ResponseEntity<SuccessResponseDto> updateApplicationInterviewSchedule(
+            @Parameter(description = "동아리의 고유 ID", required = true, example = "1") @PathVariable("clubId") Long clubId,
+            @Parameter(description = "상태를 변경할 지원서의 고유 ID", required = true, example = "100") @PathVariable("applicationId") Long applicationId,
+            @Valid @RequestBody ApplicationFixedInterviewRequestDto requestDto
+    ) {
+        SuccessResponseDto responseDto = applicationService.updateApplicationInterviewSchedule(applicationId, requestDto);
+        return ResponseEntity.ok(responseDto);
+    }
+
 
     @Operation(
             summary = "지원서 제출",

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/application/dto/ApplicationFixedInterviewRequestDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/application/dto/ApplicationFixedInterviewRequestDto.java
@@ -1,0 +1,13 @@
+package com.kakaotech.team18.backend_server.domain.application.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+
+@Schema(description = "지원자 인터뷰 일정 확정 요청 데이터")
+public record ApplicationFixedInterviewRequestDto(
+        @Schema(description = "지원자 인터뷰 일시", example = "2026-02-10T10:00:00")
+        @NotNull(message = "인터뷰 일시는 필수입니다.")
+        LocalDateTime interviewAt
+)
+{}

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/application/entity/Application.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/application/entity/Application.java
@@ -6,9 +6,7 @@ import com.kakaotech.team18.backend_server.domain.clubApplyForm.entity.ClubApply
 import com.kakaotech.team18.backend_server.domain.comment.entity.Comment;
 import com.kakaotech.team18.backend_server.domain.user.entity.User;
 import jakarta.persistence.CascadeType;
-import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
-import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -19,18 +17,17 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
-import jakarta.persistence.OrderColumn;
+import jakarta.persistence.OrderBy;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.util.ArrayList;
-import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -73,12 +70,8 @@ public class Application extends BaseEntity {
 
     private LocalTime interviewTime;
 
-    @ElementCollection
-    @CollectionTable(
-            name = "application_interview_preference",
-            joinColumns = @JoinColumn(name = "application_id")
-    )
-    @OrderColumn(name = "pref_idx")
+    @OneToMany(mappedBy = "application", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("date ASC")
     private List<InterviewPreference> interviewPreferences = new ArrayList<>();
 
     @Builder
@@ -111,12 +104,25 @@ public class Application extends BaseEntity {
 
     public void updatePreferInterviewInfo(Map<LocalDate, List<LocalTime>> preferInterviewInfo) {
         log.info("{}지원자 인터뷰 선호 시간 정보 업데이트", this.id);
-        interviewPreferences.clear();
-        for (Map.Entry<LocalDate, List<LocalTime>> entry : preferInterviewInfo.entrySet()){
+
+        // orphanRemoval=true 이므로 기존 선호 정보는 전부 제거
+        this.interviewPreferences.clear();
+
+        if (preferInterviewInfo == null || preferInterviewInfo.isEmpty()) {
+            log.info("{}지원자 인터뷰 선호 시간 정보가 비어있습니다.", this.id);
+            return;
+        }
+
+        for (Map.Entry<LocalDate, List<LocalTime>> entry : preferInterviewInfo.entrySet()) {
             LocalDate date = entry.getKey();
             List<LocalTime> timeSlots = entry.getValue();
-            interviewPreferences.add(new InterviewPreference(date, timeSlots));
+
+            // date는 필수, timeSlots는 null이면 빈 리스트로 처리
+            if (date == null) continue;
+
+            this.interviewPreferences.add(new InterviewPreference(this, date, timeSlots));
         }
+
         log.info("{}지원자 인터뷰 선호 시간 정보 업데이트 완료", this.id);
     }
 

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/application/entity/Application.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/application/entity/Application.java
@@ -100,7 +100,7 @@ public class Application extends BaseEntity {
         this.averageRating = averageRating;
     }
 
-    public void updateInterviewInfo(Map<LocalDate, List<LocalTime>> preferInterviewInfo) {
+    public void updatePreferInterviewInfo(Map<LocalDate, List<LocalTime>> preferInterviewInfo) {
         log.info("{}지원자 인터뷰 선호 시간 정보 업데이트", this.id);
         interviewPreferences.clear();
         for (Map.Entry<LocalDate, List<LocalTime>> entry : preferInterviewInfo.entrySet()){

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/application/entity/Application.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/application/entity/Application.java
@@ -6,7 +6,9 @@ import com.kakaotech.team18.backend_server.domain.clubApplyForm.entity.ClubApply
 import com.kakaotech.team18.backend_server.domain.comment.entity.Comment;
 import com.kakaotech.team18.backend_server.domain.user.entity.User;
 import jakarta.persistence.CascadeType;
+import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -17,6 +19,9 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.Map;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -24,7 +29,9 @@ import lombok.NoArgsConstructor;
 
 import java.util.ArrayList;
 import java.util.List;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -60,6 +67,13 @@ public class Application extends BaseEntity {
     @OneToMany(mappedBy = "application", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<Comment> comments = new ArrayList<>();
 
+    @ElementCollection
+    @CollectionTable(
+            name = "application_interview_preference",
+            joinColumns = @JoinColumn(name = "application_id")
+    )
+    private List<InterviewPreference> interviewPreferences = new ArrayList<>();
+
     @Builder
     private Application(User user, ClubApplyForm clubApplyForm, Status status, Stage stage) {
         this.user = user;
@@ -84,5 +98,16 @@ public class Application extends BaseEntity {
 
     public void updateAverageRating(Double averageRating) {
         this.averageRating = averageRating;
+    }
+
+    public void updateInterviewInfo(Map<LocalDate, List<LocalTime>> preferInterviewInfo) {
+        log.info("{}지원자 인터뷰 선호 시간 정보 업데이트", this.id);
+        interviewPreferences.clear();
+        for (Map.Entry<LocalDate, List<LocalTime>> entry : preferInterviewInfo.entrySet()){
+            LocalDate date = entry.getKey();
+            List<LocalTime> timeSlots = entry.getValue();
+            interviewPreferences.add(new InterviewPreference(date, timeSlots));
+        }
+        log.info("{}지원자 인터뷰 선호 시간 정보 업데이트 완료", this.id);
     }
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/application/entity/Application.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/application/entity/Application.java
@@ -68,7 +68,9 @@ public class Application extends BaseEntity {
     @OneToMany(mappedBy = "application", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<Comment> comments = new ArrayList<>();
 
-    private LocalDateTime interviewSchedule;
+    private LocalDate interviewDate;
+
+    private LocalTime interviewTime;
 
     @ElementCollection
     @CollectionTable(
@@ -78,13 +80,14 @@ public class Application extends BaseEntity {
     private List<InterviewPreference> interviewPreferences = new ArrayList<>();
 
     @Builder
-    private Application(User user, ClubApplyForm clubApplyForm, Status status, Stage stage, LocalDateTime interviewSchedule) {
+    private Application(User user, ClubApplyForm clubApplyForm, Status status, Stage stage, LocalDate interviewDate, LocalTime interviewTime) {
         this.user = user;
         this.clubApplyForm = clubApplyForm;
         this.status = (status != null) ? status : Status.PENDING; // 기본값 보존
         this.stage = (stage != null) ? stage : Stage.INTERVIEW;
         this.averageRating = 0.0;
-        this.interviewSchedule = interviewSchedule;
+        this.interviewDate = interviewDate;
+        this.interviewTime = interviewTime;
     }
 
     /**
@@ -117,7 +120,8 @@ public class Application extends BaseEntity {
 
     public void updateInterviewInfo(LocalDateTime interviewSchedule) {
         log.info("지원자의 인터뷰 일정 업데이트 시작 applicationId={}, interviewSchedule={}", this.id, interviewSchedule);
-        this.interviewSchedule = interviewSchedule;
+        this.interviewDate = interviewSchedule.toLocalDate();
+        this.interviewTime = interviewSchedule.toLocalTime();
         log.info("지원자의 인터뷰 일정 업데이트 완료 applicationId={}, interviewSchedule={}", this.id, interviewSchedule);
     }
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/application/entity/Application.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/application/entity/Application.java
@@ -20,6 +20,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.Map;
 import lombok.AccessLevel;
@@ -67,6 +68,8 @@ public class Application extends BaseEntity {
     @OneToMany(mappedBy = "application", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<Comment> comments = new ArrayList<>();
 
+    private LocalDateTime interviewSchedule;
+
     @ElementCollection
     @CollectionTable(
             name = "application_interview_preference",
@@ -75,12 +78,13 @@ public class Application extends BaseEntity {
     private List<InterviewPreference> interviewPreferences = new ArrayList<>();
 
     @Builder
-    private Application(User user, ClubApplyForm clubApplyForm, Status status, Stage stage) {
+    private Application(User user, ClubApplyForm clubApplyForm, Status status, Stage stage, LocalDateTime interviewSchedule) {
         this.user = user;
         this.clubApplyForm = clubApplyForm;
         this.status = (status != null) ? status : Status.PENDING; // 기본값 보존
         this.stage = (stage != null) ? stage : Stage.INTERVIEW;
         this.averageRating = 0.0;
+        this.interviewSchedule = interviewSchedule;
     }
 
     /**
@@ -109,5 +113,11 @@ public class Application extends BaseEntity {
             interviewPreferences.add(new InterviewPreference(date, timeSlots));
         }
         log.info("{}지원자 인터뷰 선호 시간 정보 업데이트 완료", this.id);
+    }
+
+    public void updateInterviewInfo(LocalDateTime interviewSchedule) {
+        log.info("지원자의 인터뷰 일정 업데이트 시작 applicationId={}, interviewSchedule={}", this.id, interviewSchedule);
+        this.interviewSchedule = interviewSchedule;
+        log.info("지원자의 인터뷰 일정 업데이트 완료 applicationId={}, interviewSchedule={}", this.id, interviewSchedule);
     }
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/application/entity/Application.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/application/entity/Application.java
@@ -19,6 +19,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderColumn;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -77,6 +78,7 @@ public class Application extends BaseEntity {
             name = "application_interview_preference",
             joinColumns = @JoinColumn(name = "application_id")
     )
+    @OrderColumn(name = "pref_idx")
     private List<InterviewPreference> interviewPreferences = new ArrayList<>();
 
     @Builder

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/application/entity/InterviewPreference.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/application/entity/InterviewPreference.java
@@ -1,7 +1,10 @@
 package com.kakaotech.team18.backend_server.domain.application.entity;
 
+import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Embeddable;
+import jakarta.persistence.JoinColumn;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.ArrayList;
@@ -20,6 +23,14 @@ public class InterviewPreference {
     @Column(nullable = false)
     private LocalDate date;
 
-    @Column(nullable = false)
+    @ElementCollection
+    @CollectionTable(
+            name = "interview_preference_time",
+            joinColumns = {
+                    @JoinColumn(name = "application_id"),
+                    @JoinColumn(name = "pref_idx")
+            }
+    )
+    @Column(name = "time", nullable = false)
     private List<LocalTime> time = new ArrayList<>();
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/application/entity/InterviewPreference.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/application/entity/InterviewPreference.java
@@ -1,0 +1,25 @@
+package com.kakaotech.team18.backend_server.domain.application.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class InterviewPreference {
+
+    @Column(nullable = false)
+    private LocalDate date;
+
+    @Column(nullable = false)
+    private List<LocalTime> time = new ArrayList<>();
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/application/entity/InterviewPreference.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/application/entity/InterviewPreference.java
@@ -3,8 +3,13 @@ package com.kakaotech.team18.backend_server.domain.application.entity;
 import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
 import jakarta.persistence.ElementCollection;
-import jakarta.persistence.Embeddable;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.ArrayList;
@@ -14,11 +19,19 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Embeddable
+@Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class InterviewPreference {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "application_id", nullable = false)
+    private Application application;
 
     @Column(nullable = false)
     private LocalDate date;
@@ -26,11 +39,14 @@ public class InterviewPreference {
     @ElementCollection
     @CollectionTable(
             name = "interview_preference_time",
-            joinColumns = {
-                    @JoinColumn(name = "application_id"),
-                    @JoinColumn(name = "pref_idx")
-            }
+            joinColumns = @JoinColumn(name = "interview_preference_id")
     )
     @Column(name = "time", nullable = false)
-    private List<LocalTime> time = new ArrayList<>();
+    private List<LocalTime> times = new ArrayList<>();
+
+    public InterviewPreference(Application application, LocalDate date, List<LocalTime> times) {
+        this.application = application;
+        this.date = date;
+        if (times != null) this.times.addAll(times);
+    }
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/application/repository/ApplicationRepository.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/application/repository/ApplicationRepository.java
@@ -89,4 +89,18 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
       AND cm.role = :role
     """)
     List<Application> findAllByClubIdAndRole(Long clubId, Role role);
+
+    @Query("""
+    SELECT 
+        a.interviewDate as interviewDate,
+        a.interviewTime as interviewTime,
+        count(a.id) as assignedCount
+    FROM Application a
+    JOIN a.clubApplyForm caf
+    WHERE caf.club.id = :clubId
+      AND a.interviewDate is not null
+      AND a.interviewTime is not null
+    GROUP BY a.interviewDate, a.interviewTime
+    """)
+    List<InterviewSlotCountProjection> countInterviewSlots(Long clubId);
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/application/repository/InterviewSlotCountProjection.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/application/repository/InterviewSlotCountProjection.java
@@ -1,0 +1,10 @@
+package com.kakaotech.team18.backend_server.domain.application.repository;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public interface InterviewSlotCountProjection {
+    LocalDate getInterviewDate();
+    LocalTime getInterviewTime();
+    long getAssignedCount();
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/application/service/ApplicationService.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/application/service/ApplicationService.java
@@ -4,6 +4,7 @@ import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationApp
 import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationApplyResponseDto;
 import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationApprovedRequestDto;
 import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationDetailResponseDto;
+import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationFixedInterviewRequestDto;
 import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationStatusUpdateRequestDto;
 import com.kakaotech.team18.backend_server.domain.application.entity.Stage;
 import com.kakaotech.team18.backend_server.global.dto.SuccessResponseDto;
@@ -16,4 +17,6 @@ public interface ApplicationService {
     ApplicationApplyResponseDto submitApplication(Long clubId, ApplicationApplyRequestDto request, boolean confirmOverwrite);
 
     SuccessResponseDto sendPassFailMessage(Long clubId, ApplicationApprovedRequestDto requestDto, Stage stage);
+
+    SuccessResponseDto updateApplicationInterviewSchedule(Long applicationId, ApplicationFixedInterviewRequestDto requestDto);
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/application/service/ApplicationServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/application/service/ApplicationServiceImpl.java
@@ -400,7 +400,7 @@ public class ApplicationServiceImpl implements ApplicationService {
                         a.getUser().getEmail(),
                         requestDto.message(),
                         originalStage,
-                        LocalDateTime.of(a.getInterviewDate(), a.getInterviewTime())
+                        safeInterviewAt(a)
                 ));
             }
             for(Application a : rejected) {
@@ -484,6 +484,17 @@ public class ApplicationServiceImpl implements ApplicationService {
     }
 
     //helper methods
+
+    private LocalDateTime safeInterviewAt(Application a) {
+        // 인터뷰 합격(=다음 단계 진행)인데 면접 시간이 비어있을 수 있어 null-safe 처리
+        // (메일/알림에서 null이면 '추후 안내' 등으로 처리하도록 이벤트가 전달받게 함)
+        if (a.getInterviewDate() == null || a.getInterviewTime() == null) {
+            log.warn("Interview schedule is missing. applicationId={}, interviewDate={}, interviewTime={}",
+                    a.getId(), a.getInterviewDate(), a.getInterviewTime());
+            return null;
+        }
+        return LocalDateTime.of(a.getInterviewDate(), a.getInterviewTime());
+    }
 
     private ApplicationInfoDto buildApplicationInfo(Application a, User president) {
         return new ApplicationInfoDto(

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/application/service/ApplicationServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/application/service/ApplicationServiceImpl.java
@@ -10,6 +10,7 @@ import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationApp
 import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationApplyResponseDto;
 import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationApprovedRequestDto;
 import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationDetailResponseDto;
+import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationFixedInterviewRequestDto;
 import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationStatusUpdateRequestDto;
 import com.kakaotech.team18.backend_server.domain.application.entity.Application;
 import com.kakaotech.team18.backend_server.domain.application.entity.Stage;
@@ -133,6 +134,17 @@ public class ApplicationServiceImpl implements ApplicationService {
                 applicationId, application.getStatus());
 
         // 3. 성공 응답 DTO 반환
+        return new SuccessResponseDto(true);
+    }
+
+    @Transactional
+    @Override
+    public SuccessResponseDto updateApplicationInterviewSchedule(Long applicationId, ApplicationFixedInterviewRequestDto request) {
+        Application application = applicationRepository.findById(applicationId)
+                .orElseThrow(() -> new ApplicationNotFoundException("applicationId: " + applicationId));
+
+        application.updateInterviewInfo(request.interviewAt());
+
         return new SuccessResponseDto(true);
     }
 

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/application/service/ApplicationServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/application/service/ApplicationServiceImpl.java
@@ -399,7 +399,9 @@ public class ApplicationServiceImpl implements ApplicationService {
                         a.getId(),
                         a.getUser().getEmail(),
                         requestDto.message(),
-                        originalStage));
+                        originalStage,
+                        LocalDateTime.of(a.getInterviewDate(), a.getInterviewTime())
+                ));
             }
             for(Application a : rejected) {
                 ApplicationInfoDto applicationInfoDto = buildApplicationInfo(a,president);

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/application/service/ApplicationServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/application/service/ApplicationServiceImpl.java
@@ -1,43 +1,48 @@
 package com.kakaotech.team18.backend_server.domain.application.service;
 
+import static java.util.Objects.nonNull;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.kakaotech.team18.backend_server.domain.answer.entity.Answer;
 import com.kakaotech.team18.backend_server.domain.answer.repository.AnswerRepository;
+import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationApplyRequestDto;
+import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationApplyRequestDto.AnswerDto;
+import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationApplyResponseDto;
+import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationApprovedRequestDto;
+import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationDetailResponseDto;
+import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationStatusUpdateRequestDto;
+import com.kakaotech.team18.backend_server.domain.application.entity.Application;
+import com.kakaotech.team18.backend_server.domain.application.entity.Stage;
+import com.kakaotech.team18.backend_server.domain.application.entity.Status;
+import com.kakaotech.team18.backend_server.domain.application.repository.ApplicationRepository;
+import com.kakaotech.team18.backend_server.domain.clubApplyForm.entity.ClubApplyForm;
+import com.kakaotech.team18.backend_server.domain.clubApplyForm.repository.ClubApplyFormRepository;
 import com.kakaotech.team18.backend_server.domain.clubMember.entity.ActiveStatus;
 import com.kakaotech.team18.backend_server.domain.clubMember.entity.ClubMember;
 import com.kakaotech.team18.backend_server.domain.clubMember.entity.Role;
 import com.kakaotech.team18.backend_server.domain.clubMember.repository.ClubMemberRepository;
+import com.kakaotech.team18.backend_server.domain.email.dto.AnswerEmailLine;
 import com.kakaotech.team18.backend_server.domain.email.dto.ApplicationInfoDto;
-import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationApprovedRequestDto;
-import com.kakaotech.team18.backend_server.domain.application.entity.Stage;
-import com.kakaotech.team18.backend_server.domain.application.entity.Status;
+import com.kakaotech.team18.backend_server.domain.email.dto.ApplicationSubmittedEvent;
 import com.kakaotech.team18.backend_server.domain.email.dto.FinalApprovedEvent;
 import com.kakaotech.team18.backend_server.domain.email.dto.FinalRejectedEvent;
 import com.kakaotech.team18.backend_server.domain.email.dto.InterviewApprovedEvent;
 import com.kakaotech.team18.backend_server.domain.email.dto.InterviewRejectedEvent;
 import com.kakaotech.team18.backend_server.domain.formQuestion.entity.FormQuestion;
 import com.kakaotech.team18.backend_server.domain.formQuestion.repository.FormQuestionRepository;
-import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationApplyRequestDto;
-import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationApplyRequestDto.AnswerDto;
-import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationApplyResponseDto;
-import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationDetailResponseDto;
-import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationStatusUpdateRequestDto;
-import com.kakaotech.team18.backend_server.domain.application.entity.Application;
-import com.kakaotech.team18.backend_server.domain.application.repository.ApplicationRepository;
-import com.kakaotech.team18.backend_server.domain.clubApplyForm.entity.ClubApplyForm;
-import com.kakaotech.team18.backend_server.domain.clubApplyForm.repository.ClubApplyFormRepository;
-import com.kakaotech.team18.backend_server.domain.email.dto.AnswerEmailLine;
-import com.kakaotech.team18.backend_server.domain.email.dto.ApplicationSubmittedEvent;
 import com.kakaotech.team18.backend_server.domain.user.entity.User;
 import com.kakaotech.team18.backend_server.domain.user.repository.UserRepository;
 import com.kakaotech.team18.backend_server.global.dto.SuccessResponseDto;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.ApplicationNotFoundException;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.ClubApplyFormNotFoundException;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.ExistingUserEmailException;
-import com.kakaotech.team18.backend_server.global.exception.exceptions.ExistingUserNameException;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.ExistingUserPhoneNumberException;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.ExistingUserStudentIdException;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.InvalidAnswerException;
+import com.kakaotech.team18.backend_server.global.exception.exceptions.NoApplicationException;
+import com.kakaotech.team18.backend_server.global.exception.exceptions.PendingApplicationsExistException;
+import com.kakaotech.team18.backend_server.global.exception.exceptions.PresidentNotFoundException;
+import com.kakaotech.team18.backend_server.global.util.DateUtil;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -48,17 +53,11 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-
-import com.kakaotech.team18.backend_server.global.exception.exceptions.NoApplicationException;
-import com.kakaotech.team18.backend_server.global.exception.exceptions.PresidentNotFoundException;
-import com.kakaotech.team18.backend_server.global.exception.exceptions.PendingApplicationsExistException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import static java.util.Objects.nonNull;
 
 @Slf4j
 @Service
@@ -148,8 +147,6 @@ public class ApplicationServiceImpl implements ApplicationService {
         //1. applicationForm 찾기
         ClubApplyForm form = clubApplyFormRepository.findByClubId(clubId)
                 .orElseThrow(() -> new ClubApplyFormNotFoundException("clubId:"+clubId));
-        //근데 이 exception이 현실적으로 발생 가능한가?
-        //만약 제출폼을 작성하는 사이에 폼이 수정되었다면?
 
         //2. 유저 정보생성(없으면 생성)
         User user = userRepository.findByStudentId(request.studentId())
@@ -204,15 +201,15 @@ public class ApplicationServiceImpl implements ApplicationService {
             Application application,
             ApplicationApplyRequestDto request
     ) {
-        long deleted = answerRepository.deleteByApplication(application);
-        log.info("기존 답변 삭제됨 applicationId={}, 삭제된문항수={}", application.getId(), deleted);
+        long countDeletedAnswers = answerRepository.deleteByApplication(application);
+        log.info("기존 답변 삭제됨 applicationId={}, 삭제된문항수={}", application.getId(), countDeletedAnswers);
 
         User president = clubMemberRepository
                 .findUserByClubIdAndRoleAndStatus(application.getClubApplyForm().getClub().getId(), Role.CLUB_ADMIN, ActiveStatus.ACTIVE)
                 .orElseThrow(() -> new PresidentNotFoundException("clubId:" + application.getClubApplyForm().getClub().getId()));
 
         List<AnswerEmailLine> emailLines = saveApplicationAnswers(application, request.answers());
-        ApplicationInfoDto applicationInfoDto = buildApplicationInfo(application,  president);
+        ApplicationInfoDto applicationInfoDto = buildApplicationInfo(application, president);
         publisher.publishEvent(new ApplicationSubmittedEvent(applicationInfoDto, application.getId(), emailLines));
 
         return new ApplicationApplyResponseDto(
@@ -322,6 +319,7 @@ public class ApplicationServiceImpl implements ApplicationService {
                                 .formatted(q.getDisplayOrder(), q.getId(), q.getQuestion()));
                     }
                     normalized = String.join(",", options);
+                    application.updateInterviewInfo(DateUtil.parseDateAndTimeSlots(normalized));
                 }
                 default -> throw new InvalidAnswerException("지원하지 않는 타입: " + q.getFieldType());
             }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/application/service/ApplicationServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/application/service/ApplicationServiceImpl.java
@@ -319,7 +319,7 @@ public class ApplicationServiceImpl implements ApplicationService {
                                 .formatted(q.getDisplayOrder(), q.getId(), q.getQuestion()));
                     }
                     normalized = String.join(",", options);
-                    application.updateInterviewInfo(DateUtil.parseDateAndTimeSlots(normalized));
+                    application.updatePreferInterviewInfo(DateUtil.parseDateAndTimeSlots(normalized));
                 }
                 default -> throw new InvalidAnswerException("지원하지 않는 타입: " + q.getFieldType());
             }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/club/dto/ClubDashBoardResponseDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/club/dto/ClubDashBoardResponseDto.java
@@ -6,7 +6,7 @@ import java.time.LocalDate;
 @Schema(description = "동아리 대시보드 조회 응답 데이터")
 public record ClubDashBoardResponseDto(
         @Schema(description = "동아리 고유 ID", example = "1")
-        Long  clubId,
+        Long clubId,
         @Schema(description = "총 지원자 수", example = "50")
         int totalApplicantCount,
         @Schema(description = "현재 대기중인 지원서 수", example = "15")
@@ -14,6 +14,12 @@ public record ClubDashBoardResponseDto(
         @Schema(description = "모집 시작일 (yyyy-MM-dd 형식)", example = "2024-09-01")
         LocalDate startDay,
         @Schema(description = "모집 마감일 (yyyy-MM-dd 형식)", example = "2024-09-15")
-        LocalDate endDay
+        LocalDate endDay,
+        @Schema(description = "면접 시작일 (yyyy-MM-dd 형식)", example = "2024-09-01")
+        LocalDate interviewStartDay,
+        @Schema(description = "면접 마감일 (yyyy-MM-dd 형식)", example = "2024-09-05")
+        LocalDate interviewEndDay,
+        @Schema(description = "면접 시간 (09:00 ~ 21:00 형식)", example = "09:00 ~ 21:00")
+        String interviewTime
 ) {
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/club/dto/ClubDashboardApplicantResponseDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/club/dto/ClubDashboardApplicantResponseDto.java
@@ -3,14 +3,26 @@ package com.kakaotech.team18.backend_server.domain.club.dto;
 import com.kakaotech.team18.backend_server.domain.clubMember.dto.ApplicantResponseDto;
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
 
 public record ClubDashboardApplicantResponseDto(
         @Schema(description = "지원자 목록")
         List<ApplicantResponseDto> applicants,
 
+        List<InterviewDateSlotsDto> interviewSchedule,
+
         @Schema(description = "메세지")
         String message
 ) {
-
+    public record InterviewDateSlotsDto(
+            LocalDate date,
+            List<InterviewSlotCountDto> slots
+    ) {
+        public record InterviewSlotCountDto(
+                LocalTime time,
+                int assignedCount
+        ) {}
+    }
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/club/dto/ClubDashboardApplicantResponseDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/club/dto/ClubDashboardApplicantResponseDto.java
@@ -8,6 +8,9 @@ import java.time.LocalTime;
 import java.util.List;
 
 public record ClubDashboardApplicantResponseDto(
+        @Schema(description = "면접 필수 여부")
+        Boolean interviewRequired,
+
         @Schema(description = "지원자 목록")
         List<ApplicantResponseDto> applicants,
 

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/club/service/ClubServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/club/service/ClubServiceImpl.java
@@ -1,6 +1,5 @@
 package com.kakaotech.team18.backend_server.domain.club.service;
 
-import com.kakaotech.team18.backend_server.domain.application.entity.Application;
 import com.kakaotech.team18.backend_server.domain.application.entity.Stage;
 import com.kakaotech.team18.backend_server.domain.application.entity.Status;
 import com.kakaotech.team18.backend_server.domain.application.repository.ApplicationRepository;
@@ -28,6 +27,7 @@ import com.kakaotech.team18.backend_server.global.exception.exceptions.ClubApply
 import com.kakaotech.team18.backend_server.global.exception.exceptions.ClubMemberNotFoundException;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.ClubNotFoundException;
 import com.kakaotech.team18.backend_server.global.service.S3Service;
+import com.kakaotech.team18.backend_server.global.util.DateUtil;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -125,7 +125,10 @@ public class ClubServiceImpl implements ClubService {
                 applicantList.size(),
                 pendingApplications.size(),
                 club.getRecruitStart().toLocalDate(),
-                club.getRecruitEnd().toLocalDate());
+                club.getRecruitEnd().toLocalDate(),
+                club.getInterviewStartDate().toLocalDate(),
+                club.getInterviewEndDate().toLocalDate(),
+                DateUtil.formatTimeRange(club.getInterviewStartTime(), club.getInterviewEndTime()));
     }
 
     @Override

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/club/service/ClubServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/club/service/ClubServiceImpl.java
@@ -179,6 +179,7 @@ public class ClubServiceImpl implements ClubService {
                         ))
                         .toList();
         return new ClubDashboardApplicantResponseDto(
+                clubApplyForm.getClub().getIsInterviewRequired(),
                 applicants
                         .stream()
                         .map(ApplicantResponseDto::from)

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/club/service/ClubServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/club/service/ClubServiceImpl.java
@@ -3,8 +3,11 @@ package com.kakaotech.team18.backend_server.domain.club.service;
 import com.kakaotech.team18.backend_server.domain.application.entity.Stage;
 import com.kakaotech.team18.backend_server.domain.application.entity.Status;
 import com.kakaotech.team18.backend_server.domain.application.repository.ApplicationRepository;
+import com.kakaotech.team18.backend_server.domain.application.repository.InterviewSlotCountProjection;
 import com.kakaotech.team18.backend_server.domain.club.dto.ClubDashBoardResponseDto;
 import com.kakaotech.team18.backend_server.domain.club.dto.ClubDashboardApplicantResponseDto;
+import com.kakaotech.team18.backend_server.domain.club.dto.ClubDashboardApplicantResponseDto.InterviewDateSlotsDto;
+import com.kakaotech.team18.backend_server.domain.club.dto.ClubDashboardApplicantResponseDto.InterviewDateSlotsDto.InterviewSlotCountDto;
 import com.kakaotech.team18.backend_server.domain.club.dto.ClubDetailRequestDto;
 import com.kakaotech.team18.backend_server.domain.club.dto.ClubDetailResponseDto;
 import com.kakaotech.team18.backend_server.domain.club.dto.ClubListResponseDto;
@@ -28,8 +31,12 @@ import com.kakaotech.team18.backend_server.global.exception.exceptions.ClubMembe
 import com.kakaotech.team18.backend_server.global.exception.exceptions.ClubNotFoundException;
 import com.kakaotech.team18.backend_server.global.service.S3Service;
 import com.kakaotech.team18.backend_server.global.util.DateUtil;
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
@@ -150,11 +157,33 @@ public class ClubServiceImpl implements ClubService {
         } else {
             message = clubApplyForm.getFinalMessage();
         }
+
+        List<InterviewSlotCountProjection> rows = applicationRepository.countInterviewSlots(clubId);
+
+        Map<LocalDate, Map<LocalTime, Integer>> grouped = getLocalDateMap(rows);
+
+        List<InterviewDateSlotsDto> interviewSchedule =
+                grouped.entrySet().stream()
+                        .sorted(Map.Entry.comparingByKey())
+                        .map(dateEntry -> new InterviewDateSlotsDto(
+                                dateEntry.getKey(),
+                                dateEntry.getValue().entrySet().stream()
+                                        .sorted(Map.Entry.comparingByKey())
+                                        .map(timeEntry ->
+                                                new InterviewSlotCountDto(
+                                                        timeEntry.getKey(),
+                                                        timeEntry.getValue()
+                                                )
+                                        )
+                                        .toList()
+                        ))
+                        .toList();
         return new ClubDashboardApplicantResponseDto(
                 applicants
                         .stream()
                         .map(ApplicantResponseDto::from)
                         .toList(),
+                interviewSchedule,
                 message);
     }
 
@@ -201,6 +230,17 @@ public class ClubServiceImpl implements ClubService {
         log.info("Successfully uploaded and updated images for clubId: {}", clubId);
         applicationEventPublisher.publishEvent(new ClubImageDeletedEvent(clubId, deleteTargetUrls));
         return new SuccessResponseDto(true);
+    }
+
+    private Map<LocalDate, Map<LocalTime, Integer>> getLocalDateMap(List<InterviewSlotCountProjection> rows) {
+        return rows.stream()
+                .collect(Collectors.groupingBy(
+                        InterviewSlotCountProjection::getInterviewDate,
+                        Collectors.toMap(
+                                InterviewSlotCountProjection::getInterviewTime,
+                                r -> (int) r.getAssignedCount()
+                        )
+                ));
     }
     // ---- private helpers ----
     private ClubListResponseDto mapToResponse(List<ClubSummary> summaries) {

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/dto/ApplicantResponseDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/dto/ApplicantResponseDto.java
@@ -61,7 +61,7 @@ public record ApplicantResponseDto(
                 confirmedTime,
                 clubMember.getApplication().getId(),
                 clubMember.getApplication().getInterviewPreferences().stream()
-                        .map(pref -> new preferInterviewInfo(pref.getDate(), pref.getTime()))
+                        .map(pref -> new preferInterviewInfo(pref.getDate(), pref.getTimes()))
                         .toList()
         );
     }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/dto/ApplicantResponseDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/dto/ApplicantResponseDto.java
@@ -4,6 +4,7 @@ import com.kakaotech.team18.backend_server.domain.application.entity.Status;
 import com.kakaotech.team18.backend_server.domain.clubMember.entity.ClubMember;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 
@@ -21,6 +22,8 @@ public record ApplicantResponseDto(
         String email,
         @Schema(description = "지원서 상태", example = "PENDING")
         Status status,
+        @Schema(description = "확정된 지원자의 면접 시간", example = "2026-09-02T15:00:00")
+        LocalDateTime confirmedTime,
         @Schema(description = "지원서 ID", example = "1")
         Long applicantId,
         @Schema(description = "지원자의 인터뷰 선호 일정 리스트" )
@@ -38,6 +41,16 @@ public record ApplicantResponseDto(
 
 
     public static ApplicantResponseDto from(ClubMember clubMember) {
+
+        LocalDateTime confirmedTime = null;
+
+        if (clubMember.getApplication().getInterviewDate() != null &&
+                clubMember.getApplication().getInterviewTime() != null) {
+            confirmedTime = LocalDateTime.of(
+                    clubMember.getApplication().getInterviewDate(),
+                    clubMember.getApplication().getInterviewTime()
+            );
+        }
         return new ApplicantResponseDto(
                 clubMember.getUser().getName(),
                 clubMember.getUser().getStudentId(),
@@ -45,6 +58,7 @@ public record ApplicantResponseDto(
                 clubMember.getUser().getPhoneNumber(),
                 clubMember.getUser().getEmail(),
                 clubMember.getApplication().getStatus(),
+                confirmedTime,
                 clubMember.getApplication().getId(),
                 clubMember.getApplication().getInterviewPreferences().stream()
                         .map(pref -> new preferInterviewInfo(pref.getDate(), pref.getTime()))

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/dto/ApplicantResponseDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/dto/ApplicantResponseDto.java
@@ -3,6 +3,9 @@ package com.kakaotech.team18.backend_server.domain.clubMember.dto;
 import com.kakaotech.team18.backend_server.domain.application.entity.Status;
 import com.kakaotech.team18.backend_server.domain.clubMember.entity.ClubMember;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
 
 @Schema(description = "대시보드 내 지원자 목록의 개별 지원자 정보")
 public record ApplicantResponseDto(
@@ -19,8 +22,20 @@ public record ApplicantResponseDto(
         @Schema(description = "지원서 상태", example = "PENDING")
         Status status,
         @Schema(description = "지원서 ID", example = "1")
-        Long applicantId
+        Long applicantId,
+        @Schema(description = "지원자의 인터뷰 선호 일정 리스트" )
+        List<preferInterviewInfo> interviewInfo
 ) {
+
+    @Schema(description = "지원자의 인터뷰 선호 일정")
+    public record preferInterviewInfo(
+            @Schema(description = "면접 날짜", example = "2026-01-02")
+            LocalDate interviewDate,
+
+            @Schema(description = "면접 가능 시간 리스트")
+            List<LocalTime> availableTime
+    ) {}
+
 
     public static ApplicantResponseDto from(ClubMember clubMember) {
         return new ApplicantResponseDto(
@@ -30,7 +45,10 @@ public record ApplicantResponseDto(
                 clubMember.getUser().getPhoneNumber(),
                 clubMember.getUser().getEmail(),
                 clubMember.getApplication().getStatus(),
-                clubMember.getApplication().getId()
+                clubMember.getApplication().getId(),
+                clubMember.getApplication().getInterviewPreferences().stream()
+                        .map(pref -> new preferInterviewInfo(pref.getDate(), pref.getTime()))
+                        .toList()
         );
     }
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/email/dto/InterviewApprovedEvent.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/email/dto/InterviewApprovedEvent.java
@@ -1,11 +1,13 @@
 package com.kakaotech.team18.backend_server.domain.email.dto;
 
 import com.kakaotech.team18.backend_server.domain.application.entity.Stage;
+import java.time.LocalDateTime;
 
 public record InterviewApprovedEvent(
         ApplicationInfoDto info,
         Long applicationId,
         String email,
         String message,
-        Stage stage
+        Stage stage,
+        LocalDateTime interviewSchedule
 ) {}

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/email/eventListener/ApplicationNotificationListener.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/email/eventListener/ApplicationNotificationListener.java
@@ -1,16 +1,13 @@
 package com.kakaotech.team18.backend_server.domain.email.eventListener;
 
-import com.kakaotech.team18.backend_server.domain.application.entity.Application;
 import com.kakaotech.team18.backend_server.domain.application.repository.ApplicationRepository;
 import com.kakaotech.team18.backend_server.domain.email.dto.ApplicationInfoDto;
-import com.kakaotech.team18.backend_server.domain.club.entity.Club;
 import com.kakaotech.team18.backend_server.domain.email.dto.ApplicationSubmittedEvent;
 import com.kakaotech.team18.backend_server.domain.email.dto.FinalApprovedEvent;
 import com.kakaotech.team18.backend_server.domain.email.dto.FinalRejectedEvent;
 import com.kakaotech.team18.backend_server.domain.email.dto.InterviewApprovedEvent;
 import com.kakaotech.team18.backend_server.domain.email.dto.InterviewRejectedEvent;
 import com.kakaotech.team18.backend_server.domain.email.service.EmailService;
-import com.kakaotech.team18.backend_server.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
@@ -39,7 +36,7 @@ public class ApplicationNotificationListener {
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void onInterviewApproved(InterviewApprovedEvent event) {
         ApplicationInfoDto info = event.info();
-        emailService.sendInterviewApprovedResultToApplicant(info,  event.message());
+        emailService.sendInterviewApprovedResultToApplicant(info,  event.message(), event.interviewSchedule());
         log.info("Email sent successfully: clubName={} userName={}", info.clubName(), info.userName());
     }
 

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/email/service/EmailService.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/email/service/EmailService.java
@@ -5,6 +5,7 @@ import com.kakaotech.team18.backend_server.domain.email.dto.ApplicationInfoDto;
 import com.kakaotech.team18.backend_server.domain.email.sender.EmailSender;
 import com.kakaotech.team18.backend_server.domain.email.template.EmailTemplateRenderer;
 
+import java.time.LocalDateTime;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
@@ -52,6 +53,32 @@ public class EmailService {
         String subject = subjectPrefix + " " + info.clubName() + " - " + info.userName();
 
         emailSender.sendHtml(from, replyTo,List.of(info.userEmail()),subject, html);
+    }
+
+    public void sendInterviewApprovedResult(ApplicationInfoDto info, ResultType type, String message, LocalDateTime interviewSchedule) {
+        info.clubId();
+        String replyTo = info.presidentEmail();
+
+        boolean approved = isApproved(type);
+        if (approved && (message == null || message.isBlank())) {
+            throw new IllegalArgumentException("합격 통지 이메일에는 message가 필요합니다.");
+        }
+
+        Map<String, Object> model = baseModel(info);
+        model.put("title", titleFor(type));
+        if (approved) {
+            model.put("message", message);
+            model.put("interviewDate", interviewSchedule.toLocalDate().toString());
+            model.put("interviewTime", interviewSchedule.toLocalTime().toString());
+        }
+
+        String templateName = templateFor(type);
+
+        String html = renderer.render(templateName, model);
+        final String subjectPrefix = "[동아리 지원]";
+        String subject = subjectPrefix + " " + info.clubName() + " - " + info.userName();
+
+        emailSender.sendHtml(from, replyTo, List.of(info.userEmail()), subject, html);
     }
 
     public void sendResult(ApplicationInfoDto info, ResultType type, String message) {
@@ -114,8 +141,8 @@ public class EmailService {
         };
     }
 
-    public void sendInterviewApprovedResultToApplicant(ApplicationInfoDto info, String message) {
-        sendResult(info, ResultType.INTERVIEW_APPROVED, message);
+    public void sendInterviewApprovedResultToApplicant(ApplicationInfoDto info, String message, LocalDateTime interviewSchedule) {
+        sendInterviewApprovedResult(info, ResultType.INTERVIEW_APPROVED, message, interviewSchedule);
     }
     public void sendInterviewRejectedResultToApplicant(ApplicationInfoDto info) {
         sendResult(info, ResultType.INTERVIEW_REJECTED, null);

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/email/service/EmailService.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/email/service/EmailService.java
@@ -66,12 +66,17 @@ public class EmailService {
 
         Map<String, Object> model = baseModel(info);
         model.put("title", titleFor(type));
+
         if (approved) {
             model.put("message", message);
-            model.put("interviewDate", interviewSchedule.toLocalDate().toString());
-            model.put("interviewTime", interviewSchedule.toLocalTime().toString());
+            if (interviewSchedule != null) {
+                model.put("interviewDate", interviewSchedule.toLocalDate().toString());
+                model.put("interviewTime", interviewSchedule.toLocalTime().toString());
+            } else {
+                model.put("interviewDate", null);
+                model.put("interviewTime", null);
+            }
         }
-
         String templateName = templateFor(type);
 
         String html = renderer.render(templateName, model);

--- a/src/main/java/com/kakaotech/team18/backend_server/global/util/DateUtil.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/util/DateUtil.java
@@ -2,8 +2,15 @@ package com.kakaotech.team18.backend_server.global.util;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public class DateUtil {
 
     public static LocalDateTime[] changeToDate(String recruitDate) {
@@ -20,6 +27,41 @@ public class DateUtil {
         LocalDateTime recruitEnd = endDate.atTime(23, 59, 59);
 
         return new LocalDateTime[]{recruitStart, recruitEnd};
+    }
+
+    /**
+     * @param dateInfo ex) 2025-10-16 10:30-11:00,2025-10-16 11:00-11:30
+     * @return -> Map<선택한 날자, List<선택한 시간>>
+     */
+    public static Map<LocalDate, List<LocalTime>> parseDateAndTimeSlots(String dateInfo) {
+        if (dateInfo == null || dateInfo.isBlank()) {
+            return new HashMap<>();
+        }
+
+        Map<LocalDate, List<LocalTime>> result = new HashMap<>();
+        String[] parts = dateInfo.split(",");
+
+        DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+        for (String part : parts) {
+            String trimmed = part.trim();
+            if (trimmed.isEmpty()) continue;
+
+            String[] dateAndTime = trimmed.split("\\s+", 2);
+
+            if (dateAndTime.length == 2) {
+                try {
+                    LocalDate date = LocalDate.parse(dateAndTime[0], dateFormatter);
+                    dateAndTime[1] = dateAndTime[1].split("-")[0];
+                    LocalTime timeSlot = LocalTime.parse(dateAndTime[1]);
+
+                    result.computeIfAbsent(date, k -> new ArrayList<>()).add(timeSlot);
+                } catch (Exception e) {
+                    log.warn("인터뷰 선호 시간 파싱 실패: {}, error={}", trimmed, e.getMessage());
+                }
+            }
+        }
+        return result;
     }
 
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/global/util/DateUtil.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/util/DateUtil.java
@@ -34,34 +34,39 @@ public class DateUtil {
      * @return -> Map<선택한 날자, List<선택한 시간>>
      */
     public static Map<LocalDate, List<LocalTime>> parseDateAndTimeSlots(String dateInfo) {
-        if (dateInfo == null || dateInfo.isBlank()) {
-            return new HashMap<>();
-        }
+        if (dateInfo == null || dateInfo.isBlank()) return new HashMap<>();
 
         Map<LocalDate, List<LocalTime>> result = new HashMap<>();
-        String[] parts = dateInfo.split(",");
-
         DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+        DateTimeFormatter timeFormatter = DateTimeFormatter.ofPattern("H:mm");
 
-        for (String part : parts) {
+        for (String part : dateInfo.split(",")) {
             String trimmed = part.trim();
             if (trimmed.isEmpty()) continue;
 
             String[] dateAndTime = trimmed.split("\\s+", 2);
+            if (dateAndTime.length != 2) {
+                log.warn("인터뷰 선호 시간 형식이 올바르지 않음: {}", trimmed);
+                continue;
+            }
 
-            if (dateAndTime.length == 2) {
-                try {
-                    LocalDate date = LocalDate.parse(dateAndTime[0], dateFormatter);
-                    dateAndTime[1] = dateAndTime[1].split("-")[0];
-                    LocalTime timeSlot = LocalTime.parse(dateAndTime[1]);
+            try {
+                LocalDate date = LocalDate.parse(dateAndTime[0].trim(), dateFormatter);
 
-                    result.computeIfAbsent(date, k -> new ArrayList<>()).add(timeSlot);
-                } catch (Exception e) {
-                    log.warn("인터뷰 선호 시간 파싱 실패: {}, error={}", trimmed, e.getMessage());
+                String timeRange = dateAndTime[1].trim();      // "10:30-11:00"
+                String[] times = timeRange.split("-", 2);
+                if (times.length != 2) {
+                    log.warn("시간 범위 형식이 올바르지 않음: {}", trimmed);
+                    continue;
                 }
+
+                LocalTime start = LocalTime.parse(times[0].trim(), timeFormatter);
+                result.computeIfAbsent(date, k -> new ArrayList<>()).add(start);
+
+            } catch (Exception e) {
+                log.warn("인터뷰 선호 시간 파싱 실패: {}, error={}", trimmed, e.getMessage());
             }
         }
         return result;
     }
-
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/global/util/DateUtil.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/util/DateUtil.java
@@ -69,4 +69,10 @@ public class DateUtil {
         }
         return result;
     }
+
+    public static String formatTimeRange(LocalTime start, LocalTime end) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm");
+        return start.format(formatter) + " ~ " + end.format(formatter);
+    }
+
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/global/util/DateUtil.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/util/DateUtil.java
@@ -5,7 +5,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
@@ -34,9 +34,9 @@ public class DateUtil {
      * @return -> Map<선택한 날자, List<선택한 시간>>
      */
     public static Map<LocalDate, List<LocalTime>> parseDateAndTimeSlots(String dateInfo) {
-        if (dateInfo == null || dateInfo.isBlank()) return new HashMap<>();
+        if (dateInfo == null || dateInfo.isBlank()) return new LinkedHashMap<>();
 
-        Map<LocalDate, List<LocalTime>> result = new HashMap<>();
+        Map<LocalDate, List<LocalTime>> result = new LinkedHashMap<>();
         DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
         DateTimeFormatter timeFormatter = DateTimeFormatter.ofPattern("H:mm");
 

--- a/src/main/resources/templates/email-body-applicant-InterviewApproved.html
+++ b/src/main/resources/templates/email-body-applicant-InterviewApproved.html
@@ -31,7 +31,15 @@
     <!-- 사용자가 입력한 메시지: 개행 유지 -->
     <pre th:text="${message}">OT는 10/7(화) 19:00입니다…</pre>
   </div>
-
+    <!-- 면접 일정 안내 -->
+    <div class="card" th:if="${interviewDate != null and interviewTime != null}">
+        <div style="font-weight:600; margin-bottom:8px;">면접 일정</div>
+        <div>
+            면접 날짜는
+            <strong th:text="${interviewDate}">2026-01-02</strong> 일
+            <strong th:text="${interviewTime}">10:30</strong> 입니다.
+        </div>
+    </div>
   <div class="footer">
     본 메일은 회신 시 동아리 회장(Reply-To)에게 전달됩니다.<br/>
     © <span th:text="${clubName}">동아리명</span>

--- a/src/main/resources/templates/email-body-applicant-InterviewApproved.html
+++ b/src/main/resources/templates/email-body-applicant-InterviewApproved.html
@@ -32,14 +32,14 @@
     <pre th:text="${message}">OT는 10/7(화) 19:00입니다…</pre>
   </div>
     <!-- 면접 일정 안내 -->
-    <div class="card" th:if="${interviewDate != null and interviewTime != null}">
-        <div style="font-weight:600; margin-bottom:8px;">면접 일정</div>
-        <div>
-            면접 날짜는
-            <strong th:text="${interviewDate}">2026-01-02</strong> 일
-            <strong th:text="${interviewTime}">10:30</strong> 입니다.
-        </div>
+  <div class="card" th:if="${interviewDate != null and interviewTime != null}">
+    <div style="font-weight:600; margin-bottom:8px;">면접 일정</div>
+    <div>
+        면접 날짜는
+        <strong th:text="${interviewDate}">2026-01-02</strong> 일
+        <strong th:text="${interviewTime}">10:30</strong> 입니다.
     </div>
+  </div>
   <div class="footer">
     본 메일은 회신 시 동아리 회장(Reply-To)에게 전달됩니다.<br/>
     © <span th:text="${clubName}">동아리명</span>

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/application/controller/ApplicationControllerTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/application/controller/ApplicationControllerTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationApplyRequestDto;
 import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationApplyResponseDto;
 import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationDetailResponseDto;
+import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationFixedInterviewRequestDto;
 import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationStatusUpdateRequestDto;
 import com.kakaotech.team18.backend_server.domain.application.entity.Status;
 import com.kakaotech.team18.backend_server.domain.application.service.ApplicationService;
@@ -13,6 +14,7 @@ import com.kakaotech.team18.backend_server.global.dto.SuccessResponseDto;
 import com.kakaotech.team18.backend_server.global.exception.code.ErrorCode;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.ApplicationNotFoundException;
 import com.kakaotech.team18.backend_server.global.security.JwtAuthenticationFilter;
+import java.time.LocalDateTime;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -170,6 +172,73 @@ class ApplicationControllerTest {
         // when
         ResultActions resultActions = mockMvc.perform(
                 patch("/api/clubs/{clubId}/applications/{applicationId}/status", clubId, applicationId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(invalidRequestBody)
+        );
+
+        // then
+        resultActions.andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error_code").value(ErrorCode.INVALID_INPUT_VALUE.name()));
+    }
+
+    @Test
+    @DisplayName("지원자 면접 일정 변경 - 성공")
+    void updateApplicationInterviewSchedule_success() throws Exception {
+        // given
+        Long clubId = 1L;
+        Long applicationId = 1L;
+        ApplicationFixedInterviewRequestDto requestDto = new ApplicationFixedInterviewRequestDto(LocalDateTime.of(2026, 2, 10, 10, 0));
+
+        given(applicationService.updateApplicationInterviewSchedule(any(Long.class), any(ApplicationFixedInterviewRequestDto.class)))
+                .willReturn(new SuccessResponseDto(true));
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                patch("/api/clubs/{clubId}/applications/{applicationId}/interview", clubId, applicationId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto))
+        );
+
+        // then
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+    }
+
+    @Test
+    @DisplayName("지원자 면접 일정 변경 - 실패 (지원서 없음)")
+    void updateApplicationInterviewSchedule_fail_applicationNotFound() throws Exception {
+        // given
+        Long clubId = 1L;
+        Long nonExistentApplicationId = 999L;
+        ApplicationFixedInterviewRequestDto requestDto = new ApplicationFixedInterviewRequestDto(LocalDateTime.of(2026, 2, 10, 10, 0));
+
+        given(applicationService.updateApplicationInterviewSchedule(any(Long.class), any(ApplicationFixedInterviewRequestDto.class)))
+                .willThrow(new ApplicationNotFoundException("테스트 detail 블라블라"));
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                patch("/api/clubs/{clubId}/applications/{applicationId}/interview", clubId, nonExistentApplicationId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto))
+        );
+
+        // then
+        resultActions.andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error_code").value(ErrorCode.APPLICATION_NOT_FOUND.name()));
+    }
+
+    @Test
+    @DisplayName("지원자 면접 일정 변경 - 실패 (잘못된 요청 값 - 날짜 누락)")
+    void updateApplicationInterviewSchedule_fail_invalidInputValue() throws Exception {
+        // given
+        Long clubId = 1L;
+        Long applicationId = 1L;
+        // interviewAt 필드가 없는 잘못된 요청
+        String invalidRequestBody = "{}";
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                patch("/api/clubs/{clubId}/applications/{applicationId}/interview", clubId, applicationId)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(invalidRequestBody)
         );

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/application/entity/ApplicationTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/application/entity/ApplicationTest.java
@@ -13,7 +13,7 @@ class ApplicationTest {
 
     @DisplayName("인터뷰 선호 시간 정보 업데이트 성공")
     @Test
-    void updateInterviewInfo_success() {
+    void updatePreferInterviewInfo_success() {
         //given
         LocalDate date = LocalDate.of(2025, 10, 16);
         List<LocalTime> times = List.of(LocalTime.of(10, 30), LocalTime.of(11, 0));
@@ -22,7 +22,7 @@ class ApplicationTest {
         Application application = Application.builder().build();
 
         //when
-        application.updateInterviewInfo(dateAndTimeSlots);
+        application.updatePreferInterviewInfo(dateAndTimeSlots);
 
         //then
         Assertions.assertThat(application.getInterviewPreferences())

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/application/entity/ApplicationTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/application/entity/ApplicationTest.java
@@ -30,7 +30,7 @@ class ApplicationTest {
                 .singleElement()
                 .satisfies(pref -> {
                     Assertions.assertThat(pref.getDate()).isEqualTo(date);
-                    Assertions.assertThat(pref.getTime()).containsExactlyElementsOf(times);
+                    Assertions.assertThat(pref.getTimes()).containsExactlyElementsOf(times);
                 });
     }
 

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/application/entity/ApplicationTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/application/entity/ApplicationTest.java
@@ -1,0 +1,37 @@
+package com.kakaotech.team18.backend_server.domain.application.entity;
+
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Map;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ApplicationTest {
+
+    @DisplayName("인터뷰 선호 시간 정보 업데이트 성공")
+    @Test
+    void updateInterviewInfo_success() {
+        //given
+        LocalDate date = LocalDate.of(2025, 10, 16);
+        List<LocalTime> times = List.of(LocalTime.of(10, 30), LocalTime.of(11, 0));
+        Map<LocalDate, List<LocalTime>> dateAndTimeSlots = Map.of(date, times);
+
+        Application application = Application.builder().build();
+
+        //when
+        application.updateInterviewInfo(dateAndTimeSlots);
+
+        //then
+        Assertions.assertThat(application.getInterviewPreferences())
+                .hasSize(1)
+                .singleElement()
+                .satisfies(pref -> {
+                    Assertions.assertThat(pref.getDate()).isEqualTo(date);
+                    Assertions.assertThat(pref.getTime()).containsExactlyElementsOf(times);
+                });
+    }
+
+}

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/application/service/ApplicationServiceImplTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/application/service/ApplicationServiceImplTest.java
@@ -14,8 +14,20 @@ import static org.mockito.Mockito.when;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.kakaotech.team18.backend_server.domain.answer.entity.Answer;
 import com.kakaotech.team18.backend_server.domain.answer.repository.AnswerRepository;
+import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationApplyRequestDto;
+import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationApplyRequestDto.AnswerDto;
+import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationApplyResponseDto;
+import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationFixedInterviewRequestDto;
+import com.kakaotech.team18.backend_server.domain.application.entity.InterviewPreference;
+import com.kakaotech.team18.backend_server.domain.club.entity.Club;
+import com.kakaotech.team18.backend_server.domain.clubMember.entity.ActiveStatus;
+import com.kakaotech.team18.backend_server.domain.clubMember.entity.Role;
+import com.kakaotech.team18.backend_server.domain.clubMember.repository.ClubMemberRepository;
+import com.kakaotech.team18.backend_server.domain.formQuestion.entity.FieldType;
 import com.kakaotech.team18.backend_server.domain.formQuestion.entity.FormQuestion;
 import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationDetailResponseDto;
 import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationStatusUpdateRequestDto;
@@ -24,19 +36,28 @@ import com.kakaotech.team18.backend_server.domain.application.entity.Status;
 import com.kakaotech.team18.backend_server.domain.application.repository.ApplicationRepository;
 import com.kakaotech.team18.backend_server.domain.clubApplyForm.entity.ClubApplyForm;
 import com.kakaotech.team18.backend_server.domain.clubApplyForm.repository.ClubApplyFormRepository;
+import com.kakaotech.team18.backend_server.domain.formQuestion.repository.FormQuestionRepository;
 import com.kakaotech.team18.backend_server.domain.user.entity.User;
+import com.kakaotech.team18.backend_server.domain.user.repository.UserRepository;
 import com.kakaotech.team18.backend_server.global.dto.SuccessResponseDto;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.ClubApplyFormNotFoundException;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.ApplicationNotFoundException;
+import com.kakaotech.team18.backend_server.global.util.DateUtil;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationEventPublisher;
 
 @ExtendWith(MockitoExtension.class)
 class ApplicationServiceImplTest {
@@ -52,6 +73,18 @@ class ApplicationServiceImplTest {
 
     @Mock
     private ClubApplyFormRepository clubApplyFormRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private ClubMemberRepository clubMemberRepository;
+
+    @Mock
+    private FormQuestionRepository formQuestionRepository;
+
+    @Mock
+    private ApplicationEventPublisher publisher;
 
     @Test
     @DisplayName("지원서 상세 조회 - 성공 (여러 지원서 중 특정 지원서 조회)")
@@ -210,6 +243,129 @@ class ApplicationServiceImplTest {
         // when & then
         ApplicationNotFoundException exception = assertThrows(ApplicationNotFoundException.class, () -> {
             applicationService.updateApplicationStatus(nonExistentApplicationId, requestDto);
+        });
+
+        assertEquals("applicationId: " + nonExistentApplicationId, exception.getDetail());
+        verify(applicationRepository, times(1)).findById(nonExistentApplicationId);
+    }
+
+    @Test
+    @DisplayName("지원서 제출 - 성공 (면접 시간 파싱 및 저장 검증)")
+    void submitApplication_success_withInterviewTimeParsing() {
+        // given
+        Long clubId = 1L;
+        String studentId = "20230001";
+        String interviewTimeRaw = "2025-10-16 10:30-11:00,2025-10-16 11:00-11:30";
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode interviewTimeNode = objectMapper.valueToTree(interviewTimeRaw);
+
+        // questionNum을 0L로 설정 (FormQuestion의 displayOrder가 1L일 때, 서비스 로직에서 disp-1 = 0을 조회하므로)
+        AnswerDto answerDto = new AnswerDto(0L, "면접 가능 날짜는?", interviewTimeNode);
+        ApplicationApplyRequestDto requestDto = new ApplicationApplyRequestDto(
+                "test@test.com", "김지원", studentId, "010-1234-5678", "컴퓨터공학과", List.of(answerDto)
+        );
+
+        ClubApplyForm mockForm = mock(ClubApplyForm.class);
+        Club mockClub = mock(Club.class);
+        when(mockForm.getClub()).thenReturn(mockClub);
+        when(mockForm.getId()).thenReturn(10L);
+        when(mockClub.getId()).thenReturn(clubId);
+
+        User mockUser = User.builder()
+                .studentId(studentId)
+                .email("test@test.com")
+                .name("김지원")
+                .phoneNumber("010-1234-5678")
+                .department("컴퓨터공학과")
+                .build();
+
+        User mockPresident = mock(User.class);
+        when(mockPresident.getEmail()).thenReturn("president@test.com");
+
+        FormQuestion mockQuestion = mock(FormQuestion.class);
+        when(mockQuestion.getId()).thenReturn(1L);
+        when(mockQuestion.getDisplayOrder()).thenReturn(1L);
+        when(mockQuestion.getFieldType()).thenReturn(FieldType.TIME_SLOT);
+        when(mockQuestion.getIsRequired()).thenReturn(true);
+
+        when(clubApplyFormRepository.findByClubId(clubId)).thenReturn(Optional.of(mockForm));
+        when(userRepository.findByStudentId(studentId)).thenReturn(Optional.of(mockUser));
+        when(applicationRepository.findByStudentIdAndClubApplyForm(studentId, mockForm)).thenReturn(Optional.empty());
+        when(clubMemberRepository.findUserByClubIdAndRoleAndStatus(clubId, Role.CLUB_ADMIN, ActiveStatus.ACTIVE))
+                .thenReturn(Optional.of(mockPresident));
+        when(formQuestionRepository.findByClubApplyFormIdOrderByDisplayOrderAsc(10L)).thenReturn(List.of(mockQuestion));
+
+        // when
+        ApplicationApplyResponseDto response = applicationService.submitApplication(clubId, requestDto, false);
+
+        // then
+        assertNotNull(response);
+        
+        // Application 저장 캡처
+        ArgumentCaptor<Application> applicationCaptor = ArgumentCaptor.forClass(Application.class);
+        verify(applicationRepository).save(applicationCaptor.capture());
+        Application savedApplication = applicationCaptor.getValue();
+
+        // Answer 저장 캡처
+        ArgumentCaptor<List<Answer>> answersCaptor = ArgumentCaptor.forClass(List.class);
+        verify(answerRepository).saveAll(answersCaptor.capture());
+        List<Answer> savedAnswers = answersCaptor.getValue();
+        
+        assertEquals(1, savedAnswers.size());
+        // 저장된 답변 문자열 확인 (DateUtil.reassembleTimeSlots 로직에 따라 포맷팅됨)
+        String savedAnswerStr = savedAnswers.get(0).getAnswer();
+        assertTrue(savedAnswerStr.contains("2025-10-16 10:30-11:00"));
+        assertTrue(savedAnswerStr.contains("2025-10-16 11:00-11:30"));
+
+        // Application 객체 내 interviewPreferences 검증
+        List<InterviewPreference> preferences = savedApplication.getInterviewPreferences();
+        assertNotNull(preferences);
+        assertEquals(1, preferences.size()); // 같은 날짜이므로 1개의 InterviewPreference 객체 생성 예상
+
+        InterviewPreference pref = preferences.get(0);
+        assertEquals(LocalDate.of(2025, 10, 16), pref.getDate());
+        
+        // 시간대 검증 (10:30, 11:00 시작 시간만 저장되는지 확인)
+        List<LocalTime> times = pref.getTime();
+        assertEquals(2, times.size());
+        assertTrue(times.contains(LocalTime.of(10, 30)));
+        assertTrue(times.contains(LocalTime.of(11, 0)));
+    }
+
+    @Test
+    @DisplayName("지원자 면접 일정 변경 - 성공")
+    void updateApplicationInterviewSchedule_success() {
+        // given
+        Long applicationId = 1L;
+        LocalDateTime newInterviewTime = LocalDateTime.of(2026, 2, 10, 10, 0);
+        ApplicationFixedInterviewRequestDto requestDto = new ApplicationFixedInterviewRequestDto(newInterviewTime);
+
+        Application mockApplication = mock(Application.class);
+        when(applicationRepository.findById(applicationId)).thenReturn(Optional.of(mockApplication));
+
+        // when
+        SuccessResponseDto responseDto = applicationService.updateApplicationInterviewSchedule(applicationId, requestDto);
+
+        // then
+        assertTrue(responseDto.success());
+        verify(applicationRepository, times(1)).findById(applicationId);
+        verify(mockApplication, times(1)).updateInterviewInfo(newInterviewTime);
+    }
+
+    @Test
+    @DisplayName("지원자 면접 일정 변경 - 실패 (지원서 없음)")
+    void updateApplicationInterviewSchedule_fail_applicationNotFound() {
+        // given
+        Long nonExistentApplicationId = 999L;
+        LocalDateTime newInterviewTime = LocalDateTime.of(2026, 2, 10, 10, 0);
+        ApplicationFixedInterviewRequestDto requestDto = new ApplicationFixedInterviewRequestDto(newInterviewTime);
+
+        when(applicationRepository.findById(nonExistentApplicationId)).thenReturn(Optional.empty());
+
+        // when & then
+        ApplicationNotFoundException exception = assertThrows(ApplicationNotFoundException.class, () -> {
+            applicationService.updateApplicationInterviewSchedule(nonExistentApplicationId, requestDto);
         });
 
         assertEquals("applicationId: " + nonExistentApplicationId, exception.getDetail());

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/application/service/ApplicationServiceImplTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/application/service/ApplicationServiceImplTest.java
@@ -327,7 +327,7 @@ class ApplicationServiceImplTest {
         assertEquals(LocalDate.of(2025, 10, 16), pref.getDate());
         
         // 시간대 검증 (10:30, 11:00 시작 시간만 저장되는지 확인)
-        List<LocalTime> times = pref.getTime();
+        List<LocalTime> times = pref.getTimes();
         assertEquals(2, times.size());
         assertTrue(times.contains(LocalTime.of(10, 30)));
         assertTrue(times.contains(LocalTime.of(11, 0)));

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/club/controller/ClubControllerTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/club/controller/ClubControllerTest.java
@@ -30,6 +30,7 @@ import com.kakaotech.team18.backend_server.global.dto.SuccessResponseDto;
 import com.kakaotech.team18.backend_server.global.security.JwtAuthenticationFilter;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -177,7 +178,10 @@ class ClubControllerTest {
                 1,
                 1,
                 LocalDate.of(2025, 9, 15),
-                LocalDate.of(2025, 9, 20)
+                LocalDate.of(2025, 9, 20),
+                LocalDate.of(2025, 9, 1),
+                LocalDate.of(2025, 9, 5),
+                "09:00 ~ 21:00"
                 );
 
         //when
@@ -200,9 +204,11 @@ class ClubControllerTest {
         ClubDashboardApplicantResponseDto expect = new ClubDashboardApplicantResponseDto(
                 List.of(
                 new ApplicantResponseDto("김춘식", "111111", "철학과", "010-1234-5678", "123@email.com",
-                        Status.PENDING, 1L),
+                        Status.PENDING, 1L, List.of(new ApplicantResponseDto.preferInterviewInfo(
+                                LocalDate.of(2025, 1, 2), List.of(LocalTime.of(10, 0))))),
                 new ApplicantResponseDto("김춘식", "222222", "철학과", "010-1234-5678", "123@email.com",
-                        Status.PENDING, 2L)),
+                        Status.PENDING, 2L, List.of(new ApplicantResponseDto.preferInterviewInfo(
+                        LocalDate.of(2025, 1, 2), List.of(LocalTime.of(10, 0)))))),
                 "message");
 
         //when
@@ -225,10 +231,12 @@ class ClubControllerTest {
         String stage = String.valueOf(Stage.INTERVIEW);
         ClubDashboardApplicantResponseDto expect = new ClubDashboardApplicantResponseDto(
                 List.of(
-                new ApplicantResponseDto("김춘식", "111111", "철학과", "010-1234-5678", "123@email.com",
-                        Status.PENDING, 1L),
-                new ApplicantResponseDto("김춘식", "222222", "철학과", "010-1234-5678", "123@email.com",
-                        Status.APPROVED, 2L)),
+                        new ApplicantResponseDto("김춘식", "111111", "철학과", "010-1234-5678", "123@email.com",
+                                Status.PENDING, 1L, List.of(new ApplicantResponseDto.preferInterviewInfo(
+                                LocalDate.of(2025, 1, 2), List.of(LocalTime.of(10, 0))))),
+                        new ApplicantResponseDto("김춘식", "222222", "철학과", "010-1234-5678", "123@email.com",
+                                Status.PENDING, 2L, List.of(new ApplicantResponseDto.preferInterviewInfo(
+                                LocalDate.of(2025, 1, 2), List.of(LocalTime.of(10, 0)))))),
                 "message"
         );
 

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/club/controller/ClubControllerTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/club/controller/ClubControllerTest.java
@@ -18,6 +18,8 @@ import com.kakaotech.team18.backend_server.domain.application.entity.Stage;
 import com.kakaotech.team18.backend_server.domain.application.entity.Status;
 import com.kakaotech.team18.backend_server.domain.club.dto.ClubDashBoardResponseDto;
 import com.kakaotech.team18.backend_server.domain.club.dto.ClubDashboardApplicantResponseDto;
+import com.kakaotech.team18.backend_server.domain.club.dto.ClubDashboardApplicantResponseDto.InterviewDateSlotsDto;
+import com.kakaotech.team18.backend_server.domain.club.dto.ClubDashboardApplicantResponseDto.InterviewDateSlotsDto.InterviewSlotCountDto;
 import com.kakaotech.team18.backend_server.domain.club.dto.ClubDetailRequestDto;
 import com.kakaotech.team18.backend_server.domain.club.dto.ClubDetailResponseDto;
 import com.kakaotech.team18.backend_server.domain.club.dto.ClubListResponseDto;
@@ -201,14 +203,22 @@ class ClubControllerTest {
         Long clubId = 1L;
         String status = "미정";
         String stage = String.valueOf(Stage.INTERVIEW);
+        LocalDateTime confirmedTime = LocalDateTime.of(2025, 1, 2, 10, 0);
+
         ClubDashboardApplicantResponseDto expect = new ClubDashboardApplicantResponseDto(
                 List.of(
-                new ApplicantResponseDto("김춘식", "111111", "철학과", "010-1234-5678", "123@email.com",
-                        Status.PENDING, 1L, List.of(new ApplicantResponseDto.preferInterviewInfo(
-                                LocalDate.of(2025, 1, 2), List.of(LocalTime.of(10, 0))))),
-                new ApplicantResponseDto("김춘식", "222222", "철학과", "010-1234-5678", "123@email.com",
-                        Status.PENDING, 2L, List.of(new ApplicantResponseDto.preferInterviewInfo(
-                        LocalDate.of(2025, 1, 2), List.of(LocalTime.of(10, 0)))))),
+                        new ApplicantResponseDto("김춘식", "111111", "철학과", "010-1234-5678",
+                                "123@email.com",
+                                Status.PENDING, confirmedTime, 1L,
+                                List.of(new ApplicantResponseDto.preferInterviewInfo(
+                                        LocalDate.of(2025, 1, 2), List.of(LocalTime.of(10, 0))))),
+                        new ApplicantResponseDto("김춘식", "222222", "철학과", "010-1234-5678",
+                                "123@email.com",
+                                Status.PENDING, null, 2L,
+                                List.of(new ApplicantResponseDto.preferInterviewInfo(
+                                        LocalDate.of(2025, 1, 2), List.of(LocalTime.of(10, 0)))))),
+                List.of(new InterviewDateSlotsDto(LocalDate.of(2025, 1, 2),
+                        List.of(new InterviewSlotCountDto(LocalTime.of(12, 1, 2), 1)))),
                 "message");
 
         //when
@@ -219,7 +229,16 @@ class ClubControllerTest {
                         .param("status", status)
                 .param("stage", stage))
                 .andDo(print())
-                .andExpect(status().isOk());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.applicants.size()").value(2))
+                .andExpect(jsonPath("$.applicants[0].confirmedTime").value("2025-01-02T10:00:00"))
+                .andExpect(jsonPath("$.applicants[1].confirmedTime").isEmpty())
+                .andExpect(jsonPath("$.interviewSchedule.size()").value(1))
+                .andExpect(jsonPath("$.interviewSchedule[0].date").value("2025-01-02"))
+                .andExpect(jsonPath("$.interviewSchedule[0].slots.size()").value(1))
+                .andExpect(jsonPath("$.interviewSchedule[0].slots[0].time").value("12:01:02"))
+                .andExpect(jsonPath("$.interviewSchedule[0].slots[0].assignedCount").value(1))
+                .andExpect(jsonPath("$.message").value("message"));
     }
 
     @DisplayName("동아리 대쉬보드에서 지원서의 상태를 통해 지원자를 필터링 조회시 Status 값이 비어 있으면 모든 지원자를 조회한다.")
@@ -229,16 +248,23 @@ class ClubControllerTest {
         Long clubId = 1L;
         String status = null;
         String stage = String.valueOf(Stage.INTERVIEW);
+        LocalDateTime confirmedTime = LocalDateTime.of(2025, 1, 2, 10, 0);
+
         ClubDashboardApplicantResponseDto expect = new ClubDashboardApplicantResponseDto(
                 List.of(
-                        new ApplicantResponseDto("김춘식", "111111", "철학과", "010-1234-5678", "123@email.com",
-                                Status.PENDING, 1L, List.of(new ApplicantResponseDto.preferInterviewInfo(
-                                LocalDate.of(2025, 1, 2), List.of(LocalTime.of(10, 0))))),
-                        new ApplicantResponseDto("김춘식", "222222", "철학과", "010-1234-5678", "123@email.com",
-                                Status.PENDING, 2L, List.of(new ApplicantResponseDto.preferInterviewInfo(
-                                LocalDate.of(2025, 1, 2), List.of(LocalTime.of(10, 0)))))),
-                "message"
-        );
+                        new ApplicantResponseDto("김춘식", "111111", "철학과", "010-1234-5678",
+                                "123@email.com",
+                                Status.PENDING, confirmedTime, 1L,
+                                List.of(new ApplicantResponseDto.preferInterviewInfo(
+                                        LocalDate.of(2025, 1, 2), List.of(LocalTime.of(10, 0))))),
+                        new ApplicantResponseDto("김춘식", "222222", "철학과", "010-1234-5678",
+                                "123@email.com",
+                                Status.PENDING, null, 2L,
+                                List.of(new ApplicantResponseDto.preferInterviewInfo(
+                                        LocalDate.of(2025, 1, 2), List.of(LocalTime.of(10, 0)))))),
+                List.of(new InterviewDateSlotsDto(LocalDate.of(2025, 1, 2),
+                        List.of(new InterviewSlotCountDto(LocalTime.of(12, 1, 2), 1)))),
+                "message");
 
         //when
         when(clubService.getApplicantsByStatusAndStage(clubId, null, Stage.INTERVIEW)).thenReturn(expect);
@@ -248,7 +274,16 @@ class ClubControllerTest {
                         .param("status", status)
                 .param("stage", stage))
                 .andDo(print())
-                .andExpect(status().isOk());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.applicants.size()").value(2))
+                .andExpect(jsonPath("$.applicants[0].confirmedTime").value("2025-01-02T10:00:00"))
+                .andExpect(jsonPath("$.applicants[1].confirmedTime").isEmpty())
+                .andExpect(jsonPath("$.interviewSchedule.size()").value(1))
+                .andExpect(jsonPath("$.interviewSchedule[0].date").value("2025-01-02"))
+                .andExpect(jsonPath("$.interviewSchedule[0].slots.size()").value(1))
+                .andExpect(jsonPath("$.interviewSchedule[0].slots[0].time").value("12:01:02"))
+                .andExpect(jsonPath("$.interviewSchedule[0].slots[0].assignedCount").value(1))
+                .andExpect(jsonPath("$.message").value("message"));
     }
 
     @DisplayName("동아리 대쉬보드에서 지원서의 상태를 통해 지원자를 필터링 조회시 Status에 등록되지 않은 쿼리파라미터를 주면 404NotFoud에러가 발생한다.")

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/club/controller/ClubControllerTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/club/controller/ClubControllerTest.java
@@ -206,6 +206,7 @@ class ClubControllerTest {
         LocalDateTime confirmedTime = LocalDateTime.of(2025, 1, 2, 10, 0);
 
         ClubDashboardApplicantResponseDto expect = new ClubDashboardApplicantResponseDto(
+                false,
                 List.of(
                         new ApplicantResponseDto("김춘식", "111111", "철학과", "010-1234-5678",
                                 "123@email.com",
@@ -230,6 +231,7 @@ class ClubControllerTest {
                 .param("stage", stage))
                 .andDo(print())
                 .andExpect(status().isOk())
+                .andExpect(jsonPath("$.interviewRequired").value(false))
                 .andExpect(jsonPath("$.applicants.size()").value(2))
                 .andExpect(jsonPath("$.applicants[0].confirmedTime").value("2025-01-02T10:00:00"))
                 .andExpect(jsonPath("$.applicants[1].confirmedTime").isEmpty())
@@ -251,6 +253,7 @@ class ClubControllerTest {
         LocalDateTime confirmedTime = LocalDateTime.of(2025, 1, 2, 10, 0);
 
         ClubDashboardApplicantResponseDto expect = new ClubDashboardApplicantResponseDto(
+                true,
                 List.of(
                         new ApplicantResponseDto("김춘식", "111111", "철학과", "010-1234-5678",
                                 "123@email.com",
@@ -275,6 +278,7 @@ class ClubControllerTest {
                 .param("stage", stage))
                 .andDo(print())
                 .andExpect(status().isOk())
+                .andExpect(jsonPath("$.interviewRequired").value(true))
                 .andExpect(jsonPath("$.applicants.size()").value(2))
                 .andExpect(jsonPath("$.applicants[0].confirmedTime").value("2025-01-02T10:00:00"))
                 .andExpect(jsonPath("$.applicants[1].confirmedTime").isEmpty())

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/club/service/ClubServiceMockTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/club/service/ClubServiceMockTest.java
@@ -797,9 +797,9 @@ public class ClubServiceMockTest {
         ReflectionTestUtils.setField(application3, "id", 3L);
 
         // 면접 시간 정보 추가
-        application1.updateInterviewInfo(Map.of(LocalDate.of(2025, 1, 2), List.of(LocalTime.of(10, 0))));
-        application2.updateInterviewInfo(Map.of(LocalDate.of(2025, 1, 2), List.of(LocalTime.of(10, 0))));
-        application3.updateInterviewInfo(Map.of(LocalDate.of(2025, 1, 2), List.of(LocalTime.of(10, 0))));
+        application1.updatePreferInterviewInfo(Map.of(LocalDate.of(2025, 1, 2), List.of(LocalTime.of(10, 0))));
+        application2.updatePreferInterviewInfo(Map.of(LocalDate.of(2025, 1, 2), List.of(LocalTime.of(10, 0))));
+        application3.updatePreferInterviewInfo(Map.of(LocalDate.of(2025, 1, 2), List.of(LocalTime.of(10, 0))));
 
         ClubMember clubMember1 = createClubMember(user1, club, application1, Role.APPLICANT, ActiveStatus.ACTIVE);
         ClubMember clubMember2 = createClubMember(user2, club, application2, Role.APPLICANT, ActiveStatus.ACTIVE);

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/club/service/ClubServiceMockTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/club/service/ClubServiceMockTest.java
@@ -812,13 +812,13 @@ public class ClubServiceMockTest {
 
         List<ApplicantResponseDto> expect = List.of(
                 new ApplicantResponseDto("김춘식", "111111", "철학과", "010-1234-5678", "123@email.com",
-                        Status.PENDING, 1L, List.of(new ApplicantResponseDto.preferInterviewInfo(
+                        Status.PENDING, null, 1L, List.of(new ApplicantResponseDto.preferInterviewInfo(
                         LocalDate.of(2025, 1, 2), List.of(LocalTime.of(10, 0))))),
                 new ApplicantResponseDto("김춘식", "222222", "철학과", "010-1234-5678", "123@email.com",
-                        Status.APPROVED, 2L, List.of(new ApplicantResponseDto.preferInterviewInfo(
+                        Status.APPROVED, null,2L, List.of(new ApplicantResponseDto.preferInterviewInfo(
                         LocalDate.of(2025, 1, 2), List.of(LocalTime.of(10, 0))))),
                 new ApplicantResponseDto("김춘식", "333333", "철학과", "010-1234-5678", "123@email.com",
-                        Status.REJECTED, 3L, List.of(new ApplicantResponseDto.preferInterviewInfo(
+                        Status.REJECTED, null,3L, List.of(new ApplicantResponseDto.preferInterviewInfo(
                         LocalDate.of(2025, 1, 2), List.of(LocalTime.of(10, 0))))));
 
         //when

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/club/service/ClubServiceMockTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/club/service/ClubServiceMockTest.java
@@ -719,7 +719,10 @@ public class ClubServiceMockTest {
         Long clubId = 1L;
 
         Club club = mock(Club.class);
-        given(clubApplyFormRepository.findByClubId(clubId)).willReturn(Optional.of(mock(ClubApplyForm.class)));
+        ClubApplyForm clubApplyForm = mock(ClubApplyForm.class);
+        given(clubApplyForm.getClub()).willReturn(club);
+        given(club.getIsInterviewRequired()).willReturn(true);
+        given(clubApplyFormRepository.findByClubId(clubId)).willReturn(Optional.of(clubApplyForm));
 
         given(clubMemberRepository.findByClubIdAndRoleAndApplicationStatusAndStage(
                 eq(clubId), eq(Role.APPLICANT), eq(status), eq(stage)))

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/club/service/ClubServiceMockTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/club/service/ClubServiceMockTest.java
@@ -43,7 +43,9 @@ import com.kakaotech.team18.backend_server.global.exception.exceptions.InvalidFi
 import com.kakaotech.team18.backend_server.global.service.S3Service;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
@@ -88,7 +90,15 @@ public class ClubServiceMockTest {
     void getClubDashBoard() {
         //given
         Long clubId = 1L;
-        Club club = createClub(mock(ClubIntroduction.class), LocalDateTime.of(2025, 9, 3, 0, 0), LocalDateTime.of(2025, 9, 20, 23, 59));
+        Club club = createClub(mock(ClubIntroduction.class),
+                LocalDateTime.of(2025, 9, 3, 0, 0),
+                LocalDateTime.of(2025, 9, 20, 23, 59),
+                true,
+                LocalDateTime.of(2025, 9, 3, 0, 0),
+                LocalDateTime.of(2025, 9, 5, 0, 0),
+                LocalTime.of(9, 0),
+                LocalTime.of(21, 0)
+        );
         ReflectionTestUtils.setField(club, "id", 1L);
         User user = createUser("loginId", "123456");
         ReflectionTestUtils.setField(user, "id", 1L);
@@ -103,9 +113,13 @@ public class ClubServiceMockTest {
         given(clubApplyFormRepository.findByClubId(eq(club.getId()))).willReturn(Optional.of(clubApplyForm));
         given(clubMemberRepository.findByClubIdAndRoleAndApplicationIsNotNull(eq(clubId), eq(Role.APPLICANT))).willReturn(List.of(clubMember));
         given(clubMemberRepository.findByClubIdAndRoleAndApplicationStatus(eq(clubId), eq(Role.APPLICANT), eq(Status.PENDING))).willReturn(List.of(clubMember));
-        ClubDashBoardResponseDto expect = new ClubDashBoardResponseDto(1L,1, 1,
+        ClubDashBoardResponseDto expect = new ClubDashBoardResponseDto(1L, 1, 1,
                 LocalDate.of(2025, 9, 3),
-                LocalDate.of(2025, 9, 20));
+                LocalDate.of(2025, 9, 20),
+                LocalDate.of(2025, 9, 3),
+                LocalDate.of(2025, 9, 5),
+                "09:00 ~ 21:00"
+                );
 
         //when
         ClubDashBoardResponseDto actual = clubService.getClubDashBoard(clubId);
@@ -124,7 +138,15 @@ public class ClubServiceMockTest {
     void getClubDashBoardWithEmptyData() {
         //given
         Long clubId = 1L;
-        Club club = createClub(mock(ClubIntroduction.class), LocalDateTime.of(2025, 9, 3, 0, 0), LocalDateTime.of(2025, 9, 20, 23, 59));
+        Club club = createClub(mock(ClubIntroduction.class),
+                LocalDateTime.of(2025, 9, 3, 0, 0),
+                LocalDateTime.of(2025, 9, 20, 23, 59),
+                true,
+                LocalDateTime.of(2025, 9, 5, 0, 0),
+                LocalDateTime.of(2025, 9, 10, 0, 0),
+                LocalTime.of(9, 0),
+                LocalTime.of(21, 0)
+        );
         ReflectionTestUtils.setField(club, "id", 1L);
         User user = createUser("loginId", "123456");
         ReflectionTestUtils.setField(user, "id", 1L);
@@ -140,8 +162,12 @@ public class ClubServiceMockTest {
         given(clubMemberRepository.findByClubIdAndRoleAndApplicationIsNotNull(eq(clubId), eq(Role.APPLICANT))).willReturn(List.of());
         given(clubMemberRepository.findByClubIdAndRoleAndApplicationStatus(eq(1L), eq(Role.APPLICANT), eq(Status.PENDING))).willReturn(List.of());
 
-        ClubDashBoardResponseDto expect = new ClubDashBoardResponseDto(1L, 0, 0, LocalDate.of(2025, 9, 3),
-                LocalDate.of(2025, 9, 20)
+        ClubDashBoardResponseDto expect = new ClubDashBoardResponseDto(1L, 0, 0,
+                LocalDate.of(2025, 9, 3),
+                LocalDate.of(2025, 9, 20),
+                LocalDate.of(2025, 9, 5),
+                LocalDate.of(2025, 9, 10),
+                "09:00 ~ 21:00"
         );
 
         //when
@@ -163,7 +189,15 @@ public class ClubServiceMockTest {
         //given
         Long clubId = 1L;
         Long missingId = 0L;
-        Club club = createClub(mock(ClubIntroduction.class), LocalDateTime.of(2025, 9, 3, 0, 0), LocalDateTime.of(2025, 9, 20, 23, 59));
+        Club club = createClub(mock(ClubIntroduction.class),
+                LocalDateTime.of(2025, 9, 3, 0, 0),
+                LocalDateTime.of(2025, 9, 20, 23, 59),
+                true,
+                LocalDateTime.of(2025, 9, 3, 0, 0),
+                LocalDateTime.of(2025, 9, 5, 0, 0),
+                LocalTime.of(9, 0),
+                LocalTime.of(21, 0)
+        );
         ReflectionTestUtils.setField(club, "id", 1L);
         User user = createUser("loginId", "123456");
         ReflectionTestUtils.setField(user, "id", 1L);
@@ -194,7 +228,15 @@ public class ClubServiceMockTest {
         ClubImage image = createClubImage(clubIntroduction);
         clubIntroduction.addImage(image);
         ReflectionTestUtils.setField(image, "id", 1L);
-        Club club = createClub(clubIntroduction, LocalDateTime.of(2025, 9, 3, 0, 0), LocalDateTime.of(2025, 9, 20, 23, 59));
+        Club club = createClub(clubIntroduction,
+                LocalDateTime.of(2025, 9, 3, 0, 0),
+                LocalDateTime.of(2025, 9, 20, 23, 59),
+                true,
+                LocalDateTime.of(2025, 9, 5, 0, 0),
+                LocalDateTime.of(2025, 9, 10, 0, 0),
+                LocalTime.of(9, 10),
+                LocalTime.of(21, 0)
+        );
         ReflectionTestUtils.setField(club, "id", 1L);
         User user = createUser("loginId", "123456");
         ReflectionTestUtils.setField(user, "id", 1L);
@@ -249,7 +291,15 @@ public class ClubServiceMockTest {
         ClubIntroduction clubIntroduction = createClubIntroduction();
         ClubImage image = createClubImage(clubIntroduction);
         clubIntroduction.addImage(image);
-        Club club = createClub(clubIntroduction, LocalDateTime.of(2025, 9, 3, 0, 0), LocalDateTime.of(2025, 9, 20, 23, 59));
+        Club club = createClub(clubIntroduction,
+                LocalDateTime.of(2025, 9, 3, 0, 0),
+                LocalDateTime.of(2025, 9, 20, 23, 59),
+                true,
+                LocalDateTime.of(2025, 9, 5, 0, 0),
+                LocalDateTime.of(2025, 9, 10, 0, 0),
+                LocalTime.of(9, 10),
+                LocalTime.of(21, 0)
+        );
         User user = createUser( "loginId", "123456");
         ClubMember clubMember = createClubMember(user, club, mock(Application.class), Role.CLUB_ADMIN, ActiveStatus.ACTIVE);
 
@@ -273,7 +323,15 @@ public class ClubServiceMockTest {
         ClubIntroduction clubIntroduction = createClubIntroduction();
         ClubImage image = createClubImage(clubIntroduction);
         clubIntroduction.addImage(image);
-        Club club = createClub(clubIntroduction, LocalDateTime.of(2025, 9, 3, 0, 0), LocalDateTime.of(2025, 9, 20, 23, 59));
+        Club club = createClub(clubIntroduction,
+                LocalDateTime.of(2025, 9, 3, 0, 0),
+                LocalDateTime.of(2025, 9, 20, 23, 59),
+                true,
+                LocalDateTime.of(2025, 9, 5, 0, 0),
+                LocalDateTime.of(2025, 9, 10, 0, 0),
+                LocalTime.of(9, 10),
+                LocalTime.of(21, 0)
+        );
         ReflectionTestUtils.setField(club, "id", clubId);
 
         given(clubRepository.findClubDetailById(eq(clubId))).willReturn(Optional.of(club));
@@ -400,8 +458,15 @@ public class ClubServiceMockTest {
         clubIntroduction.addImage(existingImage2);
         clubIntroduction.addImage(existingImage3);
 
-        Club club = createClub(clubIntroduction, LocalDateTime.of(2025, 9, 3, 0, 0),
-                LocalDateTime.of(2025, 9, 20, 23, 59));
+        Club club = createClub(clubIntroduction,
+                LocalDateTime.of(2025, 9, 3, 0, 0),
+                LocalDateTime.of(2025, 9, 20, 23, 59),
+                true,
+                LocalDateTime.of(2025, 9, 5, 0, 0),
+                LocalDateTime.of(2025, 9, 10, 0, 0),
+                LocalTime.of(9, 10),
+                LocalTime.of(21, 0)
+        );
         ReflectionTestUtils.setField(club, "id", 1L);
 
         // 유지할 이미지 ID: 1L (old1.jpg)
@@ -458,8 +523,15 @@ public class ClubServiceMockTest {
         clubIntroduction.addImage(existingImage1);
         clubIntroduction.addImage(existingImage2);
 
-        Club club = createClub(clubIntroduction, LocalDateTime.of(2025, 9, 3, 0, 0),
-                LocalDateTime.of(2025, 9, 20, 23, 59));
+        Club club = createClub(clubIntroduction,
+                LocalDateTime.of(2025, 9, 3, 0, 0),
+                LocalDateTime.of(2025, 9, 20, 23, 59),
+                true,
+                LocalDateTime.of(2025, 9, 5, 0, 0),
+                LocalDateTime.of(2025, 9, 10, 0, 0),
+                LocalTime.of(9, 10),
+                LocalTime.of(21, 0)
+        );
         ReflectionTestUtils.setField(club, "id", 1L);
 
         // 유지할 이미지 없음 (모두 삭제)
@@ -547,8 +619,15 @@ public class ClubServiceMockTest {
         clubIntroduction.addImage(existingImage1);
         clubIntroduction.addImage(existingImage2);
 
-        Club club = createClub(clubIntroduction, LocalDateTime.of(2025, 9, 3, 0, 0),
-                LocalDateTime.of(2025, 9, 20, 23, 59));
+        Club club = createClub(clubIntroduction,
+                LocalDateTime.of(2025, 9, 3, 0, 0),
+                LocalDateTime.of(2025, 9, 20, 23, 59),
+                true,
+                LocalDateTime.of(2025, 9, 5, 0, 0),
+                LocalDateTime.of(2025, 9, 10, 0, 0),
+                LocalTime.of(9, 10),
+                LocalTime.of(21, 0)
+        );
         ReflectionTestUtils.setField(club, "id", 1L);
 
         // 유지할 이미지 없음 (모두 삭제)
@@ -657,7 +736,13 @@ public class ClubServiceMockTest {
     private static Stream<Arguments> provideStatusAndClubMembers() {
         Club club = createClub(mock(ClubIntroduction.class),
                 LocalDateTime.of(2025, 9, 3, 0, 0),
-                LocalDateTime.of(2025, 9, 20, 23, 59));
+                LocalDateTime.of(2025, 9, 20, 23, 59),
+                true,
+                LocalDateTime.of(2025, 9, 5, 0, 0),
+                LocalDateTime.of(2025, 9, 10, 0, 0),
+                LocalTime.of(9, 10),
+                LocalTime.of(21, 0)
+        );
         ClubApplyForm clubApplyForm = createClubApplyForm(club);
 
         User user1 = createUser("loginId1", "111111");
@@ -686,7 +771,15 @@ public class ClubServiceMockTest {
     void viewApplicantsByNoFilter() {
         //given
         Long clubId = 1L;
-        Club club = createClub(mock(ClubIntroduction.class), LocalDateTime.of(2025, 9, 3, 0, 0), LocalDateTime.of(2025, 9, 20, 23, 59));
+        Club club = createClub(mock(ClubIntroduction.class),
+                LocalDateTime.of(2025, 9, 3, 0, 0),
+                LocalDateTime.of(2025, 9, 20, 23, 59),
+                true,
+                LocalDateTime.of(2025, 9, 5, 0, 0),
+                LocalDateTime.of(2025, 9, 10, 0, 0),
+                LocalTime.of(9, 10),
+                LocalTime.of(21, 0)
+        );
         ReflectionTestUtils.setField(club, "id", clubId);
 
         User user1 = createUser( "loginId1", "111111");
@@ -703,6 +796,11 @@ public class ClubServiceMockTest {
         ReflectionTestUtils.setField(application2, "id", 2L);
         ReflectionTestUtils.setField(application3, "id", 3L);
 
+        // 면접 시간 정보 추가
+        application1.updateInterviewInfo(Map.of(LocalDate.of(2025, 1, 2), List.of(LocalTime.of(10, 0))));
+        application2.updateInterviewInfo(Map.of(LocalDate.of(2025, 1, 2), List.of(LocalTime.of(10, 0))));
+        application3.updateInterviewInfo(Map.of(LocalDate.of(2025, 1, 2), List.of(LocalTime.of(10, 0))));
+
         ClubMember clubMember1 = createClubMember(user1, club, application1, Role.APPLICANT, ActiveStatus.ACTIVE);
         ClubMember clubMember2 = createClubMember(user2, club, application2, Role.APPLICANT, ActiveStatus.ACTIVE);
         ClubMember clubMember3 = createClubMember(user3, club, application3, Role.APPLICANT, ActiveStatus.ACTIVE);
@@ -714,12 +812,14 @@ public class ClubServiceMockTest {
 
         List<ApplicantResponseDto> expect = List.of(
                 new ApplicantResponseDto("김춘식", "111111", "철학과", "010-1234-5678", "123@email.com",
-                        Status.PENDING, 1L),
+                        Status.PENDING, 1L, List.of(new ApplicantResponseDto.preferInterviewInfo(
+                        LocalDate.of(2025, 1, 2), List.of(LocalTime.of(10, 0))))),
                 new ApplicantResponseDto("김춘식", "222222", "철학과", "010-1234-5678", "123@email.com",
-                        Status.APPROVED, 2L),
+                        Status.APPROVED, 2L, List.of(new ApplicantResponseDto.preferInterviewInfo(
+                        LocalDate.of(2025, 1, 2), List.of(LocalTime.of(10, 0))))),
                 new ApplicantResponseDto("김춘식", "333333", "철학과", "010-1234-5678", "123@email.com",
-                        Status.REJECTED, 3L)
-        );
+                        Status.REJECTED, 3L, List.of(new ApplicantResponseDto.preferInterviewInfo(
+                        LocalDate.of(2025, 1, 2), List.of(LocalTime.of(10, 0))))));
 
         //when
         ClubDashboardApplicantResponseDto actual = clubService.getApplicantsByStatusAndStage(1L, null, Stage.INTERVIEW);
@@ -759,7 +859,13 @@ public class ClubServiceMockTest {
     private static Club createClub(
             ClubIntroduction clubIntroduction,
             LocalDateTime recruitStart,
-            LocalDateTime recruitEnd
+            LocalDateTime recruitEnd,
+            Boolean isInterviewRequired,
+            LocalDateTime interviewStartDate,
+            LocalDateTime interviewEndDate,
+            LocalTime interviewStartTime,
+            LocalTime interviewEndTime
+
     ) {
         return Club.builder()
                 .name("카태켐")
@@ -771,6 +877,11 @@ public class ClubServiceMockTest {
                 .recruitStart(recruitStart)
                 .recruitEnd(recruitEnd)
                 .regularMeetingInfo("매주 화요일 오후 6시반")
+                .isInterviewRequired(isInterviewRequired)
+                .interviewStartDate(interviewStartDate)
+                .interviewEndDate(interviewEndDate)
+                .interviewStartTime(interviewStartTime)
+                .interviewEndTime(interviewEndTime)
                 .build();
     }
 

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/email/service/EmailServiceUnitTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/email/service/EmailServiceUnitTest.java
@@ -24,8 +24,9 @@ import com.kakaotech.team18.backend_server.domain.user.entity.User;
 import com.kakaotech.team18.backend_server.global.dto.SuccessResponseDto;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.PendingApplicationsExistException;
 
+import java.time.LocalDate;
+import java.time.LocalTime;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -213,6 +214,10 @@ class EmailServiceUnitTest {
         when(appApproved.getUser()).thenReturn(userApproved);
         when(appRejected.getUser()).thenReturn(userRejected);
 
+        // interviewSchedule
+        when(appApproved.getInterviewDate()).thenReturn(LocalDate.of(2026, 1, 10));
+        when(appApproved.getInterviewTime()).thenReturn(LocalTime.of(10,0,0));
+
         when(applicationRepository.findAllByClubIdAndRoleAndStage(77L, Role.APPLICANT, Stage.INTERVIEW))
                 .thenReturn(List.of(appApproved, appRejected));
 
@@ -249,6 +254,7 @@ class EmailServiceUnitTest {
         assertThat(approvedEvt.email()).isEqualTo("approved@ex.com");
         assertThat(approvedEvt.message()).isEqualTo("면접 합격 안내 메시지");
         assertThat(approvedEvt.stage()).isEqualTo(Stage.INTERVIEW);
+        assertThat(approvedEvt.interviewSchedule()).isEqualTo(LocalDateTime.of(2026, 1, 10, 10, 0));
 
         // InterviewRejectedEvent
         InterviewRejectedEvent rejectedEvt = events.stream()

--- a/src/test/java/com/kakaotech/team18/backend_server/global/util/DateUtilTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/global/util/DateUtilTest.java
@@ -1,0 +1,30 @@
+package com.kakaotech.team18.backend_server.global.util;
+
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Map;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class DateUtilTest {
+
+    @DisplayName("인터뷰 선호 시간 파싱 성공")
+    @Test
+    void parseDateAndTimeSlots_success() {
+        //given
+        String dateInfo = "2025-10-16 10:30-11:00,2025-10-16 11:00-11:30";
+
+        //when
+        Map<LocalDate, List<LocalTime>> result = DateUtil.parseDateAndTimeSlots(dateInfo);
+
+        //then
+        LocalDate dateResult = LocalDate.of(2025, 10, 16);
+        Assertions.assertThat(result.containsKey(dateResult)).isTrue();
+        Assertions.assertThat(result.get(dateResult)).isEqualTo(
+                List.of(LocalTime.of(10, 30), LocalTime.of(11, 0)));
+    }
+
+}


### PR DESCRIPTION
## 🚀 작업 내용
이전 PR (#278)에서는 지원폼에서의 면접 일정 관련 기능을 구현했고, 이번 PR에서는 지원자 대쉬보드 관련한 면접 일정 관련 기능을 구현했습니다. 

크게는 
- 지원폼에 대한 대답 정보를 바탕으로 선호하는 면접 시간 DB에 저장

- 지원자의 확정된 면접 시간을 DB에 저장하는 API 추가

- 대쉬보드 조회시 동아리와 지원자의 면접 정보를 넘겨주도록 API 수정

- 메일에 지원자의 면접 일정 정보를 매핑해 전달하도록 기능 구현

의 기능을 구현했습니다. 

Application 엔티티와 관련 DTO에 면접 일정 관련 필드 값이 추가되었습니다. 
기존 지원자의 지원폼 응답을 저장하는 기능은 최대한 건드리지 않았고, 면접 관련 정보를 저장하는 기능만 추가했습니다. 

## ⏱️ 소요 시간
7시간 


## 🤔 고민했던 내용
기존 기능을 최대한 수정하지 않으려고 했습니다. 
면접 시간에 몇명이 선택되었는지를 프론트에 보내줬어야 했는데 이 부분을 직접 구현하기 어려워 LLM의 도움을 받았는데 적절하게 구현됐는지 잘 모르겠습니다. 리뷰어분들도 한번 확인 부탁드립니다. 


## 💬 리뷰 중점사항
인터뷰 관련 필드가 늘어나서 읽으시면서 어떤 필드가 선호 인터뷰 요일인지 어떤 필드가 인터뷰 확정 요일인지 헷갈릴 수 있을 것 같습니다. 그러시다면 더 좋은 변수명 혹은 메서드 명이 있으면 피드백 부탁드립니다. 

리뷰하시면서 잘 이해가 되지 않는 부분들이 있으면 코멘트 부탁드립니다. 

리뷰하시면서 구현되어야 할 로직이 누락된 것 같다면 피드백 부탁드립니다. 


## 🔗관련 이슈
- Close #280 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 지원자 면접 일정 확정(PATCH) 및 면접 일정 직접 수정 기능 추가
  * 지원자 선호 면접 슬롯(날짜·시간) 저장 및 대시보드에 날짜별 슬롯·배정수 표시 추가
  * 클럽 대시보드에 면접 시작/종료일 및 시간 범위 노출
  * 지원자 응답에 확정된 인터뷰 시간·선호시간 포함(응답 페이로드 확장)
  * 면접 승인 이메일에 확정된 면접 일정 포함 및 템플릿 조건 추가

* **Tests**
  * 면접 일정 파싱·저장·수정 관련 단위·통합·컨트롤러 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->