### PR TITLE
[FEATURE] 동아리원 관리 페이지

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -90,6 +90,12 @@ dependencies {
     //Logback 로그를 Discord Webhook으로 전송해주는 전용 Appender 라이브러리
     implementation 'com.github.napstr:logback-discord-appender:1.0.0'
 
+    // Apache POI (Excel)
+    implementation 'org.apache.poi:poi:5.4.0'
+    implementation 'org.apache.poi:poi-ooxml:5.4.0'
+
+    // OpenCSV (CSV)
+    implementation 'com.opencsv:opencsv:5.10'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -93,9 +93,6 @@ dependencies {
     // Apache POI (Excel)
     implementation 'org.apache.poi:poi:5.4.0'
     implementation 'org.apache.poi:poi-ooxml:5.4.0'
-
-    // OpenCSV (CSV)
-    implementation 'com.opencsv:opencsv:5.10'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/controller/ClubMemberController.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/controller/ClubMemberController.java
@@ -16,7 +16,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import java.io.IOException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
@@ -86,7 +85,7 @@ public class ClubMemberController {
             @Parameter(description = "동아리 ID", required = true, example = "1") @PathVariable Long clubId,
             @Parameter(description = "엑셀 파일 (.xlsx, .xls)", content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE))
             @RequestPart("file") MultipartFile file
-    ) throws IOException {
+    ) {
         clubMemberService.registerMembersByExcel(clubId, file);
         return ResponseEntity.ok(new SuccessResponseDto(true));
     }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/controller/ClubMemberController.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/controller/ClubMemberController.java
@@ -3,14 +3,18 @@ package com.kakaotech.team18.backend_server.domain.clubMember.controller;
 import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMemberResponseDto;
 import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMemberSaveRequestDto;
 import com.kakaotech.team18.backend_server.domain.clubMember.service.ClubMemberService;
+import com.kakaotech.team18.backend_server.global.dto.SuccessResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.io.IOException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -18,7 +22,9 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @Tag(name = "동아리원 관리 API", description = "동아리원 조회, 등록, 수정, 삭제 관련 API")
 @RestController
@@ -58,5 +64,23 @@ public class ClubMemberController {
     ) {
         ClubMemberResponseDto response = clubMemberService.registerMember(clubId, requestDto);
         return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "동아리원 일괄 등록 (엑셀 업로드)", description = "엑셀 파일을 업로드하여 동아리원을 일괄 등록합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "일괄 등록 성공"),
+            @ApiResponse(responseCode = "400", description = "엑셀 데이터 검증 실패 또는 파일 형식 오류"),
+            @ApiResponse(responseCode = "413", description = "파일 크기 초과"),
+            @ApiResponse(responseCode = "403", description = "권한 없음 (회장/운영진만 가능)")
+    })
+    @PreAuthorize("@customSecurityService.isClubAdminOrExecutive(#clubId)")
+    @PostMapping(value = "/{clubId}/members/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<SuccessResponseDto> uploadMembers(
+            @Parameter(description = "동아리 ID", required = true, example = "1") @PathVariable Long clubId,
+            @Parameter(description = "엑셀 파일 (.xlsx, .xls)", content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE))
+            @RequestPart("file") MultipartFile file
+    ) throws IOException {
+        clubMemberService.registerMembersByExcel(clubId, file);
+        return ResponseEntity.ok(new SuccessResponseDto(true));
     }
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/controller/ClubMemberController.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/controller/ClubMemberController.java
@@ -2,11 +2,13 @@ package com.kakaotech.team18.backend_server.domain.clubMember.controller;
 
 import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMemberResponseDto;
 import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMemberSaveRequestDto;
+import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMemberUpdateRequestDto;
 import com.kakaotech.team18.backend_server.domain.clubMember.service.ClubMemberService;
 import com.kakaotech.team18.backend_server.global.dto.SuccessResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -18,6 +20,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -82,5 +85,24 @@ public class ClubMemberController {
     ) throws IOException {
         clubMemberService.registerMembersByExcel(clubId, file);
         return ResponseEntity.ok(new SuccessResponseDto(true));
+    }
+
+    @Operation(summary = "동아리원 정보 수정", description = "동아리원의 정보를 부분 수정합니다. (직책 수정 불가)")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "수정 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 입력값"),
+            @ApiResponse(responseCode = "409", description = "중복 학번 (다른 멤버가 사용 중)"),
+            @ApiResponse(responseCode = "403", description = "권한 없음 (회장/운영진만 가능)"),
+            @ApiResponse(responseCode = "404", description = "해당 프로필을 찾을 수 없음")
+    })
+    @PreAuthorize("@customSecurityService.isClubAdminOrExecutive(#clubId)")
+    @PatchMapping("/{clubId}/members/{profileId}")
+    public ResponseEntity<ClubMemberResponseDto> updateMember(
+            @Parameter(description = "동아리 ID", required = true, example = "1") @PathVariable Long clubId,
+            @Parameter(description = "프로필 ID", required = true, example = "501") @PathVariable Long profileId,
+            @Valid @RequestBody ClubMemberUpdateRequestDto requestDto
+    ) {
+        ClubMemberResponseDto response = clubMemberService.updateMember(clubId, profileId, requestDto);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/controller/ClubMemberController.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/controller/ClubMemberController.java
@@ -1,6 +1,8 @@
 package com.kakaotech.team18.backend_server.domain.clubMember.controller;
 
 import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMemberResponseDto;
+import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMemberRoleUpdateResponseDto;
+import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMemberRoleUpdateRequestDto;
 import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMemberSaveRequestDto;
 import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMemberUpdateRequestDto;
 import com.kakaotech.team18.backend_server.domain.clubMember.service.ClubMemberService;
@@ -103,6 +105,24 @@ public class ClubMemberController {
             @Valid @RequestBody ClubMemberUpdateRequestDto requestDto
     ) {
         ClubMemberResponseDto response = clubMemberService.updateMember(clubId, profileId, requestDto);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "동아리원 직책 변경 (권한 부여)", description = "동아리원의 직책을 변경합니다. (회장 전용)")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "직책 변경 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 입력값"),
+            @ApiResponse(responseCode = "403", description = "권한 없음 (회장만 가능)"),
+            @ApiResponse(responseCode = "404", description = "해당 프로필을 찾을 수 없음")
+    })
+    @PreAuthorize("@customSecurityService.isClubAdminOrExecutive(#clubId)")
+    @PatchMapping("/{clubId}/members/{profileId}/role")
+    public ResponseEntity<ClubMemberRoleUpdateResponseDto> updateMemberRole(
+            @Parameter(description = "동아리 ID", required = true, example = "1") @PathVariable Long clubId,
+            @Parameter(description = "프로필 ID", required = true, example = "501") @PathVariable Long profileId,
+            @Valid @RequestBody ClubMemberRoleUpdateRequestDto requestDto
+    ) {
+        ClubMemberRoleUpdateResponseDto response = clubMemberService.updateMemberRole(clubId, profileId, requestDto);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/controller/ClubMemberController.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/controller/ClubMemberController.java
@@ -1,0 +1,42 @@
+package com.kakaotech.team18.backend_server.domain.clubMember.controller;
+
+import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMemberResponseDto;
+import com.kakaotech.team18.backend_server.domain.clubMember.service.ClubMemberService;
+import com.kakaotech.team18.backend_server.global.dto.SuccessResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "동아리원 관리 API", description = "동아리원 조회, 등록, 수정, 삭제 관련 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/clubs")
+public class ClubMemberController {
+
+    private final ClubMemberService clubMemberService;
+
+    @Operation(summary = "동아리원 목록 조회", description = "특정 동아리의 전체 동아리원 목록을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "403", description = "권한 없음 (회장/운영진만 가능)"),
+            @ApiResponse(responseCode = "404", description = "해당 동아리를 찾을 수 없음")
+    })
+    @PreAuthorize("@customSecurityService.isClubAdminOrExecutive(#clubId)")
+    @GetMapping("/{clubId}/members")
+    public ResponseEntity<List<ClubMemberResponseDto>> getClubMembers(
+            @Parameter(description = "동아리 ID", required = true, example = "1") @PathVariable Long clubId
+    ) {
+        List<ClubMemberResponseDto> response = clubMemberService.getClubMembers(clubId);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/controller/ClubMemberController.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/controller/ClubMemberController.java
@@ -1,5 +1,6 @@
 package com.kakaotech.team18.backend_server.domain.clubMember.controller;
 
+import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMemberDeleteResponseDto;
 import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMemberResponseDto;
 import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMemberRoleUpdateResponseDto;
 import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMemberRoleUpdateRequestDto;
@@ -21,6 +22,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -123,6 +125,23 @@ public class ClubMemberController {
             @Valid @RequestBody ClubMemberRoleUpdateRequestDto requestDto
     ) {
         ClubMemberRoleUpdateResponseDto response = clubMemberService.updateMemberRole(clubId, profileId, requestDto);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "동아리원 삭제", description = "동아리원을 목록에서 삭제합니다. (회장 전용)")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "삭제 성공"),
+            @ApiResponse(responseCode = "403", description = "권한 없음 (회장만 가능)"),
+            @ApiResponse(responseCode = "404", description = "해당 프로필을 찾을 수 없음"),
+            @ApiResponse(responseCode = "400", description = "자기 자신 삭제 불가")
+    })
+    @PreAuthorize("@customSecurityService.isClubAdminOrExecutive(#clubId)")
+    @DeleteMapping("/{clubId}/members/{profileId}")
+    public ResponseEntity<ClubMemberDeleteResponseDto> deleteMember(
+            @Parameter(description = "동아리 ID", required = true, example = "1") @PathVariable Long clubId,
+            @Parameter(description = "프로필 ID", required = true, example = "501") @PathVariable Long profileId
+    ) {
+        ClubMemberDeleteResponseDto response = clubMemberService.deleteMember(clubId, profileId);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/controller/ClubMemberController.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/controller/ClubMemberController.java
@@ -1,19 +1,22 @@
 package com.kakaotech.team18.backend_server.domain.clubMember.controller;
 
 import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMemberResponseDto;
+import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMemberSaveRequestDto;
 import com.kakaotech.team18.backend_server.domain.clubMember.service.ClubMemberService;
-import com.kakaotech.team18.backend_server.global.dto.SuccessResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -37,6 +40,23 @@ public class ClubMemberController {
             @Parameter(description = "동아리 ID", required = true, example = "1") @PathVariable Long clubId
     ) {
         List<ClubMemberResponseDto> response = clubMemberService.getClubMembers(clubId);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "동아리원 수동 등록 (단건)", description = "동아리원을 한 명씩 수동으로 등록하거나 정보를 수정합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "등록/수정 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 입력값"),
+            @ApiResponse(responseCode = "409", description = "중복 등록 실패 (이름 불일치)"),
+            @ApiResponse(responseCode = "403", description = "권한 없음 (회장/운영진만 가능)")
+    })
+    @PreAuthorize("@customSecurityService.isClubAdminOrExecutive(#clubId)")
+    @PostMapping("/{clubId}/members")
+    public ResponseEntity<ClubMemberResponseDto> registerMember(
+            @Parameter(description = "동아리 ID", required = true, example = "1") @PathVariable Long clubId,
+            @Valid @RequestBody ClubMemberSaveRequestDto requestDto
+    ) {
+        ClubMemberResponseDto response = clubMemberService.registerMember(clubId, requestDto);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/dto/ClubMemberDeleteResponseDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/dto/ClubMemberDeleteResponseDto.java
@@ -1,0 +1,13 @@
+package com.kakaotech.team18.backend_server.domain.clubMember.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "동아리원 삭제 응답 DTO")
+public record ClubMemberDeleteResponseDto(
+        @Schema(description = "결과 메시지", example = "해당 동아리원이 목록에서 삭제되었습니다.")
+        String message,
+
+        @Schema(description = "삭제된 프로필 ID", example = "501")
+        Long deletedClubMemberProfileId
+) {
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/dto/ClubMemberResponseDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/dto/ClubMemberResponseDto.java
@@ -1,0 +1,42 @@
+package com.kakaotech.team18.backend_server.domain.clubMember.dto;
+
+import com.kakaotech.team18.backend_server.domain.clubMember.entity.ClubMemberProfile;
+import com.kakaotech.team18.backend_server.domain.clubMember.entity.Role;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.format.DateTimeFormatter;
+
+@Schema(description = "동아리원 목록 조회 응답 DTO")
+public record ClubMemberResponseDto(
+        @Schema(description = "동아리원 프로필 ID", example = "101")
+        Long clubMemberProfileId,
+
+        @Schema(description = "이름", example = "이지훈")
+        String name,
+
+        @Schema(description = "학과", example = "컴퓨터공학과")
+        String department,
+
+        @Schema(description = "학번", example = "213856")
+        String studentId,
+
+        @Schema(description = "전화번호", example = "010-1234-5678")
+        String phoneNumber,
+
+        @Schema(description = "동아리 내 직책", example = "CLUB_EXECUTIVE")
+        Role role,
+
+        @Schema(description = "가입일자 (YYYY-MM)", example = "2023-03")
+        String joinDate
+) {
+    public static ClubMemberResponseDto from(ClubMemberProfile profile) {
+        return new ClubMemberResponseDto(
+                profile.getId(),
+                profile.getName(),
+                profile.getDepartment(),
+                profile.getStudentId(),
+                profile.getPhoneNumber(),
+                profile.getRole(),
+                profile.getJoinDate().format(DateTimeFormatter.ofPattern("yyyy-MM"))
+        );
+    }
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/dto/ClubMemberRoleUpdateRequestDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/dto/ClubMemberRoleUpdateRequestDto.java
@@ -1,0 +1,13 @@
+package com.kakaotech.team18.backend_server.domain.clubMember.dto;
+
+import com.kakaotech.team18.backend_server.domain.clubMember.entity.Role;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "동아리원 직책 변경 요청 DTO")
+public record ClubMemberRoleUpdateRequestDto(
+        @Schema(description = "변경할 직책 (CLUB_MEMBER, CLUB_EXECUTIVE)", example = "CLUB_EXECUTIVE")
+        @NotNull(message = "직책은 필수입니다.")
+        Role role
+) {
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/dto/ClubMemberRoleUpdateRequestDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/dto/ClubMemberRoleUpdateRequestDto.java
@@ -6,7 +6,7 @@ import jakarta.validation.constraints.NotNull;
 
 @Schema(description = "동아리원 직책 변경 요청 DTO")
 public record ClubMemberRoleUpdateRequestDto(
-        @Schema(description = "변경할 직책 (CLUB_MEMBER, CLUB_EXECUTIVE)", example = "CLUB_EXECUTIVE")
+        @Schema(description = "변경할 직책 (CLUB_MEMBER, CLUB_EXECUTIVE, CLUB_ADMIN)", example = "CLUB_EXECUTIVE")
         @NotNull(message = "직책은 필수입니다.")
         Role role
 ) {

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/dto/ClubMemberRoleUpdateResponseDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/dto/ClubMemberRoleUpdateResponseDto.java
@@ -1,0 +1,34 @@
+package com.kakaotech.team18.backend_server.domain.clubMember.dto;
+
+import com.kakaotech.team18.backend_server.domain.clubMember.entity.Role;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+@Schema(description = "동아리원 직책 변경 응답 DTO")
+public record ClubMemberRoleUpdateResponseDto(
+        @Schema(description = "동아리 ID", example = "1")
+        Long clubId,
+
+        @Schema(description = "동아리 이름", example = "동아리움")
+        String clubName,
+
+        @Schema(description = "프로필 ID", example = "501")
+        Long clubMemberProfileId,
+
+        @Schema(description = "학번", example = "212121")
+        String studentId,
+
+        @Schema(description = "이름", example = "박개명")
+        String name,
+
+        @Schema(description = "변경 전 직책", example = "CLUB_MEMBER")
+        Role previousRole,
+
+        @Schema(description = "변경 후 직책", example = "CLUB_EXECUTIVE")
+        Role newRole,
+
+        @Schema(description = "결과 메시지", example = "운영진으로 역할이 변경되었습니다.")
+        String message
+) {
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/dto/ClubMemberSaveRequestDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/dto/ClubMemberSaveRequestDto.java
@@ -1,0 +1,46 @@
+package com.kakaotech.team18.backend_server.domain.clubMember.dto;
+
+import com.kakaotech.team18.backend_server.domain.clubMember.entity.AcademicStatus;
+import com.kakaotech.team18.backend_server.domain.clubMember.entity.Role;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+
+@Schema(description = "동아리원 등록/수정 요청 DTO")
+public record ClubMemberSaveRequestDto(
+        @Schema(description = "이름", example = "박신입")
+        @NotBlank(message = "이름은 필수입니다.")
+        String name,
+
+        @Schema(description = "학번", example = "241001")
+        @NotBlank(message = "학번은 필수입니다.")
+        String studentId,
+
+        @Schema(description = "전화번호", example = "010-1111-2222")
+        @NotBlank(message = "전화번호는 필수입니다.")
+        @Pattern(regexp = "^\\d{3}-\\d{3,4}-\\d{4}$", message = "전화번호 형식이 올바르지 않습니다. (010-XXXX-XXXX)")
+        String phoneNumber,
+
+        @Schema(description = "단과대학", example = "공과대학")
+        @NotBlank(message = "단과대학은 필수입니다.")
+        String college,
+
+        @Schema(description = "학과", example = "컴퓨터공학과")
+        @NotBlank(message = "학과는 필수입니다.")
+        String department,
+
+        @Schema(description = "학적상태", example = "ENROLLED")
+        @NotNull(message = "학적상태는 필수입니다.")
+        AcademicStatus academicStatus,
+
+        @Schema(description = "직책", example = "CLUB_MEMBER")
+        @NotNull(message = "직책은 필수입니다.")
+        Role role,
+
+        @Schema(description = "가입일자 (YYYY-MM)", example = "2024-03")
+        @NotBlank(message = "가입일자는 필수입니다.")
+        @Pattern(regexp = "^\\d{4}-\\d{2}$", message = "가입일자 형식이 올바르지 않습니다. (YYYY-MM)")
+        String joinDate
+) {
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/dto/ClubMemberUpdateRequestDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/dto/ClubMemberUpdateRequestDto.java
@@ -1,0 +1,32 @@
+package com.kakaotech.team18.backend_server.domain.clubMember.dto;
+
+import com.kakaotech.team18.backend_server.domain.clubMember.entity.AcademicStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Pattern;
+
+@Schema(description = "동아리원 정보 수정 요청 DTO (변경할 필드만 포함)")
+public record ClubMemberUpdateRequestDto(
+        @Schema(description = "이름", example = "박개명")
+        String name,
+
+        @Schema(description = "학번", example = "212121")
+        String studentId,
+
+        @Schema(description = "전화번호", example = "010-9999-8888")
+        @Pattern(regexp = "^\\d{3}-\\d{3,4}-\\d{4}$", message = "전화번호 형식이 올바르지 않습니다. (010-XXXX-XXXX)")
+        String phoneNumber,
+
+        @Schema(description = "단과대학", example = "AI융합대학")
+        String college,
+
+        @Schema(description = "학과", example = "인공지능학부")
+        String department,
+
+        @Schema(description = "학적상태", example = "LEAVE_OF_ABSENCE")
+        AcademicStatus academicStatus,
+
+        @Schema(description = "가입일자 (YYYY-MM)", example = "2024-05")
+        @Pattern(regexp = "^\\d{4}-\\d{2}$", message = "가입일자 형식이 올바르지 않습니다. (YYYY-MM)")
+        String joinDate
+) {
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/entity/AcademicStatus.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/entity/AcademicStatus.java
@@ -1,0 +1,16 @@
+package com.kakaotech.team18.backend_server.domain.clubMember.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum AcademicStatus {
+    ENROLLED("재학"),
+    LEAVE_OF_ABSENCE("휴학"),
+    GRADUATED("졸업"),
+    COMPLETED("수료"),
+    EXPELLED("제적");
+
+    private final String description;
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/entity/ClubMember.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/entity/ClubMember.java
@@ -56,4 +56,10 @@ public class ClubMember extends BaseEntity {
     public void setProfile(ClubMemberProfile profile) {
         this.profile = profile;
     }
+
+    public void updateRole(Role role) {
+        if (role != null) {
+            this.role = role;
+        }
+    }
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/entity/ClubMember.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/entity/ClubMember.java
@@ -40,6 +40,9 @@ public class ClubMember extends BaseEntity {
     @Column(name = "club_role", nullable = false, length = 20) // 길이는 적당히
     private Role role;
 
+    @OneToOne(mappedBy = "clubMember", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private ClubMemberProfile profile;
+
     @Builder
     private ClubMember(User user, Club club, ActiveStatus activeStatus, Application application,
             Role role) {
@@ -48,5 +51,9 @@ public class ClubMember extends BaseEntity {
         this.activeStatus = activeStatus;
         this.application = application;
         this.role = role;
+    }
+
+    public void setProfile(ClubMemberProfile profile) {
+        this.profile = profile;
     }
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/entity/ClubMemberProfile.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/entity/ClubMemberProfile.java
@@ -89,6 +89,10 @@ public class ClubMemberProfile extends BaseEntity {
         if (role != null) this.role = role;
     }
 
+    public boolean isOwner(Long userId) {
+        return this.clubMember.getUser().getId().equals(userId);
+    }
+
     private String getOrDefault(String newValue, String oldValue) {
         if (newValue != null && !newValue.isBlank()) {
             return newValue;

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/entity/ClubMemberProfile.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/entity/ClubMemberProfile.java
@@ -1,0 +1,91 @@
+package com.kakaotech.team18.backend_server.domain.clubMember.entity;
+
+import com.kakaotech.team18.backend_server.domain.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "club_member_profile")
+public class ClubMemberProfile extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "club_member_profile_id")
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "club_member_id", nullable = false, unique = true)
+    private ClubMember clubMember;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(name = "student_id", nullable = false)
+    private String studentId;
+
+    @Column(name = "phone_number", nullable = false)
+    private String phoneNumber;
+
+    @Column(nullable = false)
+    private String college;
+
+    @Column(nullable = false)
+    private String department;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "academic_status", nullable = false)
+    private AcademicStatus academicStatus;
+
+    @Column(name = "join_date", nullable = false)
+    private LocalDate joinDate;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Role role;
+
+    @Builder
+    private ClubMemberProfile(ClubMember clubMember, String name, String studentId,
+                              String phoneNumber, String college, String department,
+                              AcademicStatus academicStatus, LocalDate joinDate, Role role) {
+        this.clubMember = clubMember;
+        this.name = name;
+        this.studentId = studentId;
+        this.phoneNumber = phoneNumber;
+        this.college = college;
+        this.department = department;
+        this.academicStatus = academicStatus;
+        this.joinDate = joinDate;
+        this.role = role;
+    }
+
+    public void update(String name, String studentId, String phoneNumber, String college,
+                       String department, AcademicStatus academicStatus, LocalDate joinDate) {
+        if (name != null) this.name = name;
+        if (studentId != null) this.studentId = studentId;
+        if (phoneNumber != null) this.phoneNumber = phoneNumber;
+        if (college != null) this.college = college;
+        if (department != null) this.department = department;
+        if (academicStatus != null) this.academicStatus = academicStatus;
+        if (joinDate != null) this.joinDate = joinDate;
+    }
+
+    public void updateRole(Role role) {
+        if (role != null) this.role = role;
+    }
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/entity/ClubMemberProfile.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/entity/ClubMemberProfile.java
@@ -1,6 +1,7 @@
 package com.kakaotech.team18.backend_server.domain.clubMember.entity;
 
 import com.kakaotech.team18.backend_server.domain.BaseEntity;
+import com.kakaotech.team18.backend_server.domain.user.entity.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -90,7 +91,8 @@ public class ClubMemberProfile extends BaseEntity {
     }
 
     public boolean isOwner(Long userId) {
-        return this.clubMember.getUser().getId().equals(userId);
+        User user = this.clubMember.getUser();
+        return user != null && userId != null && userId.equals(user.getId());
     }
 
     private String getOrDefault(String newValue, String oldValue) {

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/entity/ClubMemberProfile.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/entity/ClubMemberProfile.java
@@ -76,16 +76,30 @@ public class ClubMemberProfile extends BaseEntity {
 
     public void update(String name, String studentId, String phoneNumber, String college,
                        String department, AcademicStatus academicStatus, LocalDate joinDate) {
-        if (name != null) this.name = name;
-        if (studentId != null) this.studentId = studentId;
-        if (phoneNumber != null) this.phoneNumber = phoneNumber;
-        if (college != null) this.college = college;
-        if (department != null) this.department = department;
-        if (academicStatus != null) this.academicStatus = academicStatus;
-        if (joinDate != null) this.joinDate = joinDate;
+        this.name = getOrDefault(name, this.name);
+        this.studentId = getOrDefault(studentId, this.studentId);
+        this.phoneNumber = getOrDefault(phoneNumber, this.phoneNumber);
+        this.college = getOrDefault(college, this.college);
+        this.department = getOrDefault(department, this.department);
+        this.academicStatus = getOrDefault(academicStatus, this.academicStatus);
+        this.joinDate = getOrDefault(joinDate, this.joinDate);
     }
 
     public void updateRole(Role role) {
         if (role != null) this.role = role;
+    }
+
+    private String getOrDefault(String newValue, String oldValue) {
+        if (newValue != null && !newValue.isBlank()) {
+            return newValue;
+        }
+        return oldValue;
+    }
+
+    private <T> T getOrDefault(T newValue, T oldValue) {
+        if (newValue != null) {
+            return newValue;
+        }
+        return oldValue;
     }
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/repository/ClubMemberProfileRepository.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/repository/ClubMemberProfileRepository.java
@@ -20,4 +20,6 @@ public interface ClubMemberProfileRepository extends JpaRepository<ClubMemberPro
     Optional<ClubMemberProfile> findByIdAndClubId(@Param("profileId") Long profileId, @Param("clubId") Long clubId);
     
     boolean existsByClubMember_Club_IdAndStudentId(Long clubId, String studentId);
+
+    Optional<ClubMemberProfile> findByClubMember_Club_IdAndStudentId(Long clubId, String studentId);
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/repository/ClubMemberProfileRepository.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/repository/ClubMemberProfileRepository.java
@@ -19,7 +19,7 @@ public interface ClubMemberProfileRepository extends JpaRepository<ClubMemberPro
            "WHERE p.id = :profileId AND cm.club.id = :clubId")
     Optional<ClubMemberProfile> findByIdAndClubId(@Param("profileId") Long profileId, @Param("clubId") Long clubId);
     
-    boolean existsByClubMember_Club_IdAndStudentId(Long clubId, String studentId);
-
     Optional<ClubMemberProfile> findByClubMember_Club_IdAndStudentId(Long clubId, String studentId);
+
+    boolean existsByClubMember_Club_IdAndStudentIdAndIdNot(Long clubId, String studentId, Long profileId);
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/repository/ClubMemberProfileRepository.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/repository/ClubMemberProfileRepository.java
@@ -1,6 +1,7 @@
 package com.kakaotech.team18.backend_server.domain.clubMember.repository;
 
 import com.kakaotech.team18.backend_server.domain.clubMember.entity.ClubMemberProfile;
+import com.kakaotech.team18.backend_server.domain.clubMember.entity.Role;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -22,4 +23,6 @@ public interface ClubMemberProfileRepository extends JpaRepository<ClubMemberPro
     Optional<ClubMemberProfile> findByClubMember_Club_IdAndStudentId(Long clubId, String studentId);
 
     boolean existsByClubMember_Club_IdAndStudentIdAndIdNot(Long clubId, String studentId, Long profileId);
+
+    Optional<ClubMemberProfile> findByClubMember_Club_IdAndRole(Long clubId, Role role);
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/repository/ClubMemberProfileRepository.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/repository/ClubMemberProfileRepository.java
@@ -1,0 +1,23 @@
+package com.kakaotech.team18.backend_server.domain.clubMember.repository;
+
+import com.kakaotech.team18.backend_server.domain.clubMember.entity.ClubMemberProfile;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface ClubMemberProfileRepository extends JpaRepository<ClubMemberProfile, Long> {
+
+    @Query("SELECT p FROM ClubMemberProfile p " +
+           "JOIN p.clubMember cm " +
+           "WHERE cm.club.id = :clubId")
+    List<ClubMemberProfile> findAllByClubId(@Param("clubId") Long clubId);
+
+    @Query("SELECT p FROM ClubMemberProfile p " +
+           "JOIN p.clubMember cm " +
+           "WHERE p.id = :profileId AND cm.club.id = :clubId")
+    Optional<ClubMemberProfile> findByIdAndClubId(@Param("profileId") Long profileId, @Param("clubId") Long clubId);
+    
+    boolean existsByClubMember_Club_IdAndStudentId(Long clubId, String studentId);
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/service/ClubMemberService.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/service/ClubMemberService.java
@@ -1,0 +1,8 @@
+package com.kakaotech.team18.backend_server.domain.clubMember.service;
+
+import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMemberResponseDto;
+import java.util.List;
+
+public interface ClubMemberService {
+    List<ClubMemberResponseDto> getClubMembers(Long clubId);
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/service/ClubMemberService.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/service/ClubMemberService.java
@@ -2,8 +2,8 @@ package com.kakaotech.team18.backend_server.domain.clubMember.service;
 
 import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMemberDeleteResponseDto;
 import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMemberResponseDto;
-import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMemberRoleUpdateResponseDto;
 import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMemberRoleUpdateRequestDto;
+import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMemberRoleUpdateResponseDto;
 import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMemberSaveRequestDto;
 import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMemberUpdateRequestDto;
 import java.io.IOException;

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/service/ClubMemberService.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/service/ClubMemberService.java
@@ -2,6 +2,7 @@ package com.kakaotech.team18.backend_server.domain.clubMember.service;
 
 import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMemberResponseDto;
 import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMemberSaveRequestDto;
+import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMemberUpdateRequestDto;
 import java.io.IOException;
 import java.util.List;
 import org.springframework.web.multipart.MultipartFile;
@@ -10,4 +11,5 @@ public interface ClubMemberService {
     List<ClubMemberResponseDto> getClubMembers(Long clubId);
     ClubMemberResponseDto registerMember(Long clubId, ClubMemberSaveRequestDto requestDto);
     void registerMembersByExcel(Long clubId, MultipartFile file) throws IOException;
+    ClubMemberResponseDto updateMember(Long clubId, Long profileId, ClubMemberUpdateRequestDto requestDto);
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/service/ClubMemberService.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/service/ClubMemberService.java
@@ -2,18 +2,17 @@ package com.kakaotech.team18.backend_server.domain.clubMember.service;
 
 import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMemberDeleteResponseDto;
 import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMemberResponseDto;
-import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMemberRoleUpdateRequestDto;
 import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMemberRoleUpdateResponseDto;
+import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMemberRoleUpdateRequestDto;
 import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMemberSaveRequestDto;
 import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMemberUpdateRequestDto;
-import java.io.IOException;
 import java.util.List;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface ClubMemberService {
     List<ClubMemberResponseDto> getClubMembers(Long clubId);
     ClubMemberResponseDto registerMember(Long clubId, ClubMemberSaveRequestDto requestDto);
-    void registerMembersByExcel(Long clubId, MultipartFile file) throws IOException;
+    void registerMembersByExcel(Long clubId, MultipartFile file);
     ClubMemberResponseDto updateMember(Long clubId, Long profileId, ClubMemberUpdateRequestDto requestDto);
     ClubMemberRoleUpdateResponseDto updateMemberRole(Long clubId, Long profileId, ClubMemberRoleUpdateRequestDto requestDto);
     ClubMemberDeleteResponseDto deleteMember(Long clubId, Long profileId);

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/service/ClubMemberService.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/service/ClubMemberService.java
@@ -1,6 +1,8 @@
 package com.kakaotech.team18.backend_server.domain.clubMember.service;
 
 import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMemberResponseDto;
+import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMemberRoleUpdateRequestDto;
+import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMemberRoleUpdateResponseDto;
 import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMemberSaveRequestDto;
 import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMemberUpdateRequestDto;
 import java.io.IOException;
@@ -12,4 +14,5 @@ public interface ClubMemberService {
     ClubMemberResponseDto registerMember(Long clubId, ClubMemberSaveRequestDto requestDto);
     void registerMembersByExcel(Long clubId, MultipartFile file) throws IOException;
     ClubMemberResponseDto updateMember(Long clubId, Long profileId, ClubMemberUpdateRequestDto requestDto);
+    ClubMemberRoleUpdateResponseDto updateMemberRole(Long clubId, Long profileId, ClubMemberRoleUpdateRequestDto requestDto);
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/service/ClubMemberService.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/service/ClubMemberService.java
@@ -1,8 +1,10 @@
 package com.kakaotech.team18.backend_server.domain.clubMember.service;
 
 import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMemberResponseDto;
+import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMemberSaveRequestDto;
 import java.util.List;
 
 public interface ClubMemberService {
     List<ClubMemberResponseDto> getClubMembers(Long clubId);
+    ClubMemberResponseDto registerMember(Long clubId, ClubMemberSaveRequestDto requestDto);
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/service/ClubMemberService.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/service/ClubMemberService.java
@@ -15,4 +15,5 @@ public interface ClubMemberService {
     void registerMembersByExcel(Long clubId, MultipartFile file) throws IOException;
     ClubMemberResponseDto updateMember(Long clubId, Long profileId, ClubMemberUpdateRequestDto requestDto);
     ClubMemberRoleUpdateResponseDto updateMemberRole(Long clubId, Long profileId, ClubMemberRoleUpdateRequestDto requestDto);
+    void deleteMember(Long clubId, Long profileId);
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/service/ClubMemberService.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/service/ClubMemberService.java
@@ -1,8 +1,9 @@
 package com.kakaotech.team18.backend_server.domain.clubMember.service;
 
+import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMemberDeleteResponseDto;
 import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMemberResponseDto;
-import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMemberRoleUpdateRequestDto;
 import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMemberRoleUpdateResponseDto;
+import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMemberRoleUpdateRequestDto;
 import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMemberSaveRequestDto;
 import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMemberUpdateRequestDto;
 import java.io.IOException;
@@ -15,5 +16,5 @@ public interface ClubMemberService {
     void registerMembersByExcel(Long clubId, MultipartFile file) throws IOException;
     ClubMemberResponseDto updateMember(Long clubId, Long profileId, ClubMemberUpdateRequestDto requestDto);
     ClubMemberRoleUpdateResponseDto updateMemberRole(Long clubId, Long profileId, ClubMemberRoleUpdateRequestDto requestDto);
-    void deleteMember(Long clubId, Long profileId);
+    ClubMemberDeleteResponseDto deleteMember(Long clubId, Long profileId);
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/service/ClubMemberService.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/service/ClubMemberService.java
@@ -2,9 +2,12 @@ package com.kakaotech.team18.backend_server.domain.clubMember.service;
 
 import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMemberResponseDto;
 import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMemberSaveRequestDto;
+import java.io.IOException;
 import java.util.List;
+import org.springframework.web.multipart.MultipartFile;
 
 public interface ClubMemberService {
     List<ClubMemberResponseDto> getClubMembers(Long clubId);
     ClubMemberResponseDto registerMember(Long clubId, ClubMemberSaveRequestDto requestDto);
+    void registerMembersByExcel(Long clubId, MultipartFile file) throws IOException;
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/service/ClubMemberServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/service/ClubMemberServiceImpl.java
@@ -1,8 +1,22 @@
 package com.kakaotech.team18.backend_server.domain.clubMember.service;
 
+import com.kakaotech.team18.backend_server.domain.club.entity.Club;
+import com.kakaotech.team18.backend_server.domain.club.repository.ClubRepository;
 import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMemberResponseDto;
+import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMemberSaveRequestDto;
+import com.kakaotech.team18.backend_server.domain.clubMember.entity.ActiveStatus;
+import com.kakaotech.team18.backend_server.domain.clubMember.entity.ClubMember;
+import com.kakaotech.team18.backend_server.domain.clubMember.entity.ClubMemberProfile;
 import com.kakaotech.team18.backend_server.domain.clubMember.repository.ClubMemberProfileRepository;
+import com.kakaotech.team18.backend_server.domain.clubMember.repository.ClubMemberRepository;
+import com.kakaotech.team18.backend_server.domain.user.entity.User;
+import com.kakaotech.team18.backend_server.domain.user.repository.UserRepository;
+import com.kakaotech.team18.backend_server.global.exception.code.ErrorCode;
+import com.kakaotech.team18.backend_server.global.exception.exceptions.CustomException;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -13,11 +27,96 @@ import org.springframework.transaction.annotation.Transactional;
 public class ClubMemberServiceImpl implements ClubMemberService {
 
     private final ClubMemberProfileRepository clubMemberProfileRepository;
+    private final ClubMemberRepository clubMemberRepository;
+    private final UserRepository userRepository;
+    private final ClubRepository clubRepository;
 
     @Override
     public List<ClubMemberResponseDto> getClubMembers(Long clubId) {
         return clubMemberProfileRepository.findAllByClubId(clubId).stream()
                 .map(ClubMemberResponseDto::from)
                 .toList();
+    }
+
+    @Override
+    @Transactional
+    public ClubMemberResponseDto registerMember(Long clubId, ClubMemberSaveRequestDto requestDto) {
+        // 1. 기존 프로필 조회 (학번 기준)
+        Optional<ClubMemberProfile> existingProfile = clubMemberProfileRepository.findByClubMember_Club_IdAndStudentId(clubId, requestDto.studentId());
+
+        if (existingProfile.isPresent()) {
+            // 2. 존재하면 업데이트 (이름 일치 여부 확인)
+            ClubMemberProfile profile = existingProfile.get();
+            if (!profile.getName().equals(requestDto.name())) {
+                throw new CustomException(ErrorCode.USER_ALREADY_EXISTS,
+                        String.format("studentId: %s, existingName: %s, inputName: %s",
+                                requestDto.studentId(), profile.getName(), requestDto.name()));
+            }
+            
+            // 이름이 일치하면 정보 업데이트
+            profile.update(
+                    requestDto.name(),
+                    requestDto.studentId(),
+                    requestDto.phoneNumber(),
+                    requestDto.college(),
+                    requestDto.department(),
+                    requestDto.academicStatus(),
+                    parseJoinDate(requestDto.joinDate())
+            );
+            // Role 업데이트 (별도 메서드 사용)
+            profile.updateRole(requestDto.role());
+            
+            return ClubMemberResponseDto.from(profile);
+        } else {
+            // 3. 존재하지 않으면 신규 등록
+            Club club = clubRepository.findById(clubId)
+                    .orElseThrow(() -> new CustomException(ErrorCode.CLUB_NOT_FOUND, "clubId: " + clubId));
+
+            // User 조회 또는 생성 (껍데기)
+            User user = userRepository.findByStudentId(requestDto.studentId())
+                    .orElseGet(() -> createShellUser(requestDto));
+
+            // ClubMember 생성
+            ClubMember clubMember = ClubMember.builder()
+                    .user(user)
+                    .club(club)
+                    .activeStatus(ActiveStatus.ACTIVE) // 기본값 ACTIVE
+                    .role(requestDto.role()) // ClubMember의 role은 일단 요청값으로 설정 (Profile과 동기화)
+                    .build();
+
+            // ClubMemberProfile 생성
+            ClubMemberProfile profile = ClubMemberProfile.builder()
+                    .name(requestDto.name())
+                    .studentId(requestDto.studentId())
+                    .phoneNumber(requestDto.phoneNumber())
+                    .college(requestDto.college())
+                    .department(requestDto.department())
+                    .academicStatus(requestDto.academicStatus())
+                    .joinDate(parseJoinDate(requestDto.joinDate()))
+                    .role(requestDto.role())
+                    .build();
+
+            // 연관관계 설정 (Cascade 저장)
+            clubMember.setProfile(profile);
+            clubMemberRepository.save(clubMember);
+
+            return ClubMemberResponseDto.from(profile);
+        }
+    }
+
+    private User createShellUser(ClubMemberSaveRequestDto requestDto) {
+        User user = User.builder()
+                .name(requestDto.name())
+                .studentId(requestDto.studentId())
+                .phoneNumber(requestDto.phoneNumber())
+                .department(requestDto.department())
+                .email(requestDto.studentId() + "@placeholder.com") // 이메일 필수라 임시값 설정 (추후 고민 필요)
+                .build();
+        return userRepository.save(user);
+    }
+
+    private LocalDate parseJoinDate(String joinDateStr) {
+        // YYYY-MM 형식을 YYYY-MM-01로 변환
+        return LocalDate.parse(joinDateStr + "-01", DateTimeFormatter.ofPattern("yyyy-MM-dd"));
     }
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/service/ClubMemberServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/service/ClubMemberServiceImpl.java
@@ -10,11 +10,15 @@ import com.kakaotech.team18.backend_server.domain.clubMember.entity.ClubMemberPr
 import com.kakaotech.team18.backend_server.domain.clubMember.entity.Role;
 import com.kakaotech.team18.backend_server.domain.clubMember.repository.ClubMemberProfileRepository;
 import com.kakaotech.team18.backend_server.domain.clubMember.repository.ClubMemberRepository;
+import com.kakaotech.team18.backend_server.domain.clubMember.util.ExcelParseResult;
+import com.kakaotech.team18.backend_server.domain.clubMember.util.ExcelUtils;
 import com.kakaotech.team18.backend_server.domain.user.entity.User;
 import com.kakaotech.team18.backend_server.domain.user.repository.UserRepository;
 import com.kakaotech.team18.backend_server.global.exception.code.ErrorCode;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.CustomException;
+import com.kakaotech.team18.backend_server.global.exception.exceptions.ExcelParsingException;
 import com.kakaotech.team18.backend_server.global.security.CustomSecurityService;
+import java.io.IOException;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
@@ -22,6 +26,7 @@ import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
@@ -107,6 +112,39 @@ public class ClubMemberServiceImpl implements ClubMemberService {
             clubMemberRepository.save(clubMember);
 
             return ClubMemberResponseDto.from(profile);
+        }
+    }
+
+    @Override
+    @Transactional
+    public void registerMembersByExcel(Long clubId, MultipartFile file) throws IOException {
+        // 1. 파일 유효성 검사
+        if (file.isEmpty()) {
+            throw new CustomException(ErrorCode.INVALID_FILE, "파일이 비어있습니다.");
+        }
+        if (!file.getOriginalFilename().endsWith(".xlsx") && !file.getOriginalFilename().endsWith(".xls")) {
+            throw new CustomException(ErrorCode.INVALID_FILE, "엑셀 파일(.xlsx, .xls)만 업로드 가능합니다.");
+        }
+
+        // 2. 엑셀 파싱 (형식 오류 수집)
+        ExcelParseResult parseResult = ExcelUtils.parseExcel(file);
+
+        // 3. 파싱된 DTO 리스트를 순회하며 DB 저장 (비즈니스 오류 수집)
+        // 형식 오류가 있어도, 성공한 데이터들에 대해서는 비즈니스 검증을 계속 진행하여 에러를 한 번에 모음
+        List<ClubMemberSaveRequestDto> successList = parseResult.getSuccessList();
+
+        for (ClubMemberSaveRequestDto dto : successList) {
+            try {
+                registerMember(clubId, dto);
+            } catch (CustomException e) {
+                // registerMember 내부에서 발생한 비즈니스 예외를 수집
+                parseResult.addError(String.format("학번 %s: %s", dto.studentId(), e.getMessage()));
+            }
+        }
+
+        // 4. 에러가 하나라도 있으면 전체 롤백
+        if (parseResult.hasErrors()) {
+            throw new ExcelParsingException("엑셀 데이터 검증 실패로 인해 전체 등록이 취소되었습니다.", parseResult.getErrorMessages());
         }
     }
 

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/service/ClubMemberServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/service/ClubMemberServiceImpl.java
@@ -105,7 +105,7 @@ public class ClubMemberServiceImpl implements ClubMemberService {
                     .user(user)
                     .club(club)
                     .activeStatus(ActiveStatus.ACTIVE)
-                    .role(targetRole) // Clubmember의 role도 결정된 Role로 설정
+                    .role(targetRole) // ClubMember의 role도 결정된 Role로 설정
                     .build();
 
             ClubMemberProfile profile = ClubMemberProfile.builder()
@@ -129,7 +129,7 @@ public class ClubMemberServiceImpl implements ClubMemberService {
 
     @Override
     @Transactional
-    public void registerMembersByExcel(Long clubId, MultipartFile file) throws IOException {
+    public void registerMembersByExcel(Long clubId, MultipartFile file) {
         // 1. 파일 유효성 검사
         if (file.isEmpty()) {
             throw new CustomException(ErrorCode.INVALID_FILE, "파일이 비어있습니다.");
@@ -139,7 +139,12 @@ public class ClubMemberServiceImpl implements ClubMemberService {
         }
 
         // 2. 엑셀 파싱 (형식 오류 수집)
-        ExcelParseResult parseResult = ExcelUtils.parseExcel(file);
+        ExcelParseResult parseResult;
+        try {
+            parseResult = ExcelUtils.parseExcel(file);
+        } catch (IOException e) {
+            throw new CustomException(ErrorCode.INVALID_FILE, "파일을 읽는 도중 오류가 발생했습니다.");
+        }
 
         // 3. 파싱된 DTO 리스트를 순회하며 DB 저장 (비즈니스 오류 수집)
         // 형식 오류가 있어도, 성공한 데이터들에 대해서는 비즈니스 검증을 계속 진행하여 에러를 한 번에 모음

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/service/ClubMemberServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/service/ClubMemberServiceImpl.java
@@ -20,6 +20,7 @@ import com.kakaotech.team18.backend_server.domain.user.entity.User;
 import com.kakaotech.team18.backend_server.domain.user.repository.UserRepository;
 import com.kakaotech.team18.backend_server.global.exception.code.ErrorCode;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.CannotDeleteSelfException;
+import com.kakaotech.team18.backend_server.global.exception.exceptions.ClubNotFoundException;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.CustomException;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.ExcelParsingException;
 import com.kakaotech.team18.backend_server.global.security.CustomSecurityService;
@@ -46,6 +47,9 @@ public class ClubMemberServiceImpl implements ClubMemberService {
 
     @Override
     public List<ClubMemberResponseDto> getClubMembers(Long clubId) {
+        if (!clubRepository.existsById(clubId)) {
+            throw new ClubNotFoundException("clubId: " + clubId);
+        }
         return clubMemberProfileRepository.findAllByClubId(clubId).stream()
                 .map(ClubMemberResponseDto::from)
                 .toList();

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/service/ClubMemberServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/service/ClubMemberServiceImpl.java
@@ -1,0 +1,23 @@
+package com.kakaotech.team18.backend_server.domain.clubMember.service;
+
+import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMemberResponseDto;
+import com.kakaotech.team18.backend_server.domain.clubMember.repository.ClubMemberProfileRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ClubMemberServiceImpl implements ClubMemberService {
+
+    private final ClubMemberProfileRepository clubMemberProfileRepository;
+
+    @Override
+    public List<ClubMemberResponseDto> getClubMembers(Long clubId) {
+        return clubMemberProfileRepository.findAllByClubId(clubId).stream()
+                .map(ClubMemberResponseDto::from)
+                .toList();
+    }
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/service/ClubMemberServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/service/ClubMemberServiceImpl.java
@@ -18,6 +18,7 @@ import com.kakaotech.team18.backend_server.domain.clubMember.util.ExcelUtils;
 import com.kakaotech.team18.backend_server.domain.user.entity.User;
 import com.kakaotech.team18.backend_server.domain.user.repository.UserRepository;
 import com.kakaotech.team18.backend_server.global.exception.code.ErrorCode;
+import com.kakaotech.team18.backend_server.global.exception.exceptions.CannotDeleteSelfException;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.CustomException;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.ExcelParsingException;
 import com.kakaotech.team18.backend_server.global.security.CustomSecurityService;
@@ -201,7 +202,7 @@ public class ClubMemberServiceImpl implements ClubMemberService {
         profile.getClubMember().updateRole(newRole);
 
         // 4. 메시지 생성
-        String message = newRole == Role.CLUB_MEMBER ? 
+        String message = newRole == Role.CLUB_MEMBER ?
                 "일반 부원으로 역할이 변경되었습니다." : "운영진으로 역할이 변경되었습니다.";
 
         return ClubMemberRoleUpdateResponseDto.builder()
@@ -214,6 +215,29 @@ public class ClubMemberServiceImpl implements ClubMemberService {
                 .newRole(newRole)
                 .message(message)
                 .build();
+    }
+
+    @Override
+    @Transactional
+    public void deleteMember(Long clubId, Long profileId) {
+        // 1. 요청자 권한 확인 (회장만 가능)
+        Role currentUserRole = customSecurityService.getUserRoleInClub(clubId);
+        if (currentUserRole != Role.CLUB_ADMIN) {
+            throw new CustomException(ErrorCode.FORBIDDEN, "동아리원 삭제는 회장만 가능합니다.");
+        }
+
+        // 2. 프로필 조회
+        ClubMemberProfile profile = clubMemberProfileRepository.findByIdAndClubId(profileId, clubId)
+                .orElseThrow(() -> new CustomException(ErrorCode.CLUB_MEMBER_NOT_FOUND, "profileId: " + profileId));
+
+        // 3. 자기 자신 삭제 방지
+        Long currentUserId = customSecurityService.getCurrentUserId();
+        if (profile.isOwner(currentUserId)) {
+            throw new CannotDeleteSelfException();
+        }
+
+        // 4. 삭제 (Cascade로 Profile도 함께 삭제됨)
+        clubMemberRepository.delete(profile.getClubMember());
     }
 
 

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/service/ClubMemberServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/service/ClubMemberServiceImpl.java
@@ -2,6 +2,7 @@ package com.kakaotech.team18.backend_server.domain.clubMember.service;
 
 import com.kakaotech.team18.backend_server.domain.club.entity.Club;
 import com.kakaotech.team18.backend_server.domain.club.repository.ClubRepository;
+import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMemberDeleteResponseDto;
 import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMemberResponseDto;
 import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMemberRoleUpdateResponseDto;
 import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMemberRoleUpdateRequestDto;
@@ -219,7 +220,7 @@ public class ClubMemberServiceImpl implements ClubMemberService {
 
     @Override
     @Transactional
-    public void deleteMember(Long clubId, Long profileId) {
+    public ClubMemberDeleteResponseDto deleteMember(Long clubId, Long profileId) {
         // 1. 요청자 권한 확인 (회장만 가능)
         Role currentUserRole = customSecurityService.getUserRoleInClub(clubId);
         if (currentUserRole != Role.CLUB_ADMIN) {
@@ -238,6 +239,11 @@ public class ClubMemberServiceImpl implements ClubMemberService {
 
         // 4. 삭제 (Cascade로 Profile도 함께 삭제됨)
         clubMemberRepository.delete(profile.getClubMember());
+
+        return new ClubMemberDeleteResponseDto(
+                "해당 동아리원이 목록에서 삭제되었습니다.",
+                profileId
+        );
     }
 
 

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/service/ClubMemberServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/service/ClubMemberServiceImpl.java
@@ -27,6 +27,7 @@ import com.kakaotech.team18.backend_server.global.security.CustomSecurityService
 import java.io.IOException;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -88,10 +89,13 @@ public class ClubMemberServiceImpl implements ClubMemberService {
                     requestDto.academicStatus(),
                     parseJoinDate(requestDto.joinDate())
             );
-            profile.updateRole(targetRole); // 결정된 Role로 업데이트
-            // ClubMember의 Role도 동기화
-            profile.getClubMember().updateRole(targetRole);
-
+            
+            // 회장일 때만 Role 업데이트 수행 (운영진에 의한 강등 방지)
+            if (currentUserRole == Role.CLUB_ADMIN) {
+                profile.updateRole(targetRole);
+                profile.getClubMember().updateRole(targetRole);
+            }
+            
             return ClubMemberResponseDto.from(profile);
         } else {
             // 5. 존재하지 않으면 신규 등록
@@ -294,6 +298,10 @@ public class ClubMemberServiceImpl implements ClubMemberService {
     }
 
     private LocalDate parseJoinDate(String joinDateStr) {
-        return LocalDate.parse(joinDateStr + "-01", DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+        try {
+            return LocalDate.parse(joinDateStr + "-01", DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+        } catch (DateTimeParseException e) {
+            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE, "가입일자 형식이 올바르지 않습니다. (YYYY-MM)");
+        }
     }
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/service/ClubMemberServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/service/ClubMemberServiceImpl.java
@@ -203,13 +203,31 @@ public class ClubMemberServiceImpl implements ClubMemberService {
         Role previousRole = profile.getRole();
         Role newRole = requestDto.role();
 
-        // 3. Role 업데이트 (Profile & ClubMember 동기화)
+        // 3. 회장직 이양 로직 (새로운 역할이 회장인 경우)
+        if (newRole == Role.CLUB_ADMIN) {
+            Optional<ClubMemberProfile> currentAdminProfile = clubMemberProfileRepository.findByClubMember_Club_IdAndRole(clubId, Role.CLUB_ADMIN);
+            
+            // 기존 회장이 존재하고, 그 사람이 이번에 임명되는 사람이 아니라면 강등
+            if (currentAdminProfile.isPresent() && !currentAdminProfile.get().getId().equals(profileId)) {
+                ClubMemberProfile oldAdmin = currentAdminProfile.get();
+                oldAdmin.updateRole(Role.CLUB_MEMBER); // 일반 부원으로 강등
+                oldAdmin.getClubMember().updateRole(Role.CLUB_MEMBER);
+            }
+        }
+
+        // 4. Role 업데이트 (Profile & ClubMember 동기화)
         profile.updateRole(newRole);
         profile.getClubMember().updateRole(newRole);
 
-        // 4. 메시지 생성
-        String message = newRole == Role.CLUB_MEMBER ?
-                "일반 부원으로 역할이 변경되었습니다." : "운영진으로 역할이 변경되었습니다.";
+        // 5. 메시지 생성
+        String message;
+        if (newRole == Role.CLUB_MEMBER) {
+            message = "일반 부원으로 역할이 변경되었습니다.";
+        } else if (newRole == Role.CLUB_EXECUTIVE) {
+            message = "운영진으로 역할이 변경되었습니다.";
+        } else {
+            message = "회장으로 역할이 변경되었습니다.";
+        }
 
         return ClubMemberRoleUpdateResponseDto.builder()
                 .clubId(clubId)

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/service/ClubMemberServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/service/ClubMemberServiceImpl.java
@@ -4,6 +4,7 @@ import com.kakaotech.team18.backend_server.domain.club.entity.Club;
 import com.kakaotech.team18.backend_server.domain.club.repository.ClubRepository;
 import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMemberResponseDto;
 import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMemberSaveRequestDto;
+import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMemberUpdateRequestDto;
 import com.kakaotech.team18.backend_server.domain.clubMember.entity.ActiveStatus;
 import com.kakaotech.team18.backend_server.domain.clubMember.entity.ClubMember;
 import com.kakaotech.team18.backend_server.domain.clubMember.entity.ClubMemberProfile;
@@ -132,7 +133,7 @@ public class ClubMemberServiceImpl implements ClubMemberService {
         // 3. 파싱된 DTO 리스트를 순회하며 DB 저장 (비즈니스 오류 수집)
         // 형식 오류가 있어도, 성공한 데이터들에 대해서는 비즈니스 검증을 계속 진행하여 에러를 한 번에 모음
         List<ClubMemberSaveRequestDto> successList = parseResult.getSuccessList();
-
+        
         for (ClubMemberSaveRequestDto dto : successList) {
             try {
                 registerMember(clubId, dto);
@@ -147,6 +148,34 @@ public class ClubMemberServiceImpl implements ClubMemberService {
             throw new ExcelParsingException("엑셀 데이터 검증 실패로 인해 전체 등록이 취소되었습니다.", parseResult.getErrorMessages());
         }
     }
+
+    @Override
+    @Transactional
+    public ClubMemberResponseDto updateMember(Long clubId, Long profileId, ClubMemberUpdateRequestDto requestDto) {
+        // 1. 프로필 조회
+        ClubMemberProfile profile = clubMemberProfileRepository.findByIdAndClubId(profileId, clubId)
+                .orElseThrow(() -> new CustomException(ErrorCode.CLUB_MEMBER_NOT_FOUND, "profileId: " + profileId));
+
+        // 2. 중복 학번 검사 (나를 제외한 다른 멤버가 해당 학번을 사용 중인지)
+        if (requestDto.studentId() != null && 
+            clubMemberProfileRepository.existsByClubMember_Club_IdAndStudentIdAndIdNot(clubId, requestDto.studentId(), profileId)) {
+            throw new CustomException(ErrorCode.USER_ALREADY_EXISTS, "해당 학번(" + requestDto.studentId() + ")은 이미 다른 멤버가 사용 중입니다.");
+        }
+
+        // 3. 정보 업데이트
+        profile.update(
+                requestDto.name(),
+                requestDto.studentId(),
+                requestDto.phoneNumber(),
+                requestDto.college(),
+                requestDto.department(),
+                requestDto.academicStatus(),
+                requestDto.joinDate() != null ? parseJoinDate(requestDto.joinDate()) : null
+        );
+
+        return ClubMemberResponseDto.from(profile);
+    }
+
 
     private User createShellUser(ClubMemberSaveRequestDto requestDto) {
         User user = User.builder()

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/service/ClubMemberServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/service/ClubMemberServiceImpl.java
@@ -7,12 +7,14 @@ import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMemberSaveR
 import com.kakaotech.team18.backend_server.domain.clubMember.entity.ActiveStatus;
 import com.kakaotech.team18.backend_server.domain.clubMember.entity.ClubMember;
 import com.kakaotech.team18.backend_server.domain.clubMember.entity.ClubMemberProfile;
+import com.kakaotech.team18.backend_server.domain.clubMember.entity.Role;
 import com.kakaotech.team18.backend_server.domain.clubMember.repository.ClubMemberProfileRepository;
 import com.kakaotech.team18.backend_server.domain.clubMember.repository.ClubMemberRepository;
 import com.kakaotech.team18.backend_server.domain.user.entity.User;
 import com.kakaotech.team18.backend_server.domain.user.repository.UserRepository;
 import com.kakaotech.team18.backend_server.global.exception.code.ErrorCode;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.CustomException;
+import com.kakaotech.team18.backend_server.global.security.CustomSecurityService;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
@@ -30,6 +32,7 @@ public class ClubMemberServiceImpl implements ClubMemberService {
     private final ClubMemberRepository clubMemberRepository;
     private final UserRepository userRepository;
     private final ClubRepository clubRepository;
+    private final CustomSecurityService customSecurityService;
 
     @Override
     public List<ClubMemberResponseDto> getClubMembers(Long clubId) {
@@ -41,11 +44,20 @@ public class ClubMemberServiceImpl implements ClubMemberService {
     @Override
     @Transactional
     public ClubMemberResponseDto registerMember(Long clubId, ClubMemberSaveRequestDto requestDto) {
-        // 1. 기존 프로필 조회 (학번 기준)
+        // 1. 요청자 권한 확인 (DB 조회 없이 토큰에서 바로 확인)
+        Role currentUserRole = customSecurityService.getUserRoleInClub(clubId);
+
+        // 2. Role 결정
+        Role targetRole = requestDto.role();
+        if (currentUserRole == Role.CLUB_EXECUTIVE) {
+            targetRole = Role.CLUB_MEMBER; // 운영진은 무조건 일반부원으로 등록
+        }
+
+        // 3. 기존 프로필 조회 (학번 기준)
         Optional<ClubMemberProfile> existingProfile = clubMemberProfileRepository.findByClubMember_Club_IdAndStudentId(clubId, requestDto.studentId());
 
         if (existingProfile.isPresent()) {
-            // 2. 존재하면 업데이트 (이름 일치 여부 확인)
+            // 4. 존재하면 업데이트
             ClubMemberProfile profile = existingProfile.get();
             if (!profile.getName().equals(requestDto.name())) {
                 throw new CustomException(ErrorCode.USER_ALREADY_EXISTS,
@@ -53,7 +65,6 @@ public class ClubMemberServiceImpl implements ClubMemberService {
                                 requestDto.studentId(), profile.getName(), requestDto.name()));
             }
             
-            // 이름이 일치하면 정보 업데이트
             profile.update(
                     requestDto.name(),
                     requestDto.studentId(),
@@ -63,28 +74,24 @@ public class ClubMemberServiceImpl implements ClubMemberService {
                     requestDto.academicStatus(),
                     parseJoinDate(requestDto.joinDate())
             );
-            // Role 업데이트 (별도 메서드 사용)
-            profile.updateRole(requestDto.role());
+            profile.updateRole(targetRole); // 결정된 Role로 업데이트
             
             return ClubMemberResponseDto.from(profile);
         } else {
-            // 3. 존재하지 않으면 신규 등록
+            // 5. 존재하지 않으면 신규 등록
             Club club = clubRepository.findById(clubId)
                     .orElseThrow(() -> new CustomException(ErrorCode.CLUB_NOT_FOUND, "clubId: " + clubId));
 
-            // User 조회 또는 생성 (껍데기)
             User user = userRepository.findByStudentId(requestDto.studentId())
                     .orElseGet(() -> createShellUser(requestDto));
 
-            // ClubMember 생성
             ClubMember clubMember = ClubMember.builder()
                     .user(user)
                     .club(club)
-                    .activeStatus(ActiveStatus.ACTIVE) // 기본값 ACTIVE
-                    .role(requestDto.role()) // ClubMember의 role은 일단 요청값으로 설정 (Profile과 동기화)
+                    .activeStatus(ActiveStatus.ACTIVE)
+                    .role(targetRole) // ClubMember의 role도 결정된 Role로 설정
                     .build();
 
-            // ClubMemberProfile 생성
             ClubMemberProfile profile = ClubMemberProfile.builder()
                     .name(requestDto.name())
                     .studentId(requestDto.studentId())
@@ -93,10 +100,9 @@ public class ClubMemberServiceImpl implements ClubMemberService {
                     .department(requestDto.department())
                     .academicStatus(requestDto.academicStatus())
                     .joinDate(parseJoinDate(requestDto.joinDate()))
-                    .role(requestDto.role())
+                    .role(targetRole)
                     .build();
 
-            // 연관관계 설정 (Cascade 저장)
             clubMember.setProfile(profile);
             clubMemberRepository.save(clubMember);
 
@@ -110,13 +116,12 @@ public class ClubMemberServiceImpl implements ClubMemberService {
                 .studentId(requestDto.studentId())
                 .phoneNumber(requestDto.phoneNumber())
                 .department(requestDto.department())
-                .email(requestDto.studentId() + "@placeholder.com") // 이메일 필수라 임시값 설정 (추후 고민 필요)
+                .email(requestDto.studentId() + "@placeholder.com")
                 .build();
         return userRepository.save(user);
     }
 
     private LocalDate parseJoinDate(String joinDateStr) {
-        // YYYY-MM 형식을 YYYY-MM-01로 변환
         return LocalDate.parse(joinDateStr + "-01", DateTimeFormatter.ofPattern("yyyy-MM-dd"));
     }
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/service/ClubMemberServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/service/ClubMemberServiceImpl.java
@@ -3,6 +3,8 @@ package com.kakaotech.team18.backend_server.domain.clubMember.service;
 import com.kakaotech.team18.backend_server.domain.club.entity.Club;
 import com.kakaotech.team18.backend_server.domain.club.repository.ClubRepository;
 import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMemberResponseDto;
+import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMemberRoleUpdateResponseDto;
+import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMemberRoleUpdateRequestDto;
 import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMemberSaveRequestDto;
 import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMemberUpdateRequestDto;
 import com.kakaotech.team18.backend_server.domain.clubMember.entity.ActiveStatus;
@@ -81,7 +83,9 @@ public class ClubMemberServiceImpl implements ClubMemberService {
                     parseJoinDate(requestDto.joinDate())
             );
             profile.updateRole(targetRole); // 결정된 Role로 업데이트
-            
+            // ClubMember의 Role도 동기화
+            profile.getClubMember().updateRole(targetRole);
+
             return ClubMemberResponseDto.from(profile);
         } else {
             // 5. 존재하지 않으면 신규 등록
@@ -95,7 +99,7 @@ public class ClubMemberServiceImpl implements ClubMemberService {
                     .user(user)
                     .club(club)
                     .activeStatus(ActiveStatus.ACTIVE)
-                    .role(targetRole) // ClubMember의 role도 결정된 Role로 설정
+                    .role(targetRole) // Clubmember의 role도 결정된 Role로 설정
                     .build();
 
             ClubMemberProfile profile = ClubMemberProfile.builder()
@@ -157,7 +161,7 @@ public class ClubMemberServiceImpl implements ClubMemberService {
                 .orElseThrow(() -> new CustomException(ErrorCode.CLUB_MEMBER_NOT_FOUND, "profileId: " + profileId));
 
         // 2. 중복 학번 검사 (나를 제외한 다른 멤버가 해당 학번을 사용 중인지)
-        if (requestDto.studentId() != null && 
+        if (requestDto.studentId() != null &&
             clubMemberProfileRepository.existsByClubMember_Club_IdAndStudentIdAndIdNot(clubId, requestDto.studentId(), profileId)) {
             throw new CustomException(ErrorCode.USER_ALREADY_EXISTS, "해당 학번(" + requestDto.studentId() + ")은 이미 다른 멤버가 사용 중입니다.");
         }
@@ -174,6 +178,42 @@ public class ClubMemberServiceImpl implements ClubMemberService {
         );
 
         return ClubMemberResponseDto.from(profile);
+    }
+
+    @Override
+    @Transactional
+    public ClubMemberRoleUpdateResponseDto updateMemberRole(Long clubId, Long profileId, ClubMemberRoleUpdateRequestDto requestDto) {
+        // 1. 요청자 권한 확인 (회장만 가능)
+        Role currentUserRole = customSecurityService.getUserRoleInClub(clubId);
+        if (currentUserRole != Role.CLUB_ADMIN) {
+            throw new CustomException(ErrorCode.FORBIDDEN, "동아리원 직책 변경은 회장만 가능합니다.");
+        }
+
+        // 2. 프로필 조회
+        ClubMemberProfile profile = clubMemberProfileRepository.findByIdAndClubId(profileId, clubId)
+                .orElseThrow(() -> new CustomException(ErrorCode.CLUB_MEMBER_NOT_FOUND, "profileId: " + profileId));
+
+        Role previousRole = profile.getRole();
+        Role newRole = requestDto.role();
+
+        // 3. Role 업데이트 (Profile & ClubMember 동기화)
+        profile.updateRole(newRole);
+        profile.getClubMember().updateRole(newRole);
+
+        // 4. 메시지 생성
+        String message = newRole == Role.CLUB_MEMBER ? 
+                "일반 부원으로 역할이 변경되었습니다." : "운영진으로 역할이 변경되었습니다.";
+
+        return ClubMemberRoleUpdateResponseDto.builder()
+                .clubId(clubId)
+                .clubName(profile.getClubMember().getClub().getName())
+                .clubMemberProfileId(profile.getId())
+                .studentId(profile.getStudentId())
+                .name(profile.getName())
+                .previousRole(previousRole)
+                .newRole(newRole)
+                .message(message)
+                .build();
     }
 
 

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/service/ClubMemberServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/service/ClubMemberServiceImpl.java
@@ -157,6 +157,8 @@ public class ClubMemberServiceImpl implements ClubMemberService {
             } catch (CustomException e) {
                 // registerMember 내부에서 발생한 비즈니스 예외를 수집
                 parseResult.addError(String.format("학번 %s: %s", dto.studentId(), e.getMessage()));
+            } catch (Exception e) {
+                parseResult.addError(String.format("학번 %s: 알 수 없는 오류가 발생했습니다. (%s)", dto.studentId(), e.getMessage()));
             }
         }
 
@@ -277,6 +279,10 @@ public class ClubMemberServiceImpl implements ClubMemberService {
 
 
     private User createShellUser(ClubMemberSaveRequestDto requestDto) {
+        if (userRepository.existsByPhoneNumber(requestDto.phoneNumber())) {
+            throw new CustomException(ErrorCode.EXISTING_USER_PHONE_NUMBER, "이미 사용 중인 전화번호입니다.");
+        }
+
         User user = User.builder()
                 .name(requestDto.name())
                 .studentId(requestDto.studentId())

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/service/ClubMemberServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/service/ClubMemberServiceImpl.java
@@ -109,6 +109,7 @@ public class ClubMemberServiceImpl implements ClubMemberService {
                     .build();
 
             ClubMemberProfile profile = ClubMemberProfile.builder()
+                    .clubMember(clubMember)
                     .name(requestDto.name())
                     .studentId(requestDto.studentId())
                     .phoneNumber(requestDto.phoneNumber())

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/service/ClubMemberServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/service/ClubMemberServiceImpl.java
@@ -134,7 +134,8 @@ public class ClubMemberServiceImpl implements ClubMemberService {
         if (file.isEmpty()) {
             throw new CustomException(ErrorCode.INVALID_FILE, "파일이 비어있습니다.");
         }
-        if (!file.getOriginalFilename().endsWith(".xlsx") && !file.getOriginalFilename().endsWith(".xls")) {
+        String filename = file.getOriginalFilename();
+        if (filename == null || (!filename.endsWith(".xlsx") && !filename.endsWith(".xls"))) {
             throw new CustomException(ErrorCode.INVALID_FILE, "엑셀 파일(.xlsx, .xls)만 업로드 가능합니다.");
         }
 

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/util/ExcelParseResult.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/util/ExcelParseResult.java
@@ -1,0 +1,24 @@
+package com.kakaotech.team18.backend_server.domain.clubMember.util;
+
+import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMemberSaveRequestDto;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class ExcelParseResult {
+    private final List<ClubMemberSaveRequestDto> successList = new ArrayList<>();
+    private final List<String> errorMessages = new ArrayList<>();
+
+    public void addSuccess(ClubMemberSaveRequestDto dto) {
+        successList.add(dto);
+    }
+
+    public void addError(String message) {
+        errorMessages.add(message);
+    }
+
+    public boolean hasErrors() {
+        return !errorMessages.isEmpty();
+    }
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/util/ExcelUtils.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/util/ExcelUtils.java
@@ -1,0 +1,160 @@
+package com.kakaotech.team18.backend_server.domain.clubMember.util;
+
+import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMemberSaveRequestDto;
+import com.kakaotech.team18.backend_server.domain.clubMember.entity.AcademicStatus;
+import com.kakaotech.team18.backend_server.domain.clubMember.entity.Role;
+import com.kakaotech.team18.backend_server.global.exception.exceptions.ExcelParsingException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Pattern;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.DataFormatter;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.ss.usermodel.WorkbookFactory;
+import org.springframework.web.multipart.MultipartFile;
+
+@Slf4j
+public class ExcelUtils {
+
+    private static final List<String> HEADER_NAMES = Arrays.asList(
+            "이름", "학번", "전화번호", "단과대학", "학과", "학적상태", "직책", "가입일자"
+    );
+    private static final Pattern PHONE_NUMBER_PATTERN = Pattern.compile("^\\d{3}-\\d{3,4}-\\d{4}$");
+    private static final Pattern JOIN_DATE_PATTERN = Pattern.compile("^\\d{4}-\\d{2}$");
+
+    private ExcelUtils() {
+        // Utility class
+    }
+
+    public static List<ClubMemberSaveRequestDto> parseExcel(MultipartFile file) throws IOException {
+        List<ClubMemberSaveRequestDto> dtoList = new ArrayList<>();
+        List<String> errorMessages = new ArrayList<>();
+
+        try (InputStream inputStream = file.getInputStream();
+             Workbook workbook = WorkbookFactory.create(inputStream)) {
+
+            Sheet sheet = workbook.getSheetAt(0);
+            int firstRow = sheet.getFirstRowNum();
+            int lastRow = sheet.getLastRowNum();
+
+            // 1. 헤더 검증 (첫 번째 행)
+            Row headerRow = sheet.getRow(firstRow);
+            if (headerRow == null || !isValidHeader(headerRow)) {
+                throw new ExcelParsingException("엑셀 헤더 양식이 올바르지 않습니다. 다음 순서로 작성해주세요: " + HEADER_NAMES);
+            }
+
+            DataFormatter formatter = new DataFormatter();
+
+            // 2. 데이터 파싱 (두 번째 행부터)
+            for (int i = firstRow + 1; i <= lastRow; i++) {
+                Row dataRow = sheet.getRow(i);
+                if (dataRow == null || isRowEmpty(dataRow, formatter)) {
+                    continue; // 빈 행은 건너뛰기
+                }
+
+                try {
+                    ClubMemberSaveRequestDto dto = parseRowToDto(dataRow, formatter, i + 1);
+                    dtoList.add(dto);
+                } catch (IllegalArgumentException e) {
+                    errorMessages.add(String.format("%d행: %s", i + 1, e.getMessage()));
+                }
+            }
+        }
+
+        if (!errorMessages.isEmpty()) {
+            throw new ExcelParsingException("엑셀 데이터 검증 실패", errorMessages);
+        }
+
+        return dtoList;
+    }
+
+    private static boolean isValidHeader(Row headerRow) {
+        DataFormatter formatter = new DataFormatter();
+        for (int i = 0; i < HEADER_NAMES.size(); i++) {
+            Cell cell = headerRow.getCell(i);
+            String cellValue = formatter.formatCellValue(cell).trim();
+            if (!HEADER_NAMES.get(i).equals(cellValue)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean isRowEmpty(Row row, DataFormatter formatter) {
+        for (int i = row.getFirstCellNum(); i < row.getLastCellNum(); i++) {
+            Cell cell = row.getCell(i);
+            if (cell != null && !formatter.formatCellValue(cell).trim().isEmpty()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static ClubMemberSaveRequestDto parseRowToDto(Row row, DataFormatter formatter, int rowNum) {
+        String name = getCellValue(row, 0, formatter);
+        String studentId = getCellValue(row, 1, formatter);
+        String phoneNumber = getCellValue(row, 2, formatter);
+        String college = getCellValue(row, 3, formatter);
+        String department = getCellValue(row, 4, formatter);
+        String academicStatusStr = getCellValue(row, 5, formatter);
+        String roleStr = getCellValue(row, 6, formatter);
+        String joinDateStr = getCellValue(row, 7, formatter);
+
+        // 필수값 검증
+        if (name.isEmpty()) throw new IllegalArgumentException("이름이 비어있습니다.");
+        if (studentId.isEmpty()) throw new IllegalArgumentException("학번이 비어있습니다.");
+        if (phoneNumber.isEmpty()) throw new IllegalArgumentException("전화번호가 비어있습니다.");
+        if (college.isEmpty()) throw new IllegalArgumentException("단과대학이 비어있습니다.");
+        if (department.isEmpty()) throw new IllegalArgumentException("학과가 비어있습니다.");
+        if (academicStatusStr.isEmpty()) throw new IllegalArgumentException("학적상태가 비어있습니다.");
+        if (roleStr.isEmpty()) throw new IllegalArgumentException("직책이 비어있습니다.");
+        if (joinDateStr.isEmpty()) throw new IllegalArgumentException("가입일자가 비어있습니다.");
+
+        // 형식 검증
+        if (!PHONE_NUMBER_PATTERN.matcher(phoneNumber).matches()) {
+            throw new IllegalArgumentException("전화번호 형식이 올바르지 않습니다. (010-XXXX-XXXX)");
+        }
+        if (!JOIN_DATE_PATTERN.matcher(joinDateStr).matches()) {
+            throw new IllegalArgumentException("가입일자 형식이 올바르지 않습니다. (YYYY-MM)");
+        }
+
+        AcademicStatus academicStatus = parseAcademicStatus(academicStatusStr);
+        Role role = parseRole(roleStr);
+
+        return new ClubMemberSaveRequestDto(
+                name, studentId, phoneNumber, college, department, academicStatus, role, joinDateStr
+        );
+    }
+
+    private static String getCellValue(Row row, int cellNum, DataFormatter formatter) {
+        Cell cell = row.getCell(cellNum);
+        return (cell == null) ? "" : formatter.formatCellValue(cell).trim();
+    }
+
+    private static AcademicStatus parseAcademicStatus(String value) {
+        return switch (value.trim()) {
+            case "재학" -> AcademicStatus.ENROLLED;
+            case "휴학" -> AcademicStatus.LEAVE_OF_ABSENCE;
+            case "졸업" -> AcademicStatus.GRADUATED;
+            case "수료" -> AcademicStatus.COMPLETED;
+            case "제적" -> AcademicStatus.EXPELLED;
+            default -> throw new IllegalArgumentException(
+                    "학적상태는 '재학', '휴학', '졸업', '수료', '제적' 중 하나여야 합니다.");
+        };
+    }
+
+    private static Role parseRole(String value) {
+        return switch (value.trim()) {
+            case "일반부원" -> Role.CLUB_MEMBER;
+            case "운영진" -> Role.CLUB_EXECUTIVE;
+            case "회장" -> Role.CLUB_ADMIN;
+            default -> throw new IllegalArgumentException("직책은 '일반부원', '운영진', '회장' 중 하나여야 합니다.");
+        };
+    }
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/util/ExcelUtils.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/util/ExcelUtils.java
@@ -6,7 +6,6 @@ import com.kakaotech.team18.backend_server.domain.clubMember.entity.Role;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.ExcelParsingException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Pattern;
@@ -32,9 +31,8 @@ public class ExcelUtils {
         // Utility class
     }
 
-    public static List<ClubMemberSaveRequestDto> parseExcel(MultipartFile file) throws IOException {
-        List<ClubMemberSaveRequestDto> dtoList = new ArrayList<>();
-        List<String> errorMessages = new ArrayList<>();
+    public static ExcelParseResult parseExcel(MultipartFile file) throws IOException {
+        ExcelParseResult result = new ExcelParseResult();
 
         try (InputStream inputStream = file.getInputStream();
              Workbook workbook = WorkbookFactory.create(inputStream)) {
@@ -46,6 +44,7 @@ public class ExcelUtils {
             // 1. 헤더 검증 (첫 번째 행)
             Row headerRow = sheet.getRow(firstRow);
             if (headerRow == null || !isValidHeader(headerRow)) {
+                // 헤더가 틀리면 더 이상 진행할 수 없으므로 즉시 예외 발생 (파일 레벨 에러 취급)
                 throw new ExcelParsingException("엑셀 헤더 양식이 올바르지 않습니다. 다음 순서로 작성해주세요: " + HEADER_NAMES);
             }
 
@@ -60,18 +59,14 @@ public class ExcelUtils {
 
                 try {
                     ClubMemberSaveRequestDto dto = parseRowToDto(dataRow, formatter, i + 1);
-                    dtoList.add(dto);
+                    result.addSuccess(dto);
                 } catch (IllegalArgumentException e) {
-                    errorMessages.add(String.format("%d행: %s", i + 1, e.getMessage()));
+                    result.addError(String.format("%d행: %s", i + 1, e.getMessage()));
                 }
             }
         }
 
-        if (!errorMessages.isEmpty()) {
-            throw new ExcelParsingException("엑셀 데이터 검증 실패", errorMessages);
-        }
-
-        return dtoList;
+        return result;
     }
 
     private static boolean isValidHeader(Row headerRow) {

--- a/src/main/java/com/kakaotech/team18/backend_server/global/exception/code/ErrorCode.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/exception/code/ErrorCode.java
@@ -38,6 +38,7 @@ public enum ErrorCode {
     NO_APPLICATION_PROCESSED("처리할 지원서가 없습니다", HttpStatus.BAD_REQUEST),
     INVALID_TIME_SLOT("면접 시작 시간은 마감 시간보다 이전이어야 합니다.", HttpStatus.BAD_REQUEST),
     INVALID_EXCEL_DATA("엑셀 데이터 검증 실패", HttpStatus.BAD_REQUEST),
+    CANNOT_DELETE_SELF("자기 자신은 삭제할 수 없습니다. 권한 위임 후 탈퇴해주세요.", HttpStatus.BAD_REQUEST),
 
     // 401 UNAUTHORIZED: 인증되지 않은 사용자
     UNAUTHENTICATED_USER("인증되지 않은 사용자입니다.", HttpStatus.UNAUTHORIZED),

--- a/src/main/java/com/kakaotech/team18/backend_server/global/exception/code/ErrorCode.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/exception/code/ErrorCode.java
@@ -37,6 +37,7 @@ public enum ErrorCode {
     TOO_LARGE_FILE("업로드 하려는 파일 크기가 너무 큽니다", HttpStatus.BAD_REQUEST),
     NO_APPLICATION_PROCESSED("처리할 지원서가 없습니다", HttpStatus.BAD_REQUEST),
     INVALID_TIME_SLOT("면접 시작 시간은 마감 시간보다 이전이어야 합니다.", HttpStatus.BAD_REQUEST),
+    INVALID_EXCEL_DATA("엑셀 데이터 검증 실패", HttpStatus.BAD_REQUEST),
 
     // 401 UNAUTHORIZED: 인증되지 않은 사용자
     UNAUTHENTICATED_USER("인증되지 않은 사용자입니다.", HttpStatus.UNAUTHORIZED),

--- a/src/main/java/com/kakaotech/team18/backend_server/global/exception/exceptions/CannotDeleteSelfException.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/exception/exceptions/CannotDeleteSelfException.java
@@ -1,0 +1,9 @@
+package com.kakaotech.team18.backend_server.global.exception.exceptions;
+
+import com.kakaotech.team18.backend_server.global.exception.code.ErrorCode;
+
+public class CannotDeleteSelfException extends CustomException {
+    public CannotDeleteSelfException() {
+        super(ErrorCode.CANNOT_DELETE_SELF);
+    }
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/global/exception/exceptions/ExcelParsingException.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/exception/exceptions/ExcelParsingException.java
@@ -1,0 +1,21 @@
+package com.kakaotech.team18.backend_server.global.exception.exceptions;
+
+import com.kakaotech.team18.backend_server.global.exception.code.ErrorCode;
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class ExcelParsingException extends CustomException {
+
+    private final List<String> errorMessages;
+
+    public ExcelParsingException(String message) {
+        super(ErrorCode.INVALID_EXCEL_DATA, message);
+        this.errorMessages = null;
+    }
+
+    public ExcelParsingException(String message, List<String> errorMessages) {
+        super(ErrorCode.INVALID_EXCEL_DATA, message);
+        this.errorMessages = errorMessages;
+    }
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/global/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/exception/handler/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import com.kakaotech.team18.backend_server.domain.application.entity.Status;
 import com.kakaotech.team18.backend_server.global.exception.code.ErrorCode;
 import com.kakaotech.team18.backend_server.global.exception.dto.ErrorResponseDto;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.CustomException;
+import com.kakaotech.team18.backend_server.global.exception.exceptions.ExcelParsingException;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.ForbiddenAccessException;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.StatusNotFoundException;
 import lombok.extern.slf4j.Slf4j;
@@ -49,6 +50,28 @@ public class GlobalExceptionHandler {
         log.warn("handleCustomException: {} (detail: {})",
                 errorCode.getMessage(),
                 detail);
+
+        return new ResponseEntity<>(response, errorCode.getHttpStatus());
+    }
+
+    /**
+     * ExcelParsingException 예외를 처리
+     * <p>
+     * 엑셀 파싱 중 발생한 여러 에러 메시지를 하나의 문자열로 합쳐서 detail에 담아 반환합니다.
+     */
+    @ExceptionHandler(ExcelParsingException.class)
+    protected ResponseEntity<ErrorResponseDto> handleExcelParsingException(final ExcelParsingException e) {
+        final ErrorCode errorCode = e.getErrorCode();
+        String detail = e.getMessage(); // 기본 메시지
+
+        if (e.getErrorMessages() != null && !e.getErrorMessages().isEmpty()) {
+            // 에러 리스트를 문자열로 변환 (예: "[3행: 오류1, 5행: 오류2]")
+            detail = e.getErrorMessages().toString();
+        }
+
+        final ErrorResponseDto response = ErrorResponseDto.of(errorCode, detail);
+
+        log.warn("handleExcelParsingException: {} (detail: {})", errorCode.getMessage(), detail);
 
         return new ResponseEntity<>(response, errorCode.getHttpStatus());
     }

--- a/src/main/java/com/kakaotech/team18/backend_server/global/security/CustomSecurityService.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/security/CustomSecurityService.java
@@ -107,6 +107,11 @@ public class CustomSecurityService {
         }
 
         String roleStr = memberships.get(clubId.toString());
+
+        if (roleStr == null || roleStr.isEmpty()) {
+            throw new CustomException(ErrorCode.UNAUTHENTICATED_USER, "유효하지 않은 Role 정보입니다.");
+        }
+
         try {
             return Role.valueOf(roleStr);
         } catch (IllegalArgumentException e) {

--- a/src/main/java/com/kakaotech/team18/backend_server/global/security/CustomSecurityService.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/security/CustomSecurityService.java
@@ -113,4 +113,12 @@ public class CustomSecurityService {
             throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR, "유효하지 않은 Role 정보입니다.");
         }
     }
+
+    public Long getCurrentUserId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !(authentication.getPrincipal() instanceof PrincipalDetails principalDetails)) {
+            throw new CustomException(ErrorCode.UNAUTHENTICATED_USER);
+        }
+        return principalDetails.getUserId();
+    }
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/global/security/CustomSecurityService.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/security/CustomSecurityService.java
@@ -2,6 +2,8 @@ package com.kakaotech.team18.backend_server.global.security;
 
 import com.kakaotech.team18.backend_server.domain.application.repository.ApplicationRepository;
 import com.kakaotech.team18.backend_server.domain.clubMember.entity.Role;
+import com.kakaotech.team18.backend_server.global.exception.code.ErrorCode;
+import com.kakaotech.team18.backend_server.global.exception.exceptions.CustomException;
 import java.util.Map;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
@@ -84,5 +86,31 @@ public class CustomSecurityService {
         // 4. 역할이 CLUB_ADMIN 또는 CLUB_EXECUTIVE인지 확인
         return Objects.equals(userRoleForClub, Role.CLUB_ADMIN.name()) ||
                Objects.equals(userRoleForClub, Role.CLUB_EXECUTIVE.name());
+    }
+
+    /**
+     * 현재 로그인한 사용자의 특정 동아리(clubId)에서의 Role을 반환합니다.
+     *
+     * @param clubId 동아리 ID
+     * @return Role (해당 동아리의 직책)
+     * @throws CustomException 해당 동아리에 대한 권한 정보가 없을 경우
+     */
+    public Role getUserRoleInClub(Long clubId) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !(authentication.getPrincipal() instanceof PrincipalDetails principalDetails)) {
+            throw new CustomException(ErrorCode.UNAUTHENTICATED_USER);
+        }
+
+        Map<String, String> memberships = principalDetails.getMemberships();
+        if (memberships == null || !memberships.containsKey(clubId.toString())) {
+            throw new CustomException(ErrorCode.FORBIDDEN, "해당 동아리에 대한 권한 정보가 없습니다.");
+        }
+
+        String roleStr = memberships.get(clubId.toString());
+        try {
+            return Role.valueOf(roleStr);
+        } catch (IllegalArgumentException e) {
+            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR, "유효하지 않은 Role 정보입니다.");
+        }
     }
 }

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/clubMember/service/ClubMemberServiceTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/clubMember/service/ClubMemberServiceTest.java
@@ -77,8 +77,8 @@ class ClubMemberServiceTest {
     void getClubMembers_Success() {
         // given
         Long clubId = 1L;
-        ClubMemberProfile profile1 = createProfile("이지훈", "20231234", Role.CLUB_EXECUTIVE);
-        ClubMemberProfile profile2 = createProfile("김철수", "20245678", Role.CLUB_MEMBER);
+        ClubMemberProfile profile1 = createProfile(10L, 100L, "이지훈", "20231234", Role.CLUB_EXECUTIVE);
+        ClubMemberProfile profile2 = createProfile(20L, 200L, "김철수", "20245678", Role.CLUB_MEMBER);
 
         given(clubRepository.existsById(clubId)).willReturn(true);
         given(clubMemberProfileRepository.findAllByClubId(clubId)).willReturn(List.of(profile1, profile2));
@@ -165,7 +165,7 @@ class ClubMemberServiceTest {
         // given
         Long clubId = 1L;
         ClubMemberSaveRequestDto requestDto = createRequestDto("이지훈", "20231234", Role.CLUB_MEMBER);
-        ClubMemberProfile existingProfile = createProfile("이지훈", "20231234", Role.CLUB_MEMBER); // 이름 일치
+        ClubMemberProfile existingProfile = createProfile(10L, 100L, "이지훈", "20231234", Role.CLUB_MEMBER); // 이름 일치
 
         given(customSecurityService.getUserRoleInClub(clubId)).willReturn(Role.CLUB_ADMIN);
         given(clubMemberProfileRepository.findByClubMember_Club_IdAndStudentId(clubId, requestDto.studentId()))
@@ -187,7 +187,7 @@ class ClubMemberServiceTest {
         // given
         Long clubId = 1L;
         ClubMemberSaveRequestDto requestDto = createRequestDto("김기춘", "20231234", Role.CLUB_MEMBER); // 이름 다름
-        ClubMemberProfile existingProfile = createProfile("이지훈", "20231234", Role.CLUB_MEMBER);
+        ClubMemberProfile existingProfile = createProfile(10L, 100L, "이지훈", "20231234", Role.CLUB_MEMBER);
 
         given(customSecurityService.getUserRoleInClub(clubId)).willReturn(Role.CLUB_ADMIN);
         given(clubMemberProfileRepository.findByClubMember_Club_IdAndStudentId(clubId, requestDto.studentId()))
@@ -271,7 +271,7 @@ class ClubMemberServiceTest {
         );
         MockMultipartFile file = createExcelFile("members.xlsx", data);
 
-        ClubMemberProfile existingProfile = createProfile("이지훈", "20231234", Role.CLUB_MEMBER);
+        ClubMemberProfile existingProfile = createProfile(10L, 100L, "이지훈", "20231234", Role.CLUB_MEMBER);
         
         given(customSecurityService.getUserRoleInClub(clubId)).willReturn(Role.CLUB_ADMIN);
         given(clubMemberProfileRepository.findByClubMember_Club_IdAndStudentId(clubId, "20231234"))
@@ -305,7 +305,7 @@ class ClubMemberServiceTest {
         ClubMemberUpdateRequestDto requestDto = new ClubMemberUpdateRequestDto(
                 "박개명", null, null, null, null, null, null
         );
-        ClubMemberProfile profile = createProfile("박원래", "212121", Role.CLUB_MEMBER);
+        ClubMemberProfile profile = createProfile(profileId, 100L, "박원래", "212121", Role.CLUB_MEMBER);
 
         given(clubMemberProfileRepository.findByIdAndClubId(profileId, clubId)).willReturn(Optional.of(profile));
         // 중복 검사 통과 (학번 변경 없음)
@@ -327,7 +327,7 @@ class ClubMemberServiceTest {
         ClubMemberUpdateRequestDto requestDto = new ClubMemberUpdateRequestDto(
                 null, "20245678", null, null, null, null, null // 다른 사람 학번으로 변경 시도
         );
-        ClubMemberProfile profile = createProfile("이지훈", "20245678", Role.CLUB_MEMBER);
+        ClubMemberProfile profile = createProfile(profileId, 100L, "이지훈", "20231234", Role.CLUB_MEMBER);
 
         given(clubMemberProfileRepository.findByIdAndClubId(profileId, clubId)).willReturn(Optional.of(profile));
         given(clubMemberProfileRepository.existsByClubMember_Club_IdAndStudentIdAndIdNot(clubId, "20245678", profileId))
@@ -346,7 +346,7 @@ class ClubMemberServiceTest {
         Long clubId = 1L;
         Long profileId = 501L;
         ClubMemberRoleUpdateRequestDto requestDto = new ClubMemberRoleUpdateRequestDto(Role.CLUB_EXECUTIVE);
-        ClubMemberProfile profile = createProfile("이지훈", "20231234", Role.CLUB_MEMBER);
+        ClubMemberProfile profile = createProfile(profileId, 100L, "이지훈", "20231234", Role.CLUB_MEMBER);
 
         given(customSecurityService.getUserRoleInClub(clubId)).willReturn(Role.CLUB_ADMIN); // 회장
         given(clubMemberProfileRepository.findByIdAndClubId(profileId, clubId)).willReturn(Optional.of(profile));
@@ -376,14 +376,39 @@ class ClubMemberServiceTest {
     }
 
     @Test
+    @DisplayName("동아리원 직책 변경 성공 - 회장직 이양")
+    void updateMemberRole_Success_TransferAdmin() {
+        // given
+        Long clubId = 1L;
+        Long oldAdminProfileId = 10L;
+        Long newAdminProfileId = 20L;
+        
+        ClubMemberProfile oldAdmin = createProfile(oldAdminProfileId, 100L, "나회장", "111111", Role.CLUB_ADMIN);
+        ClubMemberProfile newAdmin = createProfile(newAdminProfileId, 200L, "너회장", "222222", Role.CLUB_MEMBER);
+        
+        ClubMemberRoleUpdateRequestDto requestDto = new ClubMemberRoleUpdateRequestDto(Role.CLUB_ADMIN);
+
+        given(customSecurityService.getUserRoleInClub(clubId)).willReturn(Role.CLUB_ADMIN);
+        given(clubMemberProfileRepository.findByIdAndClubId(newAdminProfileId, clubId)).willReturn(Optional.of(newAdmin));
+        given(clubMemberProfileRepository.findByClubMember_Club_IdAndRole(clubId, Role.CLUB_ADMIN)).willReturn(Optional.of(oldAdmin));
+
+        // when
+        ClubMemberRoleUpdateResponseDto result = clubMemberService.updateMemberRole(clubId, newAdminProfileId, requestDto);
+
+        // then
+        assertThat(result.newRole()).isEqualTo(Role.CLUB_ADMIN);
+        assertThat(newAdmin.getRole()).isEqualTo(Role.CLUB_ADMIN); // 새 회장 승격 확인
+        assertThat(oldAdmin.getRole()).isEqualTo(Role.CLUB_MEMBER); // 기존 회장 강등 확인
+    }
+
+    @Test
     @DisplayName("동아리원 삭제 성공")
     void deleteMember_Success() {
         // given
         Long clubId = 1L;
         Long profileId = 501L;
         Long currentUserId = 100L;
-        ClubMemberProfile profile = createProfile("이지훈", "20231234", Role.CLUB_MEMBER);
-        // profile의 주인은 userId가 999L (createProfile에서 설정)
+        ClubMemberProfile profile = createProfile(profileId, 999L, "이지훈", "20231234", Role.CLUB_MEMBER);
         
         given(customSecurityService.getUserRoleInClub(clubId)).willReturn(Role.CLUB_ADMIN);
         given(clubMemberProfileRepository.findByIdAndClubId(profileId, clubId)).willReturn(Optional.of(profile));
@@ -407,11 +432,12 @@ class ClubMemberServiceTest {
         
         // 내 프로필 생성 (User ID = 100)
         User user = User.builder().name("나회장").studentId("20231234").build();
-        ReflectionTestUtils.setField(user, "id", currentUserId); // ID 강제 주입
+        ReflectionTestUtils.setField(user, "id", currentUserId);
 
         Club club = Club.builder().build();
         ClubMember clubMember = ClubMember.builder().user(user).club(club).role(Role.CLUB_ADMIN).build();
         ClubMemberProfile profile = ClubMemberProfile.builder().clubMember(clubMember).name("나회장").role(Role.CLUB_ADMIN).build();
+        ReflectionTestUtils.setField(profile, "id", profileId);
         clubMember.setProfile(profile);
 
         given(customSecurityService.getUserRoleInClub(clubId)).willReturn(Role.CLUB_ADMIN);
@@ -423,9 +449,9 @@ class ClubMemberServiceTest {
                 .isInstanceOf(CannotDeleteSelfException.class);
     }
 
-    private ClubMemberProfile createProfile(String name, String studentId, Role role) {
+    private ClubMemberProfile createProfile(Long profileId, Long userId, String name, String studentId, Role role) {
         User user = User.builder().name(name).studentId(studentId).build();
-        ReflectionTestUtils.setField(user, "id", 999L); // ID 강제 주입
+        ReflectionTestUtils.setField(user, "id", userId);
 
         Club club = Club.builder().name("동아리움").build();
         
@@ -437,7 +463,7 @@ class ClubMemberServiceTest {
                 .build();
 
         ClubMemberProfile profile = ClubMemberProfile.builder()
-                .clubMember(clubMember) // ClubMember 연결
+                .clubMember(clubMember)
                 .name(name)
                 .studentId(studentId)
                 .phoneNumber("010-1234-5678")
@@ -447,6 +473,7 @@ class ClubMemberServiceTest {
                 .joinDate(LocalDate.of(2024, 3, 1))
                 .role(role)
                 .build();
+        ReflectionTestUtils.setField(profile, "id", profileId);
         
         clubMember.setProfile(profile); // 양방향 연결
         return profile;

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/clubMember/service/ClubMemberServiceTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/clubMember/service/ClubMemberServiceTest.java
@@ -2,20 +2,33 @@ package com.kakaotech.team18.backend_server.domain.clubMember.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import com.kakaotech.team18.backend_server.domain.club.entity.Club;
 import com.kakaotech.team18.backend_server.domain.club.repository.ClubRepository;
 import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMemberResponseDto;
+import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMemberSaveRequestDto;
 import com.kakaotech.team18.backend_server.domain.clubMember.entity.AcademicStatus;
+import com.kakaotech.team18.backend_server.domain.clubMember.entity.ActiveStatus;
+import com.kakaotech.team18.backend_server.domain.clubMember.entity.ClubMember;
 import com.kakaotech.team18.backend_server.domain.clubMember.entity.ClubMemberProfile;
 import com.kakaotech.team18.backend_server.domain.clubMember.entity.Role;
 import com.kakaotech.team18.backend_server.domain.clubMember.repository.ClubMemberProfileRepository;
+import com.kakaotech.team18.backend_server.domain.clubMember.repository.ClubMemberRepository;
+import com.kakaotech.team18.backend_server.domain.user.entity.User;
+import com.kakaotech.team18.backend_server.domain.user.repository.UserRepository;
+import com.kakaotech.team18.backend_server.global.exception.code.ErrorCode;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.ClubNotFoundException;
+import com.kakaotech.team18.backend_server.global.exception.exceptions.CustomException;
+import com.kakaotech.team18.backend_server.global.security.CustomSecurityService;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -33,15 +46,24 @@ class ClubMemberServiceTest {
     private ClubMemberProfileRepository clubMemberProfileRepository;
 
     @Mock
+    private ClubMemberRepository clubMemberRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
     private ClubRepository clubRepository;
+
+    @Mock
+    private CustomSecurityService customSecurityService;
 
     @Test
     @DisplayName("동아리원 목록 조회 성공 - 존재하는 동아리 ID")
     void getClubMembers_Success() {
         // given
         Long clubId = 1L;
-        ClubMemberProfile profile1 = createProfile("이지훈", "212121", Role.CLUB_EXECUTIVE);
-        ClubMemberProfile profile2 = createProfile("김철수", "232323", Role.CLUB_MEMBER);
+        ClubMemberProfile profile1 = createProfile("이지훈", "20231234", Role.CLUB_EXECUTIVE);
+        ClubMemberProfile profile2 = createProfile("김철수", "20245678", Role.CLUB_MEMBER);
 
         given(clubRepository.existsById(clubId)).willReturn(true);
         given(clubMemberProfileRepository.findAllByClubId(clubId)).willReturn(List.of(profile1, profile2));
@@ -74,8 +96,125 @@ class ClubMemberServiceTest {
         verify(clubMemberProfileRepository, times(0)).findAllByClubId(anyLong());
     }
 
+    @Test
+    @DisplayName("동아리원 수동 등록 성공 - 회장이 신규 등록 (Role 유지)")
+    void registerMember_Success_New_Admin() {
+        // given
+        Long clubId = 1L;
+        ClubMemberSaveRequestDto requestDto = createRequestDto("박신입", "241001", Role.CLUB_EXECUTIVE);
+        
+        given(customSecurityService.getUserRoleInClub(clubId)).willReturn(Role.CLUB_ADMIN); // 회장
+        given(clubMemberProfileRepository.findByClubMember_Club_IdAndStudentId(clubId, requestDto.studentId()))
+                .willReturn(Optional.empty()); // 신규
+        given(clubRepository.findById(clubId)).willReturn(Optional.of(Club.builder().build()));
+        given(userRepository.findByStudentId(requestDto.studentId())).willReturn(Optional.empty()); // User 없음 -> 껍데기 생성
+        given(userRepository.save(any(User.class))).willReturn(User.builder().build());
+
+        // when
+        ClubMemberResponseDto result = clubMemberService.registerMember(clubId, requestDto);
+
+        // then
+        assertThat(result.name()).isEqualTo("박신입");
+        assertThat(result.role()).isEqualTo(Role.CLUB_EXECUTIVE); // Role 유지됨
+        
+        verify(clubMemberRepository, times(1)).save(any(ClubMember.class));
+    }
+
+    @Test
+    @DisplayName("동아리원 수동 등록 성공 - 운영진이 신규 등록 (Role 강등)")
+    void registerMember_Success_New_Executive() {
+        // given
+        Long clubId = 1L;
+        ClubMemberSaveRequestDto requestDto = createRequestDto("박신입", "241001", Role.CLUB_EXECUTIVE); // 운영진으로 요청했지만
+        
+        given(customSecurityService.getUserRoleInClub(clubId)).willReturn(Role.CLUB_EXECUTIVE); // 요청자가 운영진
+        given(clubMemberProfileRepository.findByClubMember_Club_IdAndStudentId(clubId, requestDto.studentId()))
+                .willReturn(Optional.empty());
+        given(clubRepository.findById(clubId)).willReturn(Optional.of(Club.builder().build()));
+        given(userRepository.findByStudentId(requestDto.studentId())).willReturn(Optional.empty());
+        given(userRepository.save(any(User.class))).willReturn(User.builder().build());
+
+        // when
+        ClubMemberResponseDto result = clubMemberService.registerMember(clubId, requestDto);
+
+        // then
+        assertThat(result.name()).isEqualTo("박신입");
+        assertThat(result.role()).isEqualTo(Role.CLUB_MEMBER); // 일반부원으로 강등됨
+        
+        verify(clubMemberRepository, times(1)).save(any(ClubMember.class));
+    }
+
+    @Test
+    @DisplayName("동아리원 수동 등록 성공 - 정보 업데이트 (이름 일치)")
+    void registerMember_Success_Update() {
+        // given
+        Long clubId = 1L;
+        ClubMemberSaveRequestDto requestDto = createRequestDto("이지훈", "20231234", Role.CLUB_MEMBER);
+        ClubMemberProfile existingProfile = createProfile("이지훈", "20231234", Role.CLUB_MEMBER); // 이름 일치
+
+        given(customSecurityService.getUserRoleInClub(clubId)).willReturn(Role.CLUB_ADMIN);
+        given(clubMemberProfileRepository.findByClubMember_Club_IdAndStudentId(clubId, requestDto.studentId()))
+                .willReturn(Optional.of(existingProfile));
+
+        // when
+        ClubMemberResponseDto result = clubMemberService.registerMember(clubId, requestDto);
+
+        // then
+        assertThat(result.name()).isEqualTo("이지훈");
+        assertThat(result.studentId()).isEqualTo("20231234");
+        
+        verify(clubMemberRepository, times(0)).save(any(ClubMember.class)); // 저장이 아니라 업데이트
+    }
+
+    @Test
+    @DisplayName("동아리원 수동 등록 실패 - 중복 충돌 (이름 불일치)")
+    void registerMember_Fail_Conflict() {
+        // given
+        Long clubId = 1L;
+        ClubMemberSaveRequestDto requestDto = createRequestDto("김기춘", "20231234", Role.CLUB_MEMBER); // 이름 다름
+        ClubMemberProfile existingProfile = createProfile("이지훈", "20231234", Role.CLUB_MEMBER);
+
+        given(customSecurityService.getUserRoleInClub(clubId)).willReturn(Role.CLUB_ADMIN);
+        given(clubMemberProfileRepository.findByClubMember_Club_IdAndStudentId(clubId, requestDto.studentId()))
+                .willReturn(Optional.of(existingProfile));
+
+        // when & then
+        assertThatThrownBy(() -> clubMemberService.registerMember(clubId, requestDto))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_ALREADY_EXISTS);
+    }
+
+    @Test
+    @DisplayName("동아리원 수동 등록 실패 - 동아리 없음")
+    void registerMember_Fail_ClubNotFound() {
+        // given
+        Long clubId = 999L;
+        ClubMemberSaveRequestDto requestDto = createRequestDto("박신입", "241001", Role.CLUB_MEMBER);
+
+        given(customSecurityService.getUserRoleInClub(clubId)).willReturn(Role.CLUB_ADMIN);
+        given(clubMemberProfileRepository.findByClubMember_Club_IdAndStudentId(clubId, requestDto.studentId()))
+                .willReturn(Optional.empty());
+        given(clubRepository.findById(clubId)).willReturn(Optional.empty()); // 동아리 없음
+
+        // when & then
+        assertThatThrownBy(() -> clubMemberService.registerMember(clubId, requestDto))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.CLUB_NOT_FOUND);
+    }
+
     private ClubMemberProfile createProfile(String name, String studentId, Role role) {
-        return ClubMemberProfile.builder()
+        User user = User.builder().name(name).studentId(studentId).build();
+        Club club = Club.builder().build();
+        
+        ClubMember clubMember = ClubMember.builder()
+                .user(user)
+                .club(club)
+                .activeStatus(ActiveStatus.ACTIVE)
+                .role(role)
+                .build();
+
+        ClubMemberProfile profile = ClubMemberProfile.builder()
+                .clubMember(clubMember) // ClubMember 연결
                 .name(name)
                 .studentId(studentId)
                 .phoneNumber("010-1234-5678")
@@ -85,5 +224,15 @@ class ClubMemberServiceTest {
                 .joinDate(LocalDate.of(2024, 3, 1))
                 .role(role)
                 .build();
+        
+        clubMember.setProfile(profile); // 양방향 연결
+        return profile;
+    }
+
+    private ClubMemberSaveRequestDto createRequestDto(String name, String studentId, Role role) {
+        return new ClubMemberSaveRequestDto(
+                name, studentId, "010-1111-2222", "공과대학", "컴퓨터공학과",
+                AcademicStatus.ENROLLED, role, "2024-03"
+        );
     }
 }

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/clubMember/service/ClubMemberServiceTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/clubMember/service/ClubMemberServiceTest.java
@@ -13,7 +13,10 @@ import static org.mockito.Mockito.verify;
 import com.kakaotech.team18.backend_server.domain.club.entity.Club;
 import com.kakaotech.team18.backend_server.domain.club.repository.ClubRepository;
 import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMemberResponseDto;
+import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMemberRoleUpdateResponseDto;
+import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMemberRoleUpdateRequestDto;
 import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMemberSaveRequestDto;
+import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMemberUpdateRequestDto;
 import com.kakaotech.team18.backend_server.domain.clubMember.entity.AcademicStatus;
 import com.kakaotech.team18.backend_server.domain.clubMember.entity.ActiveStatus;
 import com.kakaotech.team18.backend_server.domain.clubMember.entity.ClubMember;
@@ -24,6 +27,7 @@ import com.kakaotech.team18.backend_server.domain.clubMember.repository.ClubMemb
 import com.kakaotech.team18.backend_server.domain.user.entity.User;
 import com.kakaotech.team18.backend_server.domain.user.repository.UserRepository;
 import com.kakaotech.team18.backend_server.global.exception.code.ErrorCode;
+import com.kakaotech.team18.backend_server.global.exception.exceptions.CannotDeleteSelfException;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.ClubNotFoundException;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.CustomException;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.ExcelParsingException;
@@ -45,6 +49,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 class ClubMemberServiceTest {
@@ -224,10 +229,6 @@ class ClubMemberServiceTest {
         );
         MockMultipartFile file = createExcelFile("members.xlsx", data);
 
-        // Mocking registerMember behavior (내부 호출)
-        // 주의: 같은 클래스 내의 메서드 호출은 @Spy를 쓰지 않는 한 Mocking이 안 됨.
-        // 여기서는 registerMember가 실제로 실행되도록 두고, 내부 의존성들을 Mocking해야 함.
-        
         given(customSecurityService.getUserRoleInClub(clubId)).willReturn(Role.CLUB_ADMIN);
         given(clubMemberProfileRepository.findByClubMember_Club_IdAndStudentId(anyLong(), anyString()))
                 .willReturn(Optional.empty()); // 모두 신규
@@ -295,9 +296,138 @@ class ClubMemberServiceTest {
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_FILE);
     }
 
+    @Test
+    @DisplayName("동아리원 정보 수정 성공")
+    void updateMember_Success() {
+        // given
+        Long clubId = 1L;
+        Long profileId = 501L;
+        ClubMemberUpdateRequestDto requestDto = new ClubMemberUpdateRequestDto(
+                "박개명", null, null, null, null, null, null
+        );
+        ClubMemberProfile profile = createProfile("박원래", "212121", Role.CLUB_MEMBER);
+
+        given(clubMemberProfileRepository.findByIdAndClubId(profileId, clubId)).willReturn(Optional.of(profile));
+        // 중복 검사 통과 (학번 변경 없음)
+
+        // when
+        ClubMemberResponseDto result = clubMemberService.updateMember(clubId, profileId, requestDto);
+
+        // then
+        assertThat(result.name()).isEqualTo("박개명"); // 이름 변경됨
+        assertThat(result.studentId()).isEqualTo("212121"); // 학번 유지됨
+    }
+
+    @Test
+    @DisplayName("동아리원 정보 수정 실패 - 중복 학번")
+    void updateMember_Fail_DuplicateStudentId() {
+        // given
+        Long clubId = 1L;
+        Long profileId = 501L;
+        ClubMemberUpdateRequestDto requestDto = new ClubMemberUpdateRequestDto(
+                null, "20245678", null, null, null, null, null // 다른 사람 학번으로 변경 시도
+        );
+        ClubMemberProfile profile = createProfile("이지훈", "20245678", Role.CLUB_MEMBER);
+
+        given(clubMemberProfileRepository.findByIdAndClubId(profileId, clubId)).willReturn(Optional.of(profile));
+        given(clubMemberProfileRepository.existsByClubMember_Club_IdAndStudentIdAndIdNot(clubId, "20245678", profileId))
+                .willReturn(true); // 이미 존재함
+
+        // when & then
+        assertThatThrownBy(() -> clubMemberService.updateMember(clubId, profileId, requestDto))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_ALREADY_EXISTS);
+    }
+
+    @Test
+    @DisplayName("동아리원 직책 변경 성공 - 회장 요청")
+    void updateMemberRole_Success() {
+        // given
+        Long clubId = 1L;
+        Long profileId = 501L;
+        ClubMemberRoleUpdateRequestDto requestDto = new ClubMemberRoleUpdateRequestDto(Role.CLUB_EXECUTIVE);
+        ClubMemberProfile profile = createProfile("이지훈", "20231234", Role.CLUB_MEMBER);
+
+        given(customSecurityService.getUserRoleInClub(clubId)).willReturn(Role.CLUB_ADMIN); // 회장
+        given(clubMemberProfileRepository.findByIdAndClubId(profileId, clubId)).willReturn(Optional.of(profile));
+
+        // when
+        ClubMemberRoleUpdateResponseDto result = clubMemberService.updateMemberRole(clubId, profileId, requestDto);
+
+        // then
+        assertThat(result.newRole()).isEqualTo(Role.CLUB_EXECUTIVE);
+        assertThat(profile.getClubMember().getRole()).isEqualTo(Role.CLUB_EXECUTIVE); // 동기화 확인
+    }
+
+    @Test
+    @DisplayName("동아리원 직책 변경 실패 - 운영진 요청")
+    void updateMemberRole_Fail_Forbidden() {
+        // given
+        Long clubId = 1L;
+        Long profileId = 501L;
+        ClubMemberRoleUpdateRequestDto requestDto = new ClubMemberRoleUpdateRequestDto(Role.CLUB_EXECUTIVE);
+
+        given(customSecurityService.getUserRoleInClub(clubId)).willReturn(Role.CLUB_EXECUTIVE); // 운영진
+
+        // when & then
+        assertThatThrownBy(() -> clubMemberService.updateMemberRole(clubId, profileId, requestDto))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.FORBIDDEN);
+    }
+
+    @Test
+    @DisplayName("동아리원 삭제 성공")
+    void deleteMember_Success() {
+        // given
+        Long clubId = 1L;
+        Long profileId = 501L;
+        Long currentUserId = 100L;
+        ClubMemberProfile profile = createProfile("이지훈", "20231234", Role.CLUB_MEMBER);
+        // profile의 주인은 userId가 999L (createProfile에서 설정)
+        
+        given(customSecurityService.getUserRoleInClub(clubId)).willReturn(Role.CLUB_ADMIN);
+        given(clubMemberProfileRepository.findByIdAndClubId(profileId, clubId)).willReturn(Optional.of(profile));
+        given(customSecurityService.getCurrentUserId()).willReturn(currentUserId);
+        // isOwner -> false (100 != 999)
+
+        // when
+        clubMemberService.deleteMember(clubId, profileId);
+
+        // then
+        verify(clubMemberRepository, times(1)).delete(any(ClubMember.class));
+    }
+
+    @Test
+    @DisplayName("동아리원 삭제 실패 - 자기 자신 삭제")
+    void deleteMember_Fail_SelfDelete() {
+        // given
+        Long clubId = 1L;
+        Long profileId = 501L;
+        Long currentUserId = 100L;
+        
+        // 내 프로필 생성 (User ID = 100)
+        User user = User.builder().name("나회장").studentId("20231234").build();
+        ReflectionTestUtils.setField(user, "id", currentUserId); // ID 강제 주입
+
+        Club club = Club.builder().build();
+        ClubMember clubMember = ClubMember.builder().user(user).club(club).role(Role.CLUB_ADMIN).build();
+        ClubMemberProfile profile = ClubMemberProfile.builder().clubMember(clubMember).name("나회장").role(Role.CLUB_ADMIN).build();
+        clubMember.setProfile(profile);
+
+        given(customSecurityService.getUserRoleInClub(clubId)).willReturn(Role.CLUB_ADMIN);
+        given(clubMemberProfileRepository.findByIdAndClubId(profileId, clubId)).willReturn(Optional.of(profile));
+        given(customSecurityService.getCurrentUserId()).willReturn(currentUserId);
+
+        // when & then
+        assertThatThrownBy(() -> clubMemberService.deleteMember(clubId, profileId))
+                .isInstanceOf(CannotDeleteSelfException.class);
+    }
+
     private ClubMemberProfile createProfile(String name, String studentId, Role role) {
         User user = User.builder().name(name).studentId(studentId).build();
-        Club club = Club.builder().build();
+        ReflectionTestUtils.setField(user, "id", 999L); // ID 강제 주입
+
+        Club club = Club.builder().name("동아리움").build();
         
         ClubMember clubMember = ClubMember.builder()
                 .user(user)

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/clubMember/service/ClubMemberServiceTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/clubMember/service/ClubMemberServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -25,16 +26,25 @@ import com.kakaotech.team18.backend_server.domain.user.repository.UserRepository
 import com.kakaotech.team18.backend_server.global.exception.code.ErrorCode;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.ClubNotFoundException;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.CustomException;
+import com.kakaotech.team18.backend_server.global.exception.exceptions.ExcelParsingException;
 import com.kakaotech.team18.backend_server.global.security.CustomSecurityService;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.time.LocalDate;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
 
 @ExtendWith(MockitoExtension.class)
 class ClubMemberServiceTest {
@@ -202,6 +212,89 @@ class ClubMemberServiceTest {
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.CLUB_NOT_FOUND);
     }
 
+    @Test
+    @DisplayName("동아리원 일괄 등록 성공 - 정상 파일")
+    void registerMembersByExcel_Success() throws IOException {
+        // given
+        Long clubId = 1L;
+        List<List<String>> data = Arrays.asList(
+                Arrays.asList("이름", "학번", "전화번호", "단과대학", "학과", "학적상태", "직책", "가입일자"), // 헤더
+                Arrays.asList("박신입", "241001", "010-1111-2222", "공대", "컴공", "재학", "일반부원", "2024-03"),
+                Arrays.asList("김신입", "241002", "010-3333-4444", "공대", "컴공", "재학", "일반부원", "2024-03")
+        );
+        MockMultipartFile file = createExcelFile("members.xlsx", data);
+
+        // Mocking registerMember behavior (내부 호출)
+        // 주의: 같은 클래스 내의 메서드 호출은 @Spy를 쓰지 않는 한 Mocking이 안 됨.
+        // 여기서는 registerMember가 실제로 실행되도록 두고, 내부 의존성들을 Mocking해야 함.
+        
+        given(customSecurityService.getUserRoleInClub(clubId)).willReturn(Role.CLUB_ADMIN);
+        given(clubMemberProfileRepository.findByClubMember_Club_IdAndStudentId(anyLong(), anyString()))
+                .willReturn(Optional.empty()); // 모두 신규
+        given(clubRepository.findById(clubId)).willReturn(Optional.of(Club.builder().build()));
+        given(userRepository.findByStudentId(anyString())).willReturn(Optional.empty());
+        given(userRepository.save(any(User.class))).willReturn(User.builder().build());
+
+        // when
+        clubMemberService.registerMembersByExcel(clubId, file);
+
+        // then
+        verify(clubMemberRepository, times(2)).save(any(ClubMember.class)); // 2명 저장됨
+    }
+
+    @Test
+    @DisplayName("동아리원 일괄 등록 실패 - 엑셀 파싱 에러 (형식 오류)")
+    void registerMembersByExcel_Fail_ParsingError() throws IOException {
+        // given
+        Long clubId = 1L;
+        List<List<String>> data = Arrays.asList(
+                Arrays.asList("이름", "학번", "전화번호", "단과대학", "학과", "학적상태", "직책", "가입일자"),
+                Arrays.asList("박신입", "241001", "잘못된번호", "공대", "컴공", "재학", "일반부원", "2024-03") // 전화번호 오류
+        );
+        MockMultipartFile file = createExcelFile("members.xlsx", data);
+
+        // when & then
+        assertThatThrownBy(() -> clubMemberService.registerMembersByExcel(clubId, file))
+                .isInstanceOf(ExcelParsingException.class)
+                .hasMessageContaining("엑셀 데이터 검증 실패");
+    }
+
+    @Test
+    @DisplayName("동아리원 일괄 등록 실패 - 비즈니스 에러 (중복 충돌)")
+    void registerMembersByExcel_Fail_BusinessError() throws IOException {
+        // given
+        Long clubId = 1L;
+        List<List<String>> data = Arrays.asList(
+                Arrays.asList("이름", "학번", "전화번호", "단과대학", "학과", "학적상태", "직책", "가입일자"),
+                Arrays.asList("김기춘", "20231234", "010-1111-2222", "공대", "컴공", "재학", "일반부원", "2024-03") // 이름 불일치
+        );
+        MockMultipartFile file = createExcelFile("members.xlsx", data);
+
+        ClubMemberProfile existingProfile = createProfile("이지훈", "20231234", Role.CLUB_MEMBER);
+        
+        given(customSecurityService.getUserRoleInClub(clubId)).willReturn(Role.CLUB_ADMIN);
+        given(clubMemberProfileRepository.findByClubMember_Club_IdAndStudentId(clubId, "20231234"))
+                .willReturn(Optional.of(existingProfile));
+
+        // when & then
+        assertThatThrownBy(() -> clubMemberService.registerMembersByExcel(clubId, file))
+                .isInstanceOf(ExcelParsingException.class)
+                .hasMessageContaining("엑셀 데이터 검증 실패");
+    }
+
+    @Test
+    @DisplayName("동아리원 일괄 등록 실패 - 파일 확장자 오류")
+    void registerMembersByExcel_Fail_InvalidExtension() {
+        // given
+        Long clubId = 1L;
+        MockMultipartFile file = new MockMultipartFile("file", "members.txt", "text/plain", "test".getBytes());
+
+        // when & then
+        assertThatThrownBy(() -> clubMemberService.registerMembersByExcel(clubId, file))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_FILE);
+    }
+
     private ClubMemberProfile createProfile(String name, String studentId, Role role) {
         User user = User.builder().name(name).studentId(studentId).build();
         Club club = Club.builder().build();
@@ -234,5 +327,23 @@ class ClubMemberServiceTest {
                 name, studentId, "010-1111-2222", "공과대학", "컴퓨터공학과",
                 AcademicStatus.ENROLLED, role, "2024-03"
         );
+    }
+
+    private MockMultipartFile createExcelFile(String fileName, List<List<String>> data) throws IOException {
+        try (Workbook workbook = new XSSFWorkbook()) {
+            Sheet sheet = workbook.createSheet("Members");
+            for (int i = 0; i < data.size(); i++) {
+                Row row = sheet.createRow(i);
+                List<String> rowData = data.get(i);
+                for (int j = 0; j < rowData.size(); j++) {
+                    row.createCell(j).setCellValue(rowData.get(j));
+                }
+            }
+            
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            workbook.write(bos);
+            return new MockMultipartFile("file", fileName, 
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", bos.toByteArray());
+        }
     }
 }

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/clubMember/service/ClubMemberServiceTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/clubMember/service/ClubMemberServiceTest.java
@@ -1,0 +1,89 @@
+package com.kakaotech.team18.backend_server.domain.clubMember.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.kakaotech.team18.backend_server.domain.club.repository.ClubRepository;
+import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubMemberResponseDto;
+import com.kakaotech.team18.backend_server.domain.clubMember.entity.AcademicStatus;
+import com.kakaotech.team18.backend_server.domain.clubMember.entity.ClubMemberProfile;
+import com.kakaotech.team18.backend_server.domain.clubMember.entity.Role;
+import com.kakaotech.team18.backend_server.domain.clubMember.repository.ClubMemberProfileRepository;
+import com.kakaotech.team18.backend_server.global.exception.exceptions.ClubNotFoundException;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ClubMemberServiceTest {
+
+    @InjectMocks
+    private ClubMemberServiceImpl clubMemberService;
+
+    @Mock
+    private ClubMemberProfileRepository clubMemberProfileRepository;
+
+    @Mock
+    private ClubRepository clubRepository;
+
+    @Test
+    @DisplayName("동아리원 목록 조회 성공 - 존재하는 동아리 ID")
+    void getClubMembers_Success() {
+        // given
+        Long clubId = 1L;
+        ClubMemberProfile profile1 = createProfile("이지훈", "212121", Role.CLUB_EXECUTIVE);
+        ClubMemberProfile profile2 = createProfile("김철수", "232323", Role.CLUB_MEMBER);
+
+        given(clubRepository.existsById(clubId)).willReturn(true);
+        given(clubMemberProfileRepository.findAllByClubId(clubId)).willReturn(List.of(profile1, profile2));
+
+        // when
+        List<ClubMemberResponseDto> result = clubMemberService.getClubMembers(clubId);
+
+        // then
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).name()).isEqualTo("이지훈");
+        assertThat(result.get(0).role()).isEqualTo(Role.CLUB_EXECUTIVE);
+        assertThat(result.get(1).name()).isEqualTo("김철수");
+        
+        verify(clubRepository, times(1)).existsById(clubId);
+        verify(clubMemberProfileRepository, times(1)).findAllByClubId(clubId);
+    }
+
+    @Test
+    @DisplayName("동아리원 목록 조회 실패 - 존재하지 않는 동아리 ID")
+    void getClubMembers_Fail_ClubNotFound() {
+        // given
+        Long invalidClubId = 999L;
+        given(clubRepository.existsById(invalidClubId)).willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> clubMemberService.getClubMembers(invalidClubId))
+                .isInstanceOf(ClubNotFoundException.class);
+        
+        verify(clubRepository, times(1)).existsById(invalidClubId);
+        verify(clubMemberProfileRepository, times(0)).findAllByClubId(anyLong());
+    }
+
+    private ClubMemberProfile createProfile(String name, String studentId, Role role) {
+        return ClubMemberProfile.builder()
+                .name(name)
+                .studentId(studentId)
+                .phoneNumber("010-1234-5678")
+                .college("공과대학")
+                .department("컴퓨터공학과")
+                .academicStatus(AcademicStatus.ENROLLED)
+                .joinDate(LocalDate.of(2024, 3, 1))
+                .role(role)
+                .build();
+    }
+}


### PR DESCRIPTION
## 🚀 작업 내용
동아리원 관리 기능 구현입니다.
PR을 나눠서 올리는게 좋았을 거 같은데 본의아니게 고봉밥이네요 .. 죄송합니다 나눠드셔주십쇼
총 6가지 기능입니다.

1. 동아리원 목록 조회 (GET)
기능: 특정 동아리의 전체 동아리원 프로필 목록을 조회합니다.
구현 포인트:
   - ClubMemberProfile 엔티티를 중심으로 조회하여 불필요한 조인을 최소화했습니다.
   - ClubMemberResponseDto를 통해 필요한 정보만 선별하여 응답합니다.
   - 존재하지 않는 동아리 조회 시 ClubNotFoundException 에러를 반환합니다.

2. 동아리원 수동 등록 (POST)
기능: 동아리원을 한 명씩 수동으로 등록하거나, 기존 정보를 갱신합니다.
구현 포인트:
   - 권한별 Role 정책: 회장은 운영진 임명이 가능하지만, 운영진은 일반부원만 등록 가능하도록 강제했습니다.
   - 기존 정보 갱신 로직: 학번이 같고 이름이 일치하면 '정보 수정'으로, 이름이 다르면 '중복 에러'로 처리했습니다
   - Lazy Activation: 미가입자도 등록 가능하며, 추후 가입 시 권한이 자동 활성화되도록 설계했습니다.

3. 동아리원 일괄 등록 (POST + Excel)
기능: 엑셀 파일을 업로드하여 다수의 동아리원을 한 번에 등록합니다.
구현 포인트:
   - Apache POI: 엑셀 파싱 유틸리티(ExcelUtils)를 구현하여 헤더 검증 및 데이터 추출을 수행합니다.
   - 전체 취소: 데이터 검증(형식/중복) 실패 시, 부분 저장이 아닌 전체 롤백을 수행하여 데이터 정합성을 보장합니다.
   - 통합 에러 리포트: 파싱 에러와 비즈니스 에러를 모두 수집하여 한 번에 상세한 에러 메시지를 반환합니다.

4. 동아리원 정보 수정 (PATCH)
기능: 동아리원의 프로필 정보(전화번호, 학과 등)를 부분 수정합니다.
구현 포인트:
   - 부분 업데이트: 변경할 필드만 요청에 포함하며, null이나 빈 문자열은 무시하고 기존 값을 유지합니다.
   - 중복 검사: 학번 변경 시, 해당 학번을 사용하는 다른 멤버가 있는지 확인하여 충돌을 방지합니다.
   - Role 수정 불가: 직책 변경은 별도 API로 분리하여 보안을 강화했습니다.
   
5. 동아리원 직책 변경 (PATCH)
기능: 동아리원의 직책(일반부원 <-> 운영진)을 변경합니다. (회장 전용)
구현 포인트:
   - 권한 제어: 오직 동아리 회장(CLUB_ADMIN)만 접근 가능하도록 @PreAuthorize 및 로직 검증을 적용했습니다.
   - 동기화: ClubMemberProfile뿐만 아니라 ClubMember 엔티티의 Role도 함께 업데이트하여 로그인 권한과 동기화했습니다.
   - 미가입자 승격: 미가입 상태에서도 운영진 임명이 가능하도록 유연하게 구현했습니다.
   
6. 동아리원 삭제 (DELETE)
기능: 동아리원을 목록에서 삭제합니다. (회장 전용)
구현 포인트:
   - Cascade Delete: ClubMember 삭제 시 연관된 ClubMemberProfile도 함께 삭제되도록 설정했습니다.
   - 안전장치: 회장이 자기 자신을 삭제하려는 시도를 막아(CannotDeleteSelfException) 동아리 관리 공백을 방지했습니다.
   - 권한 제어: 회장만 삭제 권한을 가지며, 운영진은 삭제할 수 없습니다.


## ⏱️ 소요 시간
5days

## 🤔 고민했던 내용

1. ClubMemberProfile 엔티티 분리 배경
	고민: 
		동아리원 관리 기능이 추가되면서 User 엔티티에 학적 정보 등을 넣을지 고민했습니다.
	
	결정: 
		User는 전역적인 회원 정보이므로, 
		동아리별로 달라질 수 있는 정보(학번, 학과, 직책 등)를 관리하기 위해 
		ClubMemberProfile을 별도로 분리했습니다.
	
	효과: 
		User 테이블의 비대화를 막고, 동아리별 독립적인 프로필 관리가 가능해지긴 했지만
		한편으로는 User 테이블과 ClubMember 테이블에 중복된 정보가 존재하게 되었고,
		이미 존재하는 데이터를 제대로 활용하고 있지 않아 아직도 찝찝하긴 합니다.. 
		그래도 다 뜯어고치는 것 보다는 나은 거 같아요 !
		
------------------------------------------------------------------------------		
2. 회장 전용 기능의 인가(Authorization) 처리
	고민: 
		직책 변경이나 삭제 등 회장만 가능한 기능의 권한 체크를 어떻게 할지 고민했습니다.
	
	결정: 
		API 진입점(@PreAuthorize)에서는 운영진까지 허용하되, 
		Service 계층에서 getUserRoleInClub을 통해 정밀하게 검증하는 방식을 택했습니다.
		
------------------------------------------------------------------------------		
3. 엑셀 일괄 등록 시 에러 처리 전략
	고민: 
		엑셀 파싱 중 형식 오류와 DB 저장 중 비즈니스 오류가 섞여서 발생할 때, 
		사용자에게 어떻게 알려줄지 고민했습니다.
		
	결정: 
		파싱 단계에서 멈추지 않고 모든 에러를 수집(Collect)한 뒤, 
		ExcelParsingException으로 한 번에 반환하도록 구현했습니다.
		
------------------------------------------------------------------------------				
4. 미가입자 권한 부여 (Lazy Activation)
	고민: 
		아직 앱에 가입하지 않은 동아리원을 운영진으로 임명할 때, 
		가입을 강제해야 할지 고민했습니다.
		
	결정: 
		"일단 직책은 부여하고, 권한 행사는 가입 후 로그인 시 활성화"되는 방식을 채택했습니다.
		
------------------------------------------------------------------------------				
5. 트랜잭션 전략: 
	고민: 
		엑셀 업로드 시 일부만 성공하고 일부는 실패하는 '부분 성공'을 허용할지 고민했습니다.
	
	결정: 
		데이터 정합성을 위해 "하나라도 실패하면 전체 롤백"하는 전략을 선택했습니다.

## 💬 리뷰 중점사항
위 고민했던 내용에 작성한 부분에 대해서 좋은 의견 있으시면 말씀해주세요.
테스트가 커버하지 못한 로직이 있다면 말씀해주세요.

## 🔗관련 이슈
- Close #279

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 동아리 회원 관리 API 추가: 조회, 등록(단건/엑셀), 수정, 직책 변경, 삭제(자기 삭제 방지 포함)
  * 관련 DTO/엔티티 및 엑셀 파싱 유틸(헤더/행 검증, 포맷 검사, 오류 집계) 추가

* **Chores**
  * 엑셀 처리용 라이브러리(Apache POI) 추가
  * 오류 코드 및 전역 예외 처리기 확장(엑셀 오류, 자기삭제 불가)

* **Tests**
  * 회원관리 서비스 단위 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->