### PR TITLE
[FIX] 회장직 이양 로직 수정

### DIFF
--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/service/ClubMemberServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/service/ClubMemberServiceImpl.java
@@ -222,8 +222,8 @@ public class ClubMemberServiceImpl implements ClubMemberService {
             // 기존 회장이 존재하고, 그 사람이 이번에 임명되는 사람이 아니라면 강등
             if (currentAdminProfile.isPresent() && !currentAdminProfile.get().getId().equals(profileId)) {
                 ClubMemberProfile oldAdmin = currentAdminProfile.get();
-                oldAdmin.updateRole(Role.CLUB_MEMBER); // 일반 부원으로 강등
-                oldAdmin.getClubMember().updateRole(Role.CLUB_MEMBER);
+                oldAdmin.updateRole(Role.CLUB_EXECUTIVE); // 운영진으로 강등
+                oldAdmin.getClubMember().updateRole(Role.CLUB_EXECUTIVE);
             }
         }
 

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/clubMember/service/ClubMemberServiceTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/clubMember/service/ClubMemberServiceTest.java
@@ -398,7 +398,7 @@ class ClubMemberServiceTest {
         // then
         assertThat(result.newRole()).isEqualTo(Role.CLUB_ADMIN);
         assertThat(newAdmin.getRole()).isEqualTo(Role.CLUB_ADMIN); // 새 회장 승격 확인
-        assertThat(oldAdmin.getRole()).isEqualTo(Role.CLUB_MEMBER); // 기존 회장 강등 확인
+        assertThat(oldAdmin.getRole()).isEqualTo(Role.CLUB_EXECUTIVE); // 기존 회장 운영진으로 강등 확인
     }
 
     @Test


### PR DESCRIPTION
## 🚀 작업 내용
회장직 이양 시 기존 회장을 운영진(EXECUTIVE)으로 변경하도록 정책 수정

기존에는 회장직 이양 시 기존 회장을 동아리원(CLUB_MEMBER)로 변경했는데 
아무래도 곧바로 관리 페이지에 대한 접근이 차단되다보니 
운영진으로 역할을 변경하는게 나을거라고 판단했습니다.

## ⏱️ 소요 시간
30m

## 🤔 고민했던 내용
회장직 이양 정책을 변경한게 더 나을지 

## 💬 리뷰 중점사항
테스트코드 커버하지 못한 부분 있으면 알려주세요 !

## 🔗관련 이슈
- 이슈 만드는 거 까먹어버림 ㅎ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 새 클럽 관리자가 지정될 때 이전 관리자를 일반 회원이 아닌 임원 역할로 강등하도록 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->