### PR TITLE
[FIX] 면접을 보지 않는 동아리를 위해 면접 일정이 없으면 null 로 반환하는 로직 추가 (#280)

### DIFF
--- a/src/main/java/com/kakaotech/team18/backend_server/domain/club/service/ClubServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/club/service/ClubServiceImpl.java
@@ -133,9 +133,10 @@ public class ClubServiceImpl implements ClubService {
                 pendingApplications.size(),
                 club.getRecruitStart().toLocalDate(),
                 club.getRecruitEnd().toLocalDate(),
-                club.getInterviewStartDate().toLocalDate(),
-                club.getInterviewEndDate().toLocalDate(),
-                DateUtil.formatTimeRange(club.getInterviewStartTime(), club.getInterviewEndTime()));
+                club.getInterviewStartDate() != null ? club.getInterviewStartDate().toLocalDate() : null,
+                club.getInterviewEndDate() != null ? club.getInterviewEndDate().toLocalDate() : null,
+                (club.getInterviewStartTime() != null && club.getInterviewEndTime() != null) ?
+                        DateUtil.formatTimeRange(club.getInterviewStartTime(), club.getInterviewEndTime()) : null);
     }
 
     @Override

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/formQuestion/dto/FormQuestionUpdateDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/formQuestion/dto/FormQuestionUpdateDto.java
@@ -3,7 +3,6 @@ package com.kakaotech.team18.backend_server.domain.formQuestion.dto;
 import com.kakaotech.team18.backend_server.domain.formQuestion.entity.FieldType;
 import com.kakaotech.team18.backend_server.domain.formQuestion.validate.ValidFormQuestionRequest;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
@@ -39,8 +38,7 @@ public record FormQuestionUpdateDto(
         List<String> optionList,
 
         @Schema(description = "(Time Slot)선택지")
-        @Valid
-        List<@Valid TimeSlotOptionRequestDto> timeSlotOptions
+        List<TimeSlotOptionRequestDto> timeSlotOptions
 ) implements FormQuestionBaseDto{
 
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/formQuestion/validate/FormQuestionRequestValidator.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/formQuestion/validate/FormQuestionRequestValidator.java
@@ -5,11 +5,25 @@ import static com.kakaotech.team18.backend_server.domain.formQuestion.entity.Fie
 import static com.kakaotech.team18.backend_server.domain.formQuestion.entity.FieldType.TIME_SLOT;
 
 import com.kakaotech.team18.backend_server.domain.formQuestion.dto.FormQuestionBaseDto;
+import com.kakaotech.team18.backend_server.domain.formQuestion.dto.TimeSlotOptionRequestDto;
 import com.kakaotech.team18.backend_server.domain.formQuestion.entity.FieldType;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import java.util.Set;
+import jakarta.validation.ConstraintViolation;
 
 public class FormQuestionRequestValidator implements ConstraintValidator<ValidFormQuestionRequest, FormQuestionBaseDto> {
+
+    private final Validator validator;
+
+    public FormQuestionRequestValidator() {
+        try (ValidatorFactory factory = Validation.buildDefaultValidatorFactory()) {
+            this.validator = factory.getValidator();
+        }
+    }
 
     @Override
     public boolean isValid(FormQuestionBaseDto dto, ConstraintValidatorContext context) {
@@ -22,6 +36,16 @@ public class FormQuestionRequestValidator implements ConstraintValidator<ValidFo
         if (type == TIME_SLOT) {
             if (dto.timeSlotOptions() == null || dto.timeSlotOptions().isEmpty()) {
                 return fail(context, "TIME_SLOT 유형은 timeSlotOptions를 입력해야 합니다.");
+            }
+            // TIME_SLOT일 때만 내부 요소 검증 수행
+            for (int i = 0; i < dto.timeSlotOptions().size(); i++) {
+                TimeSlotOptionRequestDto option = dto.timeSlotOptions().get(i);
+                Set<ConstraintViolation<TimeSlotOptionRequestDto>> violations = validator.validate(option);
+                if (!violations.isEmpty()) {
+                    // 첫 번째 위반 사항만 메시지로 반환
+                    ConstraintViolation<TimeSlotOptionRequestDto> violation = violations.iterator().next();
+                    return fail(context, "timeSlotOptions[" + i + "]." + violation.getPropertyPath() + ": " + violation.getMessage());
+                }
             }
         }
 


### PR DESCRIPTION
## 🚀 작업 내용
지원자 대쉬보드 API에서 클럽의 인터뷰 정보를 getter로 받아오는데 이 필드 값들이 새로 추가된 필드 값들이라서 값이 null로 채워져 있습니다. 
DB에 값을 넣어줘야할 것 같고. 

면접을 보지 않는 동아리도 존재할 것이라 생각해, 면접 정보가 존재하지 않으면 null 값을 반환하도록 했습니다. 

## ⏱️ 소요 시간


## 🤔 고민했던 내용


## 💬 리뷰 중점사항


## 🔗관련 이슈
- Close #280

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정

* 클럽 대시보드에서 면접 날짜 및 시간 정보가 누락된 경우 발생하던 오류가 해결되었습니다. 누락된 정보가 있어도 대시보드가 정상적으로 표시되도록 안정성이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->