### PR TITLE
[FEATURE] 동아리원 추가를 위한 기본 엑셀 파일 다운로드 기능 구현

### DIFF
--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/controller/ClubMemberController.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/controller/ClubMemberController.java
@@ -17,7 +17,9 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.List;
+import java.net.URI;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -39,6 +41,16 @@ import org.springframework.web.multipart.MultipartFile;
 public class ClubMemberController {
 
     private final ClubMemberService clubMemberService;
+
+    @Operation(summary = "동아리원 일괄 등록 양식 다운로드", description = "동아리원 일괄 등록을 위한 엑셀 양식 파일의 다운로드 URL을 반환합니다.")
+    @ApiResponse(responseCode = "302", description = "S3 URL로 리다이렉트")
+    @GetMapping("/members/registration-form")
+    public ResponseEntity<Void> getRegistrationForm() {
+        String url = clubMemberService.getRegistrationFormUrl();
+        return ResponseEntity.status(HttpStatus.FOUND)
+                .location(URI.create(url))
+                .build();
+    }
 
     @Operation(summary = "동아리원 목록 조회", description = "특정 동아리의 전체 동아리원 목록을 조회합니다.")
     @ApiResponses({

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/repository/ClubMemberRepository.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/repository/ClubMemberRepository.java
@@ -104,4 +104,6 @@ public interface ClubMemberRepository extends JpaRepository<ClubMember, Long> {
     @Query("update ClubMember cm set cm.application = null where cm.application.id = :applicationId")
     int clearApplicationByApplicationId(Long applicationId);
 
+    // User ID와 Club ID로 ClubMember 조회
+    Optional<ClubMember> findByUserIdAndClubId(Long userId, Long clubId);
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/service/ClubMemberService.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/service/ClubMemberService.java
@@ -16,4 +16,5 @@ public interface ClubMemberService {
     ClubMemberResponseDto updateMember(Long clubId, Long profileId, ClubMemberUpdateRequestDto requestDto);
     ClubMemberRoleUpdateResponseDto updateMemberRole(Long clubId, Long profileId, ClubMemberRoleUpdateRequestDto requestDto);
     ClubMemberDeleteResponseDto deleteMember(Long clubId, Long profileId);
+    String getRegistrationFormUrl();
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/service/ClubMemberServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/service/ClubMemberServiceImpl.java
@@ -31,6 +31,7 @@ import java.time.format.DateTimeParseException;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -45,6 +46,12 @@ public class ClubMemberServiceImpl implements ClubMemberService {
     private final UserRepository userRepository;
     private final ClubRepository clubRepository;
     private final CustomSecurityService customSecurityService;
+
+    @Value("${cloud.aws.s3.bucket-attachments}")
+    private String attachmentBucket;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
 
     @Override
     public List<ClubMemberResponseDto> getClubMembers(Long clubId) {
@@ -284,6 +291,12 @@ public class ClubMemberServiceImpl implements ClubMemberService {
                 "해당 동아리원이 목록에서 삭제되었습니다.",
                 profileId
         );
+    }
+
+    @Override
+    public String getRegistrationFormUrl() {
+        return String.format("https://%s.s3.%s.amazonaws.com/%s",
+                attachmentBucket, region, "templates/members_template.xlsx");
     }
 
 

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/service/ClubMemberServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/service/ClubMemberServiceImpl.java
@@ -70,9 +70,11 @@ public class ClubMemberServiceImpl implements ClubMemberService {
         Role currentUserRole = customSecurityService.getUserRoleInClub(clubId);
 
         // 2. Role 결정
-        Role targetRole = requestDto.role();
+        Role targetRole;
         if (currentUserRole == Role.CLUB_EXECUTIVE) {
             targetRole = Role.CLUB_MEMBER; // 운영진은 무조건 일반부원으로 등록
+        } else {
+            targetRole = requestDto.role();
         }
 
         // 3. 기존 프로필 조회 (학번 기준)
@@ -105,22 +107,41 @@ public class ClubMemberServiceImpl implements ClubMemberService {
             
             return ClubMemberResponseDto.from(profile);
         } else {
-            // 5. 존재하지 않으면 신규 등록
+            // 5. 존재하지 않으면 신규 등록 (또는 기존 ClubMember에 프로필 연결)
             Club club = clubRepository.findById(clubId)
                     .orElseThrow(() -> new CustomException(ErrorCode.CLUB_NOT_FOUND, "clubId: " + clubId));
 
             User user = userRepository.findByStudentId(requestDto.studentId())
                     .orElseGet(() -> createShellUser(requestDto));
 
-            ClubMember clubMember = ClubMember.builder()
-                    .user(user)
-                    .club(club)
-                    .activeStatus(ActiveStatus.ACTIVE)
-                    .role(targetRole) // ClubMember의 role도 결정된 Role로 설정
-                    .build();
+            // 기존 ClubMember가 있는지 확인
+            ClubMember clubMember = clubMemberRepository.findByUserIdAndClubId(user.getId(), clubId)
+                    .orElseGet(() -> ClubMember.builder()
+                            .user(user)
+                            .club(club)
+                            .activeStatus(ActiveStatus.ACTIVE)
+                            .role(targetRole)
+                            .build());
+            
+            // Profile에 저장될 최종 Role 결정
+            Role finalRole = targetRole;
+            
+            // 기존 ClubMember가 있다면
+            if (clubMember.getId() != null) {
+                // 회장이면 요청받은 Role로 업데이트
+                if (currentUserRole == Role.CLUB_ADMIN) {
+                    clubMember.updateRole(targetRole);
+                } else {
+                    // 운영진이면 기존 Role 유지 (강등 방지)
+                    // 만약 기존 Role이 더 높다면 Profile도 그 Role을 따라가야 함
+                    if (clubMember.getRole() == Role.CLUB_EXECUTIVE || clubMember.getRole() == Role.CLUB_ADMIN) {
+                        finalRole = clubMember.getRole();
+                    }
+                }
+            }
 
             ClubMemberProfile profile = ClubMemberProfile.builder()
-                    .clubMember(clubMember)
+                    .clubMember(clubMember) // 연관관계 설정
                     .name(requestDto.name())
                     .studentId(requestDto.studentId())
                     .phoneNumber(requestDto.phoneNumber())
@@ -128,7 +149,7 @@ public class ClubMemberServiceImpl implements ClubMemberService {
                     .department(requestDto.department())
                     .academicStatus(requestDto.academicStatus())
                     .joinDate(parseJoinDate(requestDto.joinDate()))
-                    .role(targetRole)
+                    .role(finalRole) // 보정된 Role 사용
                     .build();
 
             clubMember.setProfile(profile);
@@ -169,6 +190,7 @@ public class ClubMemberServiceImpl implements ClubMemberService {
                 // registerMember 내부에서 발생한 비즈니스 예외를 수집
                 parseResult.addError(String.format("학번 %s: %s", dto.studentId(), e.getMessage()));
             } catch (Exception e) {
+                // 그 외 예상치 못한 예외 수집
                 parseResult.addError(String.format("학번 %s: 알 수 없는 오류가 발생했습니다. (%s)", dto.studentId(), e.getMessage()));
             }
         }

--- a/src/main/java/com/kakaotech/team18/backend_server/global/config/SecurityConfig.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/config/SecurityConfig.java
@@ -75,6 +75,8 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.GET, "/api/clubs", "/api/clubs/*").permitAll()
                 // 지원서 양식 조회 API (공개)
                 .requestMatchers(HttpMethod.GET, "/api/clubs/*/apply").permitAll()
+                // 동아리원 일괄 등록 양식 다운로드 API (공개)
+                .requestMatchers(HttpMethod.GET, "/api/clubs/members/registration-form").permitAll()
                 // 지원서 제출 API (공개)
                 .requestMatchers(HttpMethod.POST, "/api/clubs/*/apply-submit").permitAll()
                 // 동아리 후기 조회 및 등록 API (공개)


### PR DESCRIPTION
## 🚀 작업 내용
동아리원 추가 페이지에서 기본 양식으로 다운로드해서 사용할 수 있도록 
S3 버킷에 엑셀파일 만들어 추가하고 엔드포인트 제공했습니다.

S3 버킷에 members-template.xlsx 추가
(https://dongarium-attachments.s3.ap-northeast-2.amazonaws.com/templates/members_template.xlsx)

S3 버킷 Object URL로 리다이렉트하는
엔드포인트 추가 (api/clubs/member/registration-form)


## ⏱️ 소요 시간
1h

## 🤔 고민했던 내용
엑셀은 교양 수업때 다뤄본게 전부라 엑셀 내에서 데이터 양식 만지기 편하도록 하는 기능같은 건 정말 가볍게만 제공합니다.
(교양 수업에서 배운것만)
엑셀 잘하시는 분 있으시면 첨언 부탁드립니다.

## 💬 리뷰 중점사항
테스트는 Postman + 로컬에서 진행했습니다.
Obejct URL 이용해서 엑셀 파일 다운로드 되는지만 확인 부탁드립니다

## 🔗관련 이슈
- Close #만드는 거 까먹음 ㅎ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 회원 등록 양식 다운로드용 공개 API가 추가되어 별도 인증 없이 양식을 받을 수 있습니다.
* **개선**
  * 회원 등록 시 기존 멤버 재사용 및 역할 처리 로직이 개선되어 관리자/임원 권한에 따른 역할 적용이 보다 일관되게 동작합니다.
  * 엑셀로 대량 등록할 때 예외 처리와 오류 수집이 강화되어 실패 원인 파악이 쉬워졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->