### PR TITLE
[FIX] 모니터링 포트 수정 및 Nginx, CD 파일 수정

### DIFF
--- a/.github/workflows/deploy-with-docker.yml
+++ b/.github/workflows/deploy-with-docker.yml
@@ -96,7 +96,7 @@ jobs:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USERNAME }}
           key: ${{ secrets.EC2_PRIVATE_KEY }}
-          source: "docker-compose.yml"
+          source: "docker-compose.yml,docker-compose.monitoring.yml,monitoring/"
           target: "${{ env.REMOTE_DIR }}/current"
 
       - name: Deploy on EC2 (create .env, set credHelpers, compose up)
@@ -197,3 +197,5 @@ jobs:
             ECR_REGISTRY="$REG" docker compose down || true
             ECR_REGISTRY="$REG" docker compose up -d --remove-orphans
             docker compose ps
+            # 모니터링 스택 실행 명령어
+            docker compose -f docker-compose.monitoring.yml up -d

--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -15,7 +15,7 @@ services:
       - ./monitoring/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - prometheus_data:/prometheus
     ports:
-      - "9090:9090"
+      - "127.0.0.1:9090:9090"
     deploy:
       resources:
         limits:
@@ -44,7 +44,7 @@ services:
       - grafana_data:/var/lib/grafana
       - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
     ports:
-      - "3000:3000"
+      - "127.0.0.1:3000:3000"
     depends_on:
       - prometheus
       - loki
@@ -65,7 +65,7 @@ services:
       - ./monitoring/loki/loki-config.yml:/etc/loki/loki-config.yml:ro
       - loki_data:/loki
     ports:
-      - "3100:3100"
+      - "127.0.0.1:3100:3100"
     deploy:
       resources:
         limits:


### PR DESCRIPTION
## 🚀 작업 내용
모니터링 관련된 프로세스들의 포트가 AWS Inbound rules에 안 열려 있었고, 
(애초에 안 여는게 맞는 거 같아요 !)
(443, 80 포트 제외 모든 포트를 닫아도 괜찮을 거 같습니다.)

SCP로 docker-compose.monitoring.yml 파일 전송이 이루어지지 않고 있었음.

모니터링 관련 프로세스로 향하는 트래픽이 
Nginx를 거쳤다가 Nginx에서 127.0.0.1:포트 로 트래픽을 전달하도록 수정했습니다.

일단 현재 동아리움 시스템이 Nginx를 인스턴스에 직접 설치하고 있어서 
Nginx 설정 파일은 PR에 올려지지 않는데 
급한 불부터 끄고 이후에 Nginx도 Container로 띄우도록 바꿔야할 거 같네요 !

만약 CD 안 깨지고 문제없이 진행된다면 
monitor.dongarium.co.kr 링크 접속하면 모니터링 확인 가능할 거 같습니다 !
-> 서브도메인, Nginx 활용 (IP는 동일합니다)

## ⏱️ 소요 시간
3h

## 🤔 고민했던 내용
해당 PR 내용은 아닌데 
Nginx 설정 읽다보니까 CDN을 CDN 답지않게 활용하고 있었더라구요
다른 이슈 파서 해결하겠습니다 !

## 💬 리뷰 중점사항
오류나면 긴급 롤백 해주실 분 구하는중 

## 🔗관련 이슈
- Close #이슈 만드는 거 까먹음 ㅎ