### PR TITLE
[FIX] interviewSchedule필드 값이 빈 리스트로 반환되는 문제 해결 (#280)

### DIFF
--- a/src/main/java/com/kakaotech/team18/backend_server/domain/club/service/ClubServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/club/service/ClubServiceImpl.java
@@ -32,11 +32,12 @@ import com.kakaotech.team18.backend_server.global.exception.exceptions.ClubNotFo
 import com.kakaotech.team18.backend_server.global.service.S3Service;
 import com.kakaotech.team18.backend_server.global.util.DateUtil;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
+import java.util.TreeMap;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
@@ -49,6 +50,7 @@ import org.springframework.web.multipart.MultipartFile;
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class ClubServiceImpl implements ClubService {
+    private static final int INTERVIEW_SLOT_MINUTES = 30;
 
     private final ClubRepository clubRepository;
     private final ApplicationRepository applicationRepository;
@@ -161,24 +163,10 @@ public class ClubServiceImpl implements ClubService {
 
         List<InterviewSlotCountProjection> rows = applicationRepository.countInterviewSlots(clubId);
 
-        Map<LocalDate, Map<LocalTime, Integer>> grouped = getLocalDateMap(rows);
+        Map<LocalDate, Map<LocalTime, Integer>> grouped = buildInterviewScheduleTemplate(clubApplyForm.getClub());
+        mergeAssignedInterviewCounts(grouped, rows != null ? rows : List.of());
 
-        List<InterviewDateSlotsDto> interviewSchedule =
-                grouped.entrySet().stream()
-                        .sorted(Map.Entry.comparingByKey())
-                        .map(dateEntry -> new InterviewDateSlotsDto(
-                                dateEntry.getKey(),
-                                dateEntry.getValue().entrySet().stream()
-                                        .sorted(Map.Entry.comparingByKey())
-                                        .map(timeEntry ->
-                                                new InterviewSlotCountDto(
-                                                        timeEntry.getKey(),
-                                                        timeEntry.getValue()
-                                                )
-                                        )
-                                        .toList()
-                        ))
-                        .toList();
+        List<InterviewDateSlotsDto> interviewSchedule = convertToInterviewSchedule(grouped);
         return new ClubDashboardApplicantResponseDto(
                 clubApplyForm.getClub().getIsInterviewRequired(),
                 applicants
@@ -234,15 +222,68 @@ public class ClubServiceImpl implements ClubService {
         return new SuccessResponseDto(true);
     }
 
-    private Map<LocalDate, Map<LocalTime, Integer>> getLocalDateMap(List<InterviewSlotCountProjection> rows) {
-        return rows.stream()
-                .collect(Collectors.groupingBy(
-                        InterviewSlotCountProjection::getInterviewDate,
-                        Collectors.toMap(
-                                InterviewSlotCountProjection::getInterviewTime,
-                                r -> (int) r.getAssignedCount()
-                        )
-                ));
+    private Map<LocalDate, Map<LocalTime, Integer>> buildInterviewScheduleTemplate(Club club) {
+        Map<LocalDate, Map<LocalTime, Integer>> schedule = new TreeMap<>();
+        if (Boolean.FALSE.equals(club.getIsInterviewRequired())) {
+            return schedule;
+        }
+
+        LocalDateTime interviewStartDateTime = club.getInterviewStartDate();
+        LocalDateTime interviewEndDateTime = club.getInterviewEndDate();
+        LocalTime interviewStartTime = club.getInterviewStartTime();
+        LocalTime interviewEndTime = club.getInterviewEndTime();
+
+        if (interviewStartDateTime == null || interviewEndDateTime == null
+                || interviewStartTime == null || interviewEndTime == null) {
+            return schedule;
+        }
+
+        LocalDate startDate = interviewStartDateTime.toLocalDate();
+        LocalDate endDate = interviewEndDateTime.toLocalDate();
+
+        if (startDate.isAfter(endDate)) {
+            return schedule;
+        }
+        if (!interviewStartTime.isBefore(interviewEndTime)) {
+            return schedule;
+        }
+
+        for (LocalDate date = startDate; !date.isAfter(endDate); date = date.plusDays(1)) {
+            Map<LocalTime, Integer> slots = new TreeMap<>();
+            for (LocalTime time = interviewStartTime; time.isBefore(interviewEndTime); time = time.plusMinutes(INTERVIEW_SLOT_MINUTES)) {
+                slots.put(time, 0);
+            }
+            schedule.put(date, slots);
+        }
+        return schedule;
+    }
+
+    private void mergeAssignedInterviewCounts(Map<LocalDate, Map<LocalTime, Integer>> grouped, List<InterviewSlotCountProjection> rows) {
+        for (InterviewSlotCountProjection row : rows) {
+            LocalDate date = row.getInterviewDate();
+            LocalTime time = row.getInterviewTime();
+            if (date == null || time == null) {
+                continue;
+            }
+            grouped.computeIfAbsent(date, ignored -> new TreeMap<>())
+                    .put(time, (int) row.getAssignedCount());
+        }
+    }
+
+    private List<InterviewDateSlotsDto> convertToInterviewSchedule(Map<LocalDate, Map<LocalTime, Integer>> grouped) {
+        return grouped.entrySet().stream()
+                .map(dateEntry -> new InterviewDateSlotsDto(
+                        dateEntry.getKey(),
+                        dateEntry.getValue().entrySet().stream()
+                                .map(timeEntry ->
+                                        new InterviewSlotCountDto(
+                                                timeEntry.getKey(),
+                                                timeEntry.getValue()
+                                        )
+                                )
+                                .toList()
+                ))
+                .toList();
     }
     // ---- private helpers ----
     private ClubListResponseDto mapToResponse(List<ClubSummary> summaries) {

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/club/service/ClubServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/club/service/ClubServiceImpl.java
@@ -224,7 +224,7 @@ public class ClubServiceImpl implements ClubService {
 
     private Map<LocalDate, Map<LocalTime, Integer>> buildInterviewScheduleTemplate(Club club) {
         Map<LocalDate, Map<LocalTime, Integer>> schedule = new TreeMap<>();
-        if (Boolean.FALSE.equals(club.getIsInterviewRequired())) {
+        if (!Boolean.TRUE.equals(club.getIsInterviewRequired())) {
             return schedule;
         }
 
@@ -265,8 +265,11 @@ public class ClubServiceImpl implements ClubService {
             if (date == null || time == null) {
                 continue;
             }
-            grouped.computeIfAbsent(date, ignored -> new TreeMap<>())
-                    .put(time, (int) row.getAssignedCount());
+            Map<LocalTime, Integer> slots = grouped.get(date);
+            if (slots == null || !slots.containsKey(time)) {
+                continue;
+            }
+            slots.put(time, (int) row.getAssignedCount());
         }
     }
 

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/club/service/ClubServiceMockTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/club/service/ClubServiceMockTest.java
@@ -893,7 +893,9 @@ public class ClubServiceMockTest {
                 .willReturn(List.of());
         given(applicationRepository.countInterviewSlots(clubId)).willReturn(List.of(
                 projection(LocalDate.of(2026, 9, 1), LocalTime.of(14, 0), 2),
-                projection(LocalDate.of(2026, 9, 1), LocalTime.of(14, 30), 1)
+                projection(LocalDate.of(2026, 9, 1), LocalTime.of(14, 30), 1),
+                projection(LocalDate.of(2026, 9, 2), LocalTime.of(14, 0), 99), // template 밖 날짜
+                projection(LocalDate.of(2026, 9, 1), LocalTime.of(16, 0), 99) // template 밖 시간
         ));
 
         ClubDashboardApplicantResponseDto actual = clubService.getApplicantsByStatusAndStage(clubId, null, Stage.INTERVIEW);

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/club/service/ClubServiceMockTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/club/service/ClubServiceMockTest.java
@@ -14,6 +14,7 @@ import com.kakaotech.team18.backend_server.domain.application.entity.Application
 import com.kakaotech.team18.backend_server.domain.application.entity.Stage;
 import com.kakaotech.team18.backend_server.domain.application.entity.Status;
 import com.kakaotech.team18.backend_server.domain.application.repository.ApplicationRepository;
+import com.kakaotech.team18.backend_server.domain.application.repository.InterviewSlotCountProjection;
 import com.kakaotech.team18.backend_server.domain.club.dto.ClubDashBoardResponseDto;
 import com.kakaotech.team18.backend_server.domain.club.dto.ClubDashboardApplicantResponseDto;
 import com.kakaotech.team18.backend_server.domain.club.dto.ClubDetailRequestDto;
@@ -832,6 +833,98 @@ public class ClubServiceMockTest {
 
         //then
         assertThat(actual.applicants()).isEqualTo(expect);
+    }
+
+    @DisplayName("확정된 면접 인원이 없어도 Club 면접 일정 기반으로 30분 슬롯이 0명으로 내려온다.")
+    @Test
+    void interviewSchedule_returnsZeroFilledSlots_whenNoConfirmedInterviews() {
+        Long clubId = 1L;
+        Club club = createClub(
+                mock(ClubIntroduction.class),
+                LocalDateTime.of(2026, 9, 1, 0, 0),
+                LocalDateTime.of(2026, 9, 30, 23, 59),
+                true,
+                LocalDateTime.of(2026, 9, 1, 0, 0),
+                LocalDateTime.of(2026, 9, 2, 0, 0),
+                LocalTime.of(14, 0),
+                LocalTime.of(15, 30)
+        );
+        ClubApplyForm clubApplyForm = createClubApplyForm(club);
+
+        given(clubApplyFormRepository.findByClubId(clubId)).willReturn(Optional.of(clubApplyForm));
+        given(clubMemberRepository.findByClubIdAndRoleAndStage(clubId, Role.APPLICANT, Stage.INTERVIEW))
+                .willReturn(List.of());
+        given(applicationRepository.countInterviewSlots(clubId)).willReturn(List.of());
+
+        ClubDashboardApplicantResponseDto actual = clubService.getApplicantsByStatusAndStage(clubId, null, Stage.INTERVIEW);
+
+        assertThat(actual.interviewSchedule()).hasSize(2);
+        assertThat(actual.interviewSchedule().get(0).date()).isEqualTo(LocalDate.of(2026, 9, 1));
+        assertThat(actual.interviewSchedule().get(0).slots())
+                .extracting(ClubDashboardApplicantResponseDto.InterviewDateSlotsDto.InterviewSlotCountDto::time)
+                .containsExactly(LocalTime.of(14, 0), LocalTime.of(14, 30), LocalTime.of(15, 0));
+        assertThat(actual.interviewSchedule().get(0).slots())
+                .extracting(ClubDashboardApplicantResponseDto.InterviewDateSlotsDto.InterviewSlotCountDto::assignedCount)
+                .containsExactly(0, 0, 0);
+        assertThat(actual.interviewSchedule().get(1).date()).isEqualTo(LocalDate.of(2026, 9, 2));
+        assertThat(actual.interviewSchedule().get(1).slots())
+                .extracting(ClubDashboardApplicantResponseDto.InterviewDateSlotsDto.InterviewSlotCountDto::assignedCount)
+                .containsExactly(0, 0, 0);
+    }
+
+    @DisplayName("확정된 면접 인원 카운트가 30분 슬롯에 정확히 반영된다.")
+    @Test
+    void interviewSchedule_mergesAssignedCountsIntoThirtyMinuteSlots() {
+        Long clubId = 1L;
+        Club club = createClub(
+                mock(ClubIntroduction.class),
+                LocalDateTime.of(2026, 9, 1, 0, 0),
+                LocalDateTime.of(2026, 9, 30, 23, 59),
+                true,
+                LocalDateTime.of(2026, 9, 1, 0, 0),
+                LocalDateTime.of(2026, 9, 1, 0, 0),
+                LocalTime.of(14, 0),
+                LocalTime.of(15, 30)
+        );
+        ClubApplyForm clubApplyForm = createClubApplyForm(club);
+
+        given(clubApplyFormRepository.findByClubId(clubId)).willReturn(Optional.of(clubApplyForm));
+        given(clubMemberRepository.findByClubIdAndRoleAndStage(clubId, Role.APPLICANT, Stage.INTERVIEW))
+                .willReturn(List.of());
+        given(applicationRepository.countInterviewSlots(clubId)).willReturn(List.of(
+                projection(LocalDate.of(2026, 9, 1), LocalTime.of(14, 0), 2),
+                projection(LocalDate.of(2026, 9, 1), LocalTime.of(14, 30), 1)
+        ));
+
+        ClubDashboardApplicantResponseDto actual = clubService.getApplicantsByStatusAndStage(clubId, null, Stage.INTERVIEW);
+
+        assertThat(actual.interviewSchedule()).hasSize(1);
+        assertThat(actual.interviewSchedule().get(0).date()).isEqualTo(LocalDate.of(2026, 9, 1));
+        assertThat(actual.interviewSchedule().get(0).slots())
+                .extracting(ClubDashboardApplicantResponseDto.InterviewDateSlotsDto.InterviewSlotCountDto::time)
+                .containsExactly(LocalTime.of(14, 0), LocalTime.of(14, 30), LocalTime.of(15, 0));
+        assertThat(actual.interviewSchedule().get(0).slots())
+                .extracting(ClubDashboardApplicantResponseDto.InterviewDateSlotsDto.InterviewSlotCountDto::assignedCount)
+                .containsExactly(2, 1, 0);
+    }
+
+    private static InterviewSlotCountProjection projection(LocalDate date, LocalTime time, long assignedCount) {
+        return new InterviewSlotCountProjection() {
+            @Override
+            public LocalDate getInterviewDate() {
+                return date;
+            }
+
+            @Override
+            public LocalTime getInterviewTime() {
+                return time;
+            }
+
+            @Override
+            public long getAssignedCount() {
+                return assignedCount;
+            }
+        };
     }
 
 


### PR DESCRIPTION
## 🚀 작업 내용

ClubDashboardApplicantResponseDto의 interviewSchedule이 의도대로 프론트로 전달되지 않아 지원자 면접 일정 확정이 불가능해 이를 수정했습니다. 

기존 로직은 Application Repoistory에서 countInterviewSlots 메서드의 쿼리문을 통해 면접 시간대에 면접 일정이 확정된 면접자의 수를 구하고 면접 일정과 함께 interviewSchedule 필드에 담아 전달하는거였는데, 이때 면접 일정이 확정되지 않은 면접자가 존재해 밑에 json 형식처럼 값을 전달하지 않고 쿼리문의 결과인 InterviewSlotCountProjection 자체가 추출되지 않았습니다. 

의도한 로직: 면접 확정 인원이 없더라도 이렇게 전달 
```
  "interviewSchedule": [
    {
      "date": "2026-09-01",
      "slots": [
        { "time": "14:00", "assignedCount": 0},
        { "time": "15:00", "assignedCount": 0},
        { "time": "16:00", "assignedCount": 0}
      ]
    },
    {
      "date": "2026-09-02",
      "slots": [
        { "time": "14:00", "assignedCount": 0},
        { "time": "15:00", "assignedCount": 0},
        { "time": "16:00", "assignedCount": 0}
      ]
    }
  ]
  ```
  
  전달되고 있는 값 
  ```
    "interviewSchedule": [] 
  ```

따라서 countInterviewSlots의 결과가 없더라도 Club엔티티의 면접 일정을 토대로 

```
  "interviewSchedule": [
    {
      "date": "2026-09-01",
      "slots": [
        { "time": "14:00", "assignedCount": 0},
        { "time": "15:00", "assignedCount": 0},
        { "time": "16:00", "assignedCount": 0}
      ]
    },
    {
      "date": "2026-09-02",
      "slots": [
        { "time": "14:00", "assignedCount": 0},
        { "time": "15:00", "assignedCount": 0},
        { "time": "16:00", "assignedCount": 0}
      ]
    }
  ]
```

이런식의 기본 템플릿을 만들어두고, 해당 시간대에 할당된 면접 인원이 있다면 이 값을 매핑해 전달하도록 해 빈 값이 전달되지 않도록 수정하였습니다. 

또한 면접 시간 텀을 30분 간격으로 할당하도록 변경했습니다. 
    

## ⏱️ 소요 시간
1시간 반 

## 🤔 고민했던 내용


## 💬 리뷰 중점사항


## 🔗관련 이슈
- Close #280 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 인터뷰 일정 생성 로직 개선으로 날짜/시간 정렬과 30분 단위 슬롯이 정확히 표시됩니다.
  * 실제 할당된 인터뷰 수가 각 30분 슬롯에 올바르게 반영되어 카운트가 정확해집니다.

* **테스트**
  * 슬롯 초기화 및 할당 카운트 병합 동작을 검증하는 단위 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->