### PR TITLE
[FIX] 회장직 이양 로직 ClubMember 기반으로 변경

### DIFF
--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/service/ClubMemberServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/service/ClubMemberServiceImpl.java
@@ -208,7 +208,7 @@ public class ClubMemberServiceImpl implements ClubMemberService {
             throw new CustomException(ErrorCode.FORBIDDEN, "동아리원 직책 변경은 회장만 가능합니다.");
         }
 
-        // 2. 프로필 조회
+        // 2. 프로필 조회 (대상)
         ClubMemberProfile profile = clubMemberProfileRepository.findByIdAndClubId(profileId, clubId)
                 .orElseThrow(() -> new CustomException(ErrorCode.CLUB_MEMBER_NOT_FOUND, "profileId: " + profileId));
 
@@ -217,13 +217,18 @@ public class ClubMemberServiceImpl implements ClubMemberService {
 
         // 3. 회장직 이양 로직 (새로운 역할이 회장인 경우)
         if (newRole == Role.CLUB_ADMIN) {
-            Optional<ClubMemberProfile> currentAdminProfile = clubMemberProfileRepository.findByClubMember_Club_IdAndRole(clubId, Role.CLUB_ADMIN);
+            // ClubMember 테이블 기준으로 현재 회장 조회 (프로필 유무 상관없이)
+            Optional<ClubMember> currentAdminMember = clubMemberRepository.findClubAdminByClubIdAndRole(clubId, Role.CLUB_ADMIN);
             
             // 기존 회장이 존재하고, 그 사람이 이번에 임명되는 사람이 아니라면 강등
-            if (currentAdminProfile.isPresent() && !currentAdminProfile.get().getId().equals(profileId)) {
-                ClubMemberProfile oldAdmin = currentAdminProfile.get();
+            if (currentAdminMember.isPresent() && !currentAdminMember.get().getId().equals(profile.getClubMember().getId())) {
+                ClubMember oldAdmin = currentAdminMember.get();
                 oldAdmin.updateRole(Role.CLUB_EXECUTIVE); // 운영진으로 강등
-                oldAdmin.getClubMember().updateRole(Role.CLUB_EXECUTIVE);
+                
+                // 프로필이 있다면 프로필도 동기화
+                if (oldAdmin.getProfile() != null) {
+                    oldAdmin.getProfile().updateRole(Role.CLUB_EXECUTIVE);
+                }
             }
         }
 

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/clubMember/service/ClubMemberServiceTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/clubMember/service/ClubMemberServiceTest.java
@@ -386,11 +386,18 @@ class ClubMemberServiceTest {
         ClubMemberProfile oldAdmin = createProfile(oldAdminProfileId, 100L, "나회장", "111111", Role.CLUB_ADMIN);
         ClubMemberProfile newAdmin = createProfile(newAdminProfileId, 200L, "너회장", "222222", Role.CLUB_MEMBER);
         
+        // oldAdmin의 ClubMember ID 설정 (비교 로직에서 사용)
+        ReflectionTestUtils.setField(oldAdmin.getClubMember(), "id", 1000L);
+        ReflectionTestUtils.setField(newAdmin.getClubMember(), "id", 2000L);
+
         ClubMemberRoleUpdateRequestDto requestDto = new ClubMemberRoleUpdateRequestDto(Role.CLUB_ADMIN);
 
         given(customSecurityService.getUserRoleInClub(clubId)).willReturn(Role.CLUB_ADMIN);
         given(clubMemberProfileRepository.findByIdAndClubId(newAdminProfileId, clubId)).willReturn(Optional.of(newAdmin));
-        given(clubMemberProfileRepository.findByClubMember_Club_IdAndRole(clubId, Role.CLUB_ADMIN)).willReturn(Optional.of(oldAdmin));
+        
+        // ★ 수정됨: ClubMemberRepository Mocking
+        given(clubMemberRepository.findClubAdminByClubIdAndRole(clubId, Role.CLUB_ADMIN))
+                .willReturn(Optional.of(oldAdmin.getClubMember()));
 
         // when
         ClubMemberRoleUpdateResponseDto result = clubMemberService.updateMemberRole(clubId, newAdminProfileId, requestDto);
@@ -398,7 +405,7 @@ class ClubMemberServiceTest {
         // then
         assertThat(result.newRole()).isEqualTo(Role.CLUB_ADMIN);
         assertThat(newAdmin.getRole()).isEqualTo(Role.CLUB_ADMIN); // 새 회장 승격 확인
-        assertThat(oldAdmin.getRole()).isEqualTo(Role.CLUB_EXECUTIVE); // 기존 회장 운영진으로 강등 확인
+        assertThat(oldAdmin.getRole()).isEqualTo(Role.CLUB_EXECUTIVE); // 기존 회장 강등 확인
     }
 
     @Test


### PR DESCRIPTION
## 🚀 작업 내용

기존 로직: 회장직 이양 시, 기존 회장을 찾기 위해 ClubMemberProfile 테이블을 조회했습니다.

문제점:

1. 데이터 불일치: ClubMember 테이블에는 회장(CLUB_ADMIN)으로 되어 있지만, ClubMemberProfile이 없거나 Role이 다른 경우(초기 멤버 등)가 존재했습니다.
2. 강등 실패: 위 경우 Profile 조회에 실패하여, 기존 회장의 권한 회수(강등) 로직이 실행되지 않는 이슈가 발생했습니다.
-----

개선 내용 

조회 기준 변경 (Profile -> Member)

변경 전: clubMemberProfileRepository.findBy... (프로필 기준)
변경 후: clubMemberRepository.findClubAdminByClubIdAndRole... (본체 기준)

효과:  프로필 유무와 상관없이, 실제 권한(ClubMember.role)을 가진 회장을 정확하게 찾아낼 수 있습니다.

-----

동기화 강화

찾아낸 ClubMember의 Role을 먼저 변경하고, 연결된 Profile이 있다면 그것도 함께 변경하도록 로직을 강화했습니다.

## ⏱️ 소요 시간
30m

## 🤔 고민했던 내용
ClubMember 테이블과 User 테이블이 있음에도 ClubMemberProfile 테이블을 별도로 만든 이유는 아래와 같습니다.

동아리원 관리 기능이 추가되면서 
학번, 학과, 학적 상태, 직책 등 동아리 활동에 특화된 정보를 저장할 공간이 필요했습니다. 

처음에는 전역 회원 정보를 담는 User 엔티티나 
동아리 가입 정보를 담는 ClubMember 엔티티를 확장하는 방안을 고려했습니다. 

하지만 User에 정보를 추가하면 
동아리별로 상이한 정보(예: A 동아리에서는 회장, B 동아리에서는 일반 부원)를 표현할 수 없다는 한계가 있었고, 

ClubMember에 모든 정보를 넣으면 테이블이 지나치게 비대해지며 
가입 정보(관계)와 상세 프로필(속성)의 책임이 모호해지는 문제가 있었습니다.

이에 따라 동아리별 동아리원 상세 정보를 별도 테이블로 관리하는 ClubMemberProfile 엔티티 분리 방식을 채택했습니다. 
이를 통해 User(인증), ClubMember(소속), Profile(상세 정보)의 역할을 명확히 분리하고,
동아리별로 독립적인 프로필 관리가 가능한 확장성을 확보할 수 있었습니다.

하지만 이 과정에서 불가피하게 Role(직책) 데이터의 중복 문제가 발생했습니다. 
Role은 Spring Security와 연동된 핵심 인가 데이터로서 ClubMember에 필수적이었고, 
동시에 엑셀 업로드 등을 통한 명부 관리 및 조회를 위해 ClubMemberProfile에도 필요했기 때문입니다.

이러한 이유 때문에 이번 PR 에서도 하나의 테이블에만 Role을 남기진 않습니다.
읽어보시고 다른 의견있으시면 제안해주세요 !

## 💬 리뷰 중점사항
위와 같습니다.

## 🔗관련 이슈
- Close #이슈 만드는 거 까먹음 ㅎ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * 클럽 관리자 역할 전환 처리 로직을 개선하여 더욱 안정적인 동작을 구현했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->