### PR TITLE
Fix/monitoring#302

### DIFF
--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -38,6 +38,8 @@ services:
       - GF_ALERTING_ENABLED=false
       # Discord Webhook URL (알림용)
       - DISCORD_WEBHOOK_URL=${DISCORD_WEBHOOK_URL:-}
+      # 외부 접근 URL (알림 링크에 사용)
+      - GF_SERVER_ROOT_URL=https://monitor.dongarium.co.kr
       # Timezone 설정
       - TZ=Asia/Seoul
     volumes:

--- a/monitoring/grafana/provisioning/alerting/alerting.yml
+++ b/monitoring/grafana/provisioning/alerting/alerting.yml
@@ -47,7 +47,7 @@ groups:
             relativeTimeRange:
               from: 300
               to: 0
-            datasourceUid: Prometheus
+            datasourceUid: prometheus-datasource
             model:
               expr: system_cpu_usage{application="dongarium"} * 100
               instant: false
@@ -129,7 +129,7 @@ groups:
             relativeTimeRange:
               from: 300
               to: 0
-            datasourceUid: Prometheus
+            datasourceUid: prometheus-datasource
             model:
               expr: sum(jvm_memory_used_bytes{application="dongarium", area="heap"}) / sum(jvm_memory_max_bytes{application="dongarium", area="heap"}) * 100
               instant: false
@@ -183,7 +183,7 @@ groups:
             relativeTimeRange:
               from: 180
               to: 0
-            datasourceUid: Prometheus
+            datasourceUid: prometheus-datasource
             model:
               expr: sum(rate(http_server_requests_seconds_count{application="dongarium", status=~"5.."}[5m])) / sum(rate(http_server_requests_seconds_count{application="dongarium"}[5m])) * 100
               instant: false
@@ -227,7 +227,7 @@ groups:
             relativeTimeRange:
               from: 300
               to: 0
-            datasourceUid: Prometheus
+            datasourceUid: prometheus-datasource
             model:
               expr: histogram_quantile(0.95, sum(rate(http_server_requests_seconds_bucket{application="dongarium"}[5m])) by (le))
               instant: false
@@ -279,7 +279,7 @@ groups:
             relativeTimeRange:
               from: 300
               to: 0
-            datasourceUid: Prometheus
+            datasourceUid: prometheus-datasource
             model:
               expr: rate(jvm_gc_pause_seconds_sum{application="dongarium"}[5m]) * 1000
               instant: false
@@ -323,7 +323,7 @@ groups:
             relativeTimeRange:
               from: 300
               to: 0
-            datasourceUid: Prometheus
+            datasourceUid: prometheus-datasource
             model:
               expr: jvm_threads_live_threads{application="dongarium"}
               instant: false
@@ -375,7 +375,7 @@ groups:
             relativeTimeRange:
               from: 180
               to: 0
-            datasourceUid: Prometheus
+            datasourceUid: prometheus-datasource
             model:
               expr: hikaricp_connections_pending{application="dongarium"}
               instant: false
@@ -427,7 +427,7 @@ groups:
             relativeTimeRange:
               from: 120
               to: 0
-            datasourceUid: Prometheus
+            datasourceUid: prometheus-datasource
             model:
               expr: up{job="dongarium-app"}
               instant: false

--- a/monitoring/grafana/provisioning/datasources/datasources.yml
+++ b/monitoring/grafana/provisioning/datasources/datasources.yml
@@ -2,6 +2,7 @@ apiVersion: 1
 
 datasources:
   - name: Prometheus
+    uid: prometheus-datasource
     type: prometheus
     access: proxy
     url: http://prometheus:9090
@@ -9,6 +10,7 @@ datasources:
     editable: false
 
   - name: Loki
+    uid: loki-datasource
     type: loki
     access: proxy
     url: http://loki:3100


### PR DESCRIPTION
## 🚀 작업 내용

- `datasources.yml`: Prometheus, Loki datasource에 명시적 `uid` 추가
- `alerting.yml`: `datasourceUid` 값을 이름(`Prometheus`)에서 uid(`prometheus-datasource`)로 수정 (8개 rule 전체)
- `docker-compose.monitoring.yml`: `GF_SERVER_ROOT_URL` 설정으로 알림 링크 URL 수정 (`localhost:3000` → `https://monitor.dongarium.co.kr`)


## ⏱️ 소요 시간

- 1h

## 🤔 고민했던 내용

Grafana는 alert rule에서 datasource를 UID로 찾는데, 기존 코드가 UID 대신 이름(`Prometheus`)을 사용하고 있었음. datasource에 명시적 uid를 지정하지 않으면 Grafana가 자동 생성한 UID와 불일치 발생 → 모든 alert rule이 `DatasourceError`로 오발화

## 💬 리뷰 중점사항

## 🔗관련 이슈
- Close #302