### PR TITLE
[FIX] ClubMemberProfile과 ClubMember 테이블 간의 데이터 불일치 해소

### DIFF
--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/repository/ClubMemberRepository.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/repository/ClubMemberRepository.java
@@ -104,4 +104,6 @@ public interface ClubMemberRepository extends JpaRepository<ClubMember, Long> {
     @Query("update ClubMember cm set cm.application = null where cm.application.id = :applicationId")
     int clearApplicationByApplicationId(Long applicationId);
 
+    // User ID와 Club ID로 ClubMember 조회
+    Optional<ClubMember> findByUserIdAndClubId(Long userId, Long clubId);
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/service/ClubMemberServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/service/ClubMemberServiceImpl.java
@@ -63,9 +63,11 @@ public class ClubMemberServiceImpl implements ClubMemberService {
         Role currentUserRole = customSecurityService.getUserRoleInClub(clubId);
 
         // 2. Role 결정
-        Role targetRole = requestDto.role();
+        Role targetRole;
         if (currentUserRole == Role.CLUB_EXECUTIVE) {
             targetRole = Role.CLUB_MEMBER; // 운영진은 무조건 일반부원으로 등록
+        } else {
+            targetRole = requestDto.role();
         }
 
         // 3. 기존 프로필 조회 (학번 기준)
@@ -98,22 +100,41 @@ public class ClubMemberServiceImpl implements ClubMemberService {
             
             return ClubMemberResponseDto.from(profile);
         } else {
-            // 5. 존재하지 않으면 신규 등록
+            // 5. 존재하지 않으면 신규 등록 (또는 기존 ClubMember에 프로필 연결)
             Club club = clubRepository.findById(clubId)
                     .orElseThrow(() -> new CustomException(ErrorCode.CLUB_NOT_FOUND, "clubId: " + clubId));
 
             User user = userRepository.findByStudentId(requestDto.studentId())
                     .orElseGet(() -> createShellUser(requestDto));
 
-            ClubMember clubMember = ClubMember.builder()
-                    .user(user)
-                    .club(club)
-                    .activeStatus(ActiveStatus.ACTIVE)
-                    .role(targetRole) // ClubMember의 role도 결정된 Role로 설정
-                    .build();
+            // 기존 ClubMember가 있는지 확인
+            ClubMember clubMember = clubMemberRepository.findByUserIdAndClubId(user.getId(), clubId)
+                    .orElseGet(() -> ClubMember.builder()
+                            .user(user)
+                            .club(club)
+                            .activeStatus(ActiveStatus.ACTIVE)
+                            .role(targetRole)
+                            .build());
+            
+            // Profile에 저장될 최종 Role 결정
+            Role finalRole = targetRole;
+            
+            // 기존 ClubMember가 있다면
+            if (clubMember.getId() != null) {
+                // 회장이면 요청받은 Role로 업데이트
+                if (currentUserRole == Role.CLUB_ADMIN) {
+                    clubMember.updateRole(targetRole);
+                } else {
+                    // 운영진이면 기존 Role 유지 (강등 방지)
+                    // 만약 기존 Role이 더 높다면 Profile도 그 Role을 따라가야 함
+                    if (clubMember.getRole() == Role.CLUB_EXECUTIVE || clubMember.getRole() == Role.CLUB_ADMIN) {
+                        finalRole = clubMember.getRole();
+                    }
+                }
+            }
 
             ClubMemberProfile profile = ClubMemberProfile.builder()
-                    .clubMember(clubMember)
+                    .clubMember(clubMember) // 연관관계 설정
                     .name(requestDto.name())
                     .studentId(requestDto.studentId())
                     .phoneNumber(requestDto.phoneNumber())
@@ -121,7 +142,7 @@ public class ClubMemberServiceImpl implements ClubMemberService {
                     .department(requestDto.department())
                     .academicStatus(requestDto.academicStatus())
                     .joinDate(parseJoinDate(requestDto.joinDate()))
-                    .role(targetRole)
+                    .role(finalRole) // 보정된 Role 사용
                     .build();
 
             clubMember.setProfile(profile);
@@ -162,6 +183,7 @@ public class ClubMemberServiceImpl implements ClubMemberService {
                 // registerMember 내부에서 발생한 비즈니스 예외를 수집
                 parseResult.addError(String.format("학번 %s: %s", dto.studentId(), e.getMessage()));
             } catch (Exception e) {
+                // 그 외 예상치 못한 예외 수집
                 parseResult.addError(String.format("학번 %s: 알 수 없는 오류가 발생했습니다. (%s)", dto.studentId(), e.getMessage()));
             }
         }


### PR DESCRIPTION
## 🚀 작업 내용

동아리원 등록 로직 개선 (데이터 정합성 강화)

1. 배경 및 문제점 

ClubMember (시스템 권한)와 ClubMemberProfile (명부 정보)이 분리되어 있어, 
두 테이블 간 데이터 불일치(Inconsistency)가 발생할 수 있는 구조입니다.

 문제 1: 

중복 생성 시도 (Unique 제약 위반)
회원가입 등으로 ClubMember는 이미 존재하는데 Profile은 없는 상태(유령 회원)에서, 
엑셀/수동 등록을 시도하면 ClubMember를 또 생성하려고 하여 에러가 발생했습니다.

 문제 2: 

운영진에 의한 권한 강등 
운영진이 다른 운영진(또는 회장)의 정보를 수정/등록할 때, 시스템 정책상 targetRole이 MEMBER로 고정되므로, 
의도치 않게 상위 권한자가 일반부원으로 강등되는 문제가 있었습니다.

-----

2. 개선 내용

A. 기존 ClubMember 재사용 로직 추가 

변경 전: Profile이 없으면 무조건 ClubMember와 Profile을 신규 생성(new).

변경 후:
1.userRepository.findByStudentId로 유저 조회.
2.clubMemberRepository.findByUserIdAndClubId로 기존 멤버십 조회.
3.존재 시: 기존 ClubMember 객체를 가져와서 Profile과 연결.
4.미존재 시: 신규 ClubMember 생성.

효과: 유령 회원이 존재하더라도 에러 없이 프로필을 생성하고 연결하여 정상 회원으로 전환합니다.

B. Role 동기화 및 강등 방지 로직

회장이 등록하는 경우:
ClubMember와 Profile 모두 요청받은 Role(targetRole)로 업데이트합니다. (권한 부여/박탈 가능)

운영진이 등록하는 경우:
ClubMember의 Role은 건드리지 않습니다. (권한 변경 불가)
Profile의 Role은 "기존 권한을 존중"하여 결정합니다.

기존 Role(EXECUTIVE 등)이 요청 Role(MEMBER)보다 높다면 -> 기존 Role 유지.
그렇지 않다면 -> 요청 Role(MEMBER) 적용.

효과: 운영진이 명부를 관리하더라도 상위 권한자의 직책을 훼손하지 않으면서 프로필 정보를 최신화할 수 있습니다.

-----

3. 핵심 코드 요약 (Pseudo Code)


```
// 1. 기존 멤버십 조회
ClubMember clubMember = repository.findByUserIdAndClubId(...)

    .orElseGet(() -> new ClubMember(...));

// 2. Role 결정 로직
Role finalRole = targetRole; // 기본값 (요청받은 Role)

if (clubMember.getId() != null) { // 기존 멤버라면
    if (currentUser == ADMIN) {
        // 회장은 권한 변경 가능
        clubMember.updateRole(targetRole);
    } else {
        // 운영진은 권한 변경 불가 & 강등 방지
        if (clubMember.getRole() >= EXECUTIVE) {
            finalRole = clubMember.getRole(); // 기존 높은 권한 유지
        }
    }
}

// 3. 프로필 생성 및 저장
Profile profile = Profile.builder()
    .clubMember(clubMember)
    .role(finalRole) // 보정된 Role 사용
    .build();

```

## ⏱️ 소요 시간
1h

## 🤔 고민했던 내용
데이터 불일치 요소가 여전히 존재하는지

## 💬 리뷰 중점사항
데이터 불일치 요소가 여전히 존재하는지


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **개선 사항**
  * 클럽 멤버 등록 시 역할 할당 규칙을 개선하여 더 정확한 권한 관리가 가능하도록 변경되었습니다.
  * 기존 멤버를 클럽에 추가할 때 역할 충돌을 방지하고 높은 권한을 보존하도록 처리 로직이 강화되었습니다.
  * 멤버 조회 성능 최적화를 위한 기능이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->