### PR TITLE
[Feat]ci cd 변경#287

### DIFF
--- a/.github/workflows/deploy-with-docker.yml
+++ b/.github/workflows/deploy-with-docker.yml
@@ -15,6 +15,8 @@ jobs:
     env:
       AWS_REGION: ap-northeast-2
       ECR_REPO_NAME: dongarium-server
+      MIGRATE_ECR_REPO_NAME: dongarium-migrate
+      IMAGE_TAG: ${{ github.sha }}
       REMOTE_DIR: /home/ec2-user/dongarium
 
     steps:
@@ -58,6 +60,7 @@ jobs:
           DB_ROOT_PASSWORD: '${{ secrets.DB_ROOT_PASSWORD }}'
 
         run: SPRING_PROFILES_ACTIVE=test ./gradlew clean build -x test
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -69,14 +72,21 @@ jobs:
         id: ecr
         uses: aws-actions/amazon-ecr-login@v2
 
-      - name: Build Docker image
-        run: docker build -t $ECR_REPO_NAME .
+      - name: Build Docker images (server + migrate)
+        env:
+          REG: ${{ steps.ecr.outputs.registry }}
+        run: |
+          set -e
 
-      - name: Tag image for ECR
-        run: docker tag $ECR_REPO_NAME:latest ${{ steps.ecr.outputs.registry }}/$ECR_REPO_NAME:latest
+          # server 이미지 빌드 및 푸시
+          docker build -t $ECR_REPO_NAME:$IMAGE_TAG .
+          docker tag $ECR_REPO_NAME:$IMAGE_TAG $REG/$ECR_REPO_NAME:$IMAGE_TAG
+          docker push $REG/$ECR_REPO_NAME:$IMAGE_TAG
 
-      - name: Push image to ECR
-        run: docker push ${{ steps.ecr.outputs.registry }}/$ECR_REPO_NAME:latest
+          # migrate 이미지 빌드 및 푸시
+          docker build -f Dockerfile.flyway -t $MIGRATE_ECR_REPO_NAME:$IMAGE_TAG .
+          docker tag $MIGRATE_ECR_REPO_NAME:$IMAGE_TAG $REG/$MIGRATE_ECR_REPO_NAME:$IMAGE_TAG
+          docker push $REG/$MIGRATE_ECR_REPO_NAME:$IMAGE_TAG
 
       - name: Ensure remote directory structure
         uses: appleboy/ssh-action@v1.0.3
@@ -99,7 +109,7 @@ jobs:
           source: "docker-compose.yml,docker-compose.monitoring.yml,monitoring/"
           target: "${{ env.REMOTE_DIR }}/current"
 
-      - name: Deploy on EC2 (create .env, set credHelpers, compose up)
+      - name: Deploy on EC2 (create .env, set credHelpers, migrate, compose up)
         uses: appleboy/ssh-action@v1.0.3
         with:
           host: ${{ secrets.EC2_HOST }}
@@ -110,6 +120,7 @@ jobs:
           script: |
             set -euo pipefail
             rm -f ~/.docker/config.json || true
+
             # Docker/compose 보장
             if ! systemctl is-active --quiet docker; then
               sudo systemctl start docker || true
@@ -123,7 +134,7 @@ jobs:
               docker compose version || { echo "FATAL: docker compose not available"; exit 1; }
             fi
 
-            # AWS 크레덴셜 (Instance Profile이 없을 때만)
+            # AWS 크레덴셜
             export AWS_ACCESS_KEY_ID='${{ secrets.AWS_ACCESS_KEY_ID }}'
             export AWS_SECRET_ACCESS_KEY='${{ secrets.AWS_SECRET_ACCESS_KEY }}'
             export AWS_REGION='${{ env.AWS_REGION }}'
@@ -141,10 +152,11 @@ jobs:
             export DOCKER_CONFIG=/tmp/docker-config-ecr
             mkdir -p "$DOCKER_CONFIG"
 
-            # credHelpers 설정을 jq로 생성 (heredoc NO)
             REG='${{ steps.ecr.outputs.registry }}'
+            IMAGE_TAG='${{ env.IMAGE_TAG }}'
+
+            # credHelpers 설정
             if ! command -v jq >/dev/null 2>&1; then
-              # jq가 없으면 설치 (Amazon Linux 계열)
               if command -v yum >/dev/null 2>&1; then
                 sudo yum install -y jq || true
               elif command -v dnf >/dev/null 2>&1; then
@@ -156,9 +168,10 @@ jobs:
             # 디렉토리 이동
             cd ${{ env.REMOTE_DIR }}
 
-            # .env 생성 (printf로 안전하게 생성)
+            # .env 생성
             tmp_env="$(mktemp)"
-            printf 'DB_NAME=%s\nDB_USER=%s\nDB_PASSWORD=%s\nDB_ROOT_PASSWORD=%s\nECR_REGISTRY=%s\nKAKAO_CLIENT_ID=%s\nKAKAO_CLIENT_SECRET=%s\nJWT_SECRET=%s\nKAKAO_REDIRECT_URI_PROD=%s\nKAKAO_LOGOUT_REDIRECT_URI_PROD=%s\nFRONTEND_MAIN_PAGE_URI_PROD=%s\nSMTP_HOST=%s\nSMTP_PORT=%s\nSMTP_USERNAME=%s\nSMTP_PASSWORD=%s\nEMAIL_FROM=%s\nEMAIL_SUBJECT_PREFIX=%s\nREDIS_HOST=%s\nREDIS_PORT=%s\nAPI_REST_CLIENT_CONNECT_TIMEOUT=%s\nAPI_REST_CLIENT_READ_TIMEOUT=%s\nCLOUD_AWS_S3_BUCKET=%s\nCLOUD_AWS_S3_BUCKET_ATTACHMENTS=%s\nDISCORD_WEBHOOK_URL=%s\nCLOUD_AWS_REGION_STATIC=%s\n' \
+            printf 'IMAGE_TAG=%s\nDB_NAME=%s\nDB_USER=%s\nDB_PASSWORD=%s\nDB_ROOT_PASSWORD=%s\nECR_REGISTRY=%s\nKAKAO_CLIENT_ID=%s\nKAKAO_CLIENT_SECRET=%s\nJWT_SECRET=%s\nKAKAO_REDIRECT_URI_PROD=%s\nKAKAO_LOGOUT_REDIRECT_URI_PROD=%s\nFRONTEND_MAIN_PAGE_URI_PROD=%s\nSMTP_HOST=%s\nSMTP_PORT=%s\nSMTP_USERNAME=%s\nSMTP_PASSWORD=%s\nEMAIL_FROM=%s\nEMAIL_SUBJECT_PREFIX=%s\nREDIS_HOST=%s\nREDIS_PORT=%s\nAPI_REST_CLIENT_CONNECT_TIMEOUT=%s\nAPI_REST_CLIENT_READ_TIMEOUT=%s\nCLOUD_AWS_S3_BUCKET=%s\nCLOUD_AWS_S3_BUCKET_ATTACHMENTS=%s\nDISCORD_WEBHOOK_URL=%s\nCLOUD_AWS_REGION_STATIC=%s\n' \
+            "$IMAGE_TAG" \
             '${{ secrets.DB_NAME }}' \
             '${{ secrets.DB_USER }}' \
             '${{ secrets.DB_PASSWORD }}' \
@@ -188,14 +201,27 @@ jobs:
             rm -f "$tmp_env"
             ln -sf ${{ env.REMOTE_DIR }}/shared/.env ${{ env.REMOTE_DIR }}/current/.env
 
-            echo "==> Pull latest image (credHelpers auto-auth)"
-            docker pull $REG/${{ env.ECR_REPO_NAME }}:latest
+            echo "==> Pull images (server + migrate) with tag: $IMAGE_TAG"
+            docker pull $REG/${{ env.ECR_REPO_NAME }}:$IMAGE_TAG
+            docker pull $REG/${{ env.MIGRATE_ECR_REPO_NAME }}:$IMAGE_TAG
 
-            # 재기동
+            # 포트 강제 해제
             sudo fuser -k -n tcp 8080 || true
+
             cd ${{ env.REMOTE_DIR }}/current
-            ECR_REGISTRY="$REG" docker compose down || true
-            ECR_REGISTRY="$REG" docker compose up -d --remove-orphans
+
+            # db/redis 먼저 기동 (기존 데이터 유지)
+            ECR_REGISTRY="$REG" IMAGE_TAG="$IMAGE_TAG" docker compose up -d --remove-orphans db redis
+
+            # migrate 1회 실행 (실패 시 set -e로 배포 중단)
+            echo "==> Running Flyway migration"
+            ECR_REGISTRY="$REG" IMAGE_TAG="$IMAGE_TAG" docker compose run --rm migrate
+
+            # migrate 성공 후 app 기동
+            echo "==> Starting app"
+            ECR_REGISTRY="$REG" IMAGE_TAG="$IMAGE_TAG" docker compose up -d --remove-orphans app
+
             docker compose ps
-            # 모니터링 스택 실행 명령어
+
+            # 모니터링 스택
             docker compose -f docker-compose.monitoring.yml up -d

--- a/Dockerfile.flyway
+++ b/Dockerfile.flyway
@@ -1,0 +1,3 @@
+FROM flyway/flyway:10.17.0
+
+COPY ./src/main/resources/db/migration /flyway/sql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       "--max_connections=200"
     ]
     ports:
-      - "3306:3306"        # EC2 밖에서 직접 접근 필요 없으면 이 라인은 주석처리 가능
+      - "3306:3306"
     volumes:
       - db_data:/var/lib/mysql
     healthcheck:
@@ -37,8 +37,27 @@ services:
       timeout: 3s
       retries: 5
 
+  # 1회 실행용 (배포 스크립트에서 `compose run --rm migrate`로 실행)
+  # 최초 배포 시 기존 DB가 있다면 FLYWAY_BASELINE_ON_MIGRATE=true 옵션으로
+  # baseline을 찍은 후 해당 옵션을 제거할 것
+  migrate:
+    image: ${ECR_REGISTRY}/dongarium-migrate:${IMAGE_TAG}
+    container_name: dongarium-migrate
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      TZ: Asia/Seoul
+      FLYWAY_URL: jdbc:mysql://db:3306/${DB_NAME}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+      FLYWAY_USER: ${DB_USER}
+      FLYWAY_PASSWORD: ${DB_PASSWORD}
+      FLYWAY_BASELINE_ON_MIGRATE: "true"
+      FLYWAY_BASELINE_VERSION: "1"
+    command: ["migrate"]
+    restart: "no"
+
   app:
-    image: ${ECR_REGISTRY}/dongarium-server:latest
+    image: ${ECR_REGISTRY}/dongarium-server:${IMAGE_TAG}
     container_name: dongarium-server
     restart: always
     logging:
@@ -91,7 +110,7 @@ services:
       SPRING_DATA_REDIS_HOST: ${REDIS_HOST}
       SPRING_DATA_REDIS_PORT: ${REDIS_PORT}
 
-      #AWS S3
+      # AWS S3
       CLOUD_AWS_S3_BUCKET: ${CLOUD_AWS_S3_BUCKET}
       CLOUD_AWS_S3_BUCKET_ATTACHMENTS: ${CLOUD_AWS_S3_BUCKET_ATTACHMENTS}
       CLOUD_AWS_REGION_STATIC: ${CLOUD_AWS_REGION_STATIC}
@@ -100,11 +119,10 @@ services:
       API_REST-CLIENT_CONNECT-TIMEOUT: ${API_REST_CLIENT_CONNECT_TIMEOUT:-3000}
       API_REST-CLIENT_READ-TIMEOUT: ${API_REST_CLIENT_READ_TIMEOUT:-3000}
 
-      #Loggin
+      # Logging
       LOGGING_DISCORD_WEBHOOK_URL: ${DISCORD_WEBHOOK_URL}
 
     healthcheck:
-      # 상태 코드 200이고 본문에 "status":"UP" 포함되면 성공
       test: [ "CMD-SHELL", "wget -qO- http://localhost:8080/actuator/health | grep -q '\"status\":\"UP\"'" ]
       interval: 30s
       timeout: 5s

--- a/src/main/resources/db/migration/V1__baseline.sql
+++ b/src/main/resources/db/migration/V1__baseline.sql
@@ -1,0 +1,237 @@
+SET FOREIGN_KEY_CHECKS = 0;
+
+CREATE TABLE `answer` (
+  `answer_id` bigint NOT NULL AUTO_INCREMENT,
+  `application_id` bigint NOT NULL,
+  `created_at` datetime(6) DEFAULT NULL,
+  `form_question_id` bigint NOT NULL,
+  `last_modified_at` datetime(6) DEFAULT NULL,
+  `answer` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  PRIMARY KEY (`answer_id`),
+  KEY `FKitljjo4w2o0qj6rmuv9qtujyq` (`application_id`),
+  KEY `FK7kadfagesegt560acavi83r89` (`form_question_id`),
+  CONSTRAINT `FK7kadfagesegt560acavi83r89` FOREIGN KEY (`form_question_id`) REFERENCES `form_question` (`form_question_id`),
+  CONSTRAINT `FKitljjo4w2o0qj6rmuv9qtujyq` FOREIGN KEY (`application_id`) REFERENCES `application` (`application_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE `application` (
+  `average_rating` double NOT NULL,
+  `application_id` bigint NOT NULL AUTO_INCREMENT,
+  `club_apply_form_id` bigint NOT NULL,
+  `created_at` datetime(6) DEFAULT NULL,
+  `last_modified_at` datetime(6) DEFAULT NULL,
+  `user_id` bigint NOT NULL,
+  `stage` enum('FINAL','INTERVIEW') COLLATE utf8mb4_unicode_ci NOT NULL,
+  `status` enum('APPROVED','PENDING','REJECTED') COLLATE utf8mb4_unicode_ci NOT NULL,
+  `interview_date` date DEFAULT NULL,
+  `interview_time` time DEFAULT NULL,
+  PRIMARY KEY (`application_id`),
+  KEY `FKqylpo68i4fse8sm80pu3wn0su` (`club_apply_form_id`),
+  KEY `FKawte0mbtubellxed1dvpoxhdj` (`user_id`),
+  CONSTRAINT `FKawte0mbtubellxed1dvpoxhdj` FOREIGN KEY (`user_id`) REFERENCES `users` (`user_id`),
+  CONSTRAINT `FKqylpo68i4fse8sm80pu3wn0su` FOREIGN KEY (`club_apply_form_id`) REFERENCES `club_apply_form` (`club_apply_form_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE `club` (
+  `club_id` bigint NOT NULL AUTO_INCREMENT,
+  `club_introduction_id` bigint DEFAULT NULL,
+  `created_at` datetime(6) DEFAULT NULL,
+  `last_modified_at` datetime(6) DEFAULT NULL,
+  `recruit_end` datetime(6) DEFAULT NULL,
+  `recruit_start` datetime(6) DEFAULT NULL,
+  `caution` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `club_name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `location` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `regular_meeting_info` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `short_introduction` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `category` enum('LITERATURE','RELIGION','SPORTS','STUDY','VOLUNTEER') COLLATE utf8mb4_unicode_ci NOT NULL,
+  `is_interview_required` tinyint(1) NOT NULL DEFAULT '0',
+  `interview_start_date` datetime DEFAULT NULL,
+  `interview_end_date` datetime DEFAULT NULL,
+  `interview_start_time` time DEFAULT NULL,
+  `interview_end_time` time DEFAULT NULL,
+  PRIMARY KEY (`club_id`),
+  UNIQUE KEY `UKbpsde1igbj5ggar8gcnibkk77` (`club_name`),
+  UNIQUE KEY `UKgqdl6d03elrcmo7vnb3nnaihc` (`club_introduction_id`),
+  CONSTRAINT `FKq1bk2kcu6nt6li7snlem1412n` FOREIGN KEY (`club_introduction_id`) REFERENCES `club_introduction` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE `club_apply_form` (
+  `club_apply_form_id` bigint NOT NULL AUTO_INCREMENT,
+  `club_id` bigint NOT NULL,
+  `created_at` datetime(6) DEFAULT NULL,
+  `last_modified_at` datetime(6) DEFAULT NULL,
+  `description` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `final_message` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `interview_message` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `title` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  PRIMARY KEY (`club_apply_form_id`),
+  UNIQUE KEY `UK5tc03iukrsp7our7eqxhfxu8y` (`club_id`),
+  CONSTRAINT `FK5ibyg6b5uvo83we1ttdscubfc` FOREIGN KEY (`club_id`) REFERENCES `club` (`club_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE `club_image` (
+  `club_introduction_id` bigint NOT NULL,
+  `created_at` datetime(6) DEFAULT NULL,
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `last_modified_at` datetime(6) DEFAULT NULL,
+  `image_url` varchar(500) COLLATE utf8mb4_unicode_ci NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `FKaghr6i05c2dokxtlv22fvj2oo` (`club_introduction_id`),
+  CONSTRAINT `FKaghr6i05c2dokxtlv22fvj2oo` FOREIGN KEY (`club_introduction_id`) REFERENCES `club_introduction` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE `club_introduction` (
+  `created_at` datetime(6) DEFAULT NULL,
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `last_modified_at` datetime(6) DEFAULT NULL,
+  `activities` text COLLATE utf8mb4_unicode_ci,
+  `ideal` text COLLATE utf8mb4_unicode_ci,
+  `overview` text COLLATE utf8mb4_unicode_ci,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE `club_member` (
+  `application_id` bigint DEFAULT NULL,
+  `club_id` bigint NOT NULL,
+  `club_member_id` bigint NOT NULL AUTO_INCREMENT,
+  `created_at` datetime(6) DEFAULT NULL,
+  `last_modified_at` datetime(6) DEFAULT NULL,
+  `user_id` bigint NOT NULL,
+  `active_status` enum('ACTIVE','INACTIVE') COLLATE utf8mb4_unicode_ci NOT NULL,
+  `club_role` enum('APPLICANT','CLUB_ADMIN','CLUB_EXECUTIVE','CLUB_MEMBER','SYSTEM_ADMIN') COLLATE utf8mb4_unicode_ci NOT NULL,
+  PRIMARY KEY (`club_member_id`),
+  UNIQUE KEY `UKl5kcssyclpl7otv2490ce1ghq` (`application_id`),
+  KEY `FKf6tl19ih8acrmheidn4xos2tx` (`club_id`),
+  KEY `FKbkak0q9hvao01xs5gem9h52tf` (`user_id`),
+  CONSTRAINT `FKbkak0q9hvao01xs5gem9h52tf` FOREIGN KEY (`user_id`) REFERENCES `users` (`user_id`),
+  CONSTRAINT `FKf6tl19ih8acrmheidn4xos2tx` FOREIGN KEY (`club_id`) REFERENCES `club` (`club_id`),
+  CONSTRAINT `FKobdnd29ix5ht0hwxhklyyoee5` FOREIGN KEY (`application_id`) REFERENCES `application` (`application_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE `club_member_profile` (
+  `club_member_profile_id` bigint NOT NULL AUTO_INCREMENT,
+  `club_member_id` bigint NOT NULL,
+  `name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `student_id` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `phone_number` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `college` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `department` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `academic_status` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `join_date` date NOT NULL,
+  `role` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `created_at` datetime(6) DEFAULT NULL,
+  `last_modified_at` datetime(6) DEFAULT NULL,
+  PRIMARY KEY (`club_member_profile_id`),
+  UNIQUE KEY `club_member_id` (`club_member_id`),
+  CONSTRAINT `fk_club_member_profile_club_member` FOREIGN KEY (`club_member_id`) REFERENCES `club_member` (`club_member_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE `club_review` (
+  `club_id` bigint DEFAULT NULL,
+  `created_at` datetime(6) DEFAULT NULL,
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `last_modified_at` datetime(6) DEFAULT NULL,
+  `content` varchar(500) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `writer` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `FK5jb0tx5o222iqbhp1q5pgy724` (`club_id`),
+  CONSTRAINT `FK5jb0tx5o222iqbhp1q5pgy724` FOREIGN KEY (`club_id`) REFERENCES `club` (`club_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE `comment` (
+  `rating` double NOT NULL,
+  `application_id` bigint NOT NULL,
+  `comment_id` bigint NOT NULL AUTO_INCREMENT,
+  `created_at` datetime(6) DEFAULT NULL,
+  `last_modified_at` datetime(6) DEFAULT NULL,
+  `user_id` bigint NOT NULL,
+  `content` varchar(500) COLLATE utf8mb4_unicode_ci NOT NULL,
+  PRIMARY KEY (`comment_id`),
+  KEY `FKsr2gt5xva5k4esv9ck6wqisyt` (`application_id`),
+  KEY `FKqm52p1v3o13hy268he0wcngr5` (`user_id`),
+  CONSTRAINT `FKqm52p1v3o13hy268he0wcngr5` FOREIGN KEY (`user_id`) REFERENCES `users` (`user_id`),
+  CONSTRAINT `FKsr2gt5xva5k4esv9ck6wqisyt` FOREIGN KEY (`application_id`) REFERENCES `application` (`application_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE `file` (
+  `created_at` datetime(6) DEFAULT NULL,
+  `file_id` bigint NOT NULL AUTO_INCREMENT,
+  `last_modified_at` datetime(6) DEFAULT NULL,
+  `notice_id` bigint NOT NULL,
+  `name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `object_uri` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `type` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  PRIMARY KEY (`file_id`),
+  KEY `FK9sue39n4ky49ha47ujunh07b4` (`notice_id`),
+  CONSTRAINT `FK9sue39n4ky49ha47ujunh07b4` FOREIGN KEY (`notice_id`) REFERENCES `notice` (`notice_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE `form_question` (
+  `is_required` bit(1) NOT NULL,
+  `club_apply_form_id` bigint NOT NULL,
+  `created_at` datetime(6) DEFAULT NULL,
+  `display_order` bigint NOT NULL,
+  `form_question_id` bigint NOT NULL AUTO_INCREMENT,
+  `last_modified_at` datetime(6) DEFAULT NULL,
+  `options` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `question` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `field_type` enum('CHECKBOX','RADIO','TEXT','TIME_SLOT') COLLATE utf8mb4_unicode_ci NOT NULL,
+  PRIMARY KEY (`form_question_id`),
+  KEY `FKje28bthta5ex6rpk569q3tyov` (`club_apply_form_id`),
+  CONSTRAINT `FKje28bthta5ex6rpk569q3tyov` FOREIGN KEY (`club_apply_form_id`) REFERENCES `club_apply_form` (`club_apply_form_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE `interview_preference` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `application_id` bigint NOT NULL,
+  `date` date NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `fk_interview_preference_application` (`application_id`),
+  CONSTRAINT `fk_interview_preference_application` FOREIGN KEY (`application_id`) REFERENCES `application` (`application_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE `interview_preference_time` (
+  `interview_preference_id` bigint NOT NULL,
+  `time` time NOT NULL,
+  KEY `fk_interview_preference_time_preference` (`interview_preference_id`),
+  CONSTRAINT `fk_interview_preference_time_preference` FOREIGN KEY (`interview_preference_id`) REFERENCES `interview_preference` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE `notice` (
+  `is_alive` bit(1) NOT NULL,
+  `created_at` datetime(6) DEFAULT NULL,
+  `last_modified_at` datetime(6) DEFAULT NULL,
+  `notice_id` bigint NOT NULL AUTO_INCREMENT,
+  `content` text COLLATE utf8mb4_unicode_ci NOT NULL,
+  `title` text COLLATE utf8mb4_unicode_ci NOT NULL,
+  PRIMARY KEY (`notice_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE `time_slot_options` (
+  `end_time` time(6) DEFAULT NULL,
+  `start_time` time(6) DEFAULT NULL,
+  `form_question_id` bigint NOT NULL,
+  `date` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  KEY `FK2x2l5tgfi9rr8hs8gmqworv02` (`form_question_id`),
+  CONSTRAINT `FK2x2l5tgfi9rr8hs8gmqworv02` FOREIGN KEY (`form_question_id`) REFERENCES `form_question` (`form_question_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE `users` (
+  `created_at` datetime(6) DEFAULT NULL,
+  `kakao_id` bigint DEFAULT NULL,
+  `last_modified_at` datetime(6) DEFAULT NULL,
+  `user_id` bigint NOT NULL AUTO_INCREMENT,
+  `department` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `email` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `phone_number` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `student_id` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  PRIMARY KEY (`user_id`),
+  UNIQUE KEY `UK6dotkott2kjsp8vw4d0m25fb7` (`email`),
+  UNIQUE KEY `UK9q63snka3mdh91as4io72espi` (`phone_number`),
+  UNIQUE KEY `UKqh3otyipv2k9hqte4a1abcyhq` (`student_id`),
+  UNIQUE KEY `UKk4ycaj27putgcujmehwbsrmmc` (`kakao_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+SET FOREIGN_KEY_CHECKS = 1;


### PR DESCRIPTION
## 🚀 작업 내용

### Flyway 마이그레이션 도입
- `Dockerfile.flyway` 추가: `flyway/flyway:10.17.0` 기반 migrate 전용 이미지
- `src/main/resources/db/migration/V1__baseline.sql` 추가: 현재 운영 DB 스키마 baseline

### docker-compose.yml 수정
- `migrate` 서비스 추가 (1회 실행용, `restart: no`)
- 이미지 태그를 `latest` → `${IMAGE_TAG}` (github.sha 기반 버전 고정)

### CD 파이프라인 개선 (deploy-with-docker.yml)
- `IMAGE_TAG=${{ github.sha }}`로 이미지 버전 고정
- server + migrate 이미지 동시 빌드 및 ECR 푸시
- 배포 순서 변경: `db/redis 기동` → `migrate 실행` → `app 기동`
- 기존 `compose down` 제거 → DB 컨테이너 유지, 데이터 보존

## ⏱️ 소요 시간


## 🤔 고민했던 내용

- **Flyway 실행 방식**: 앱 시작 시 자동 실행 vs CI/CD 단계 실행
  - 앱 시작 시 실행하면 migration 실패 시 서버가 아예 뜨지 않아 장애 범위가 커짐
  - CI/CD에서 migrate 컨테이너를 먼저 실행하고 실패 시 배포 자체를 중단하는 방식 채택
- **migrate 이미지 분리**: Spring 이미지에 SQL을 포함하지 않고 별도 이미지로 분리하여 관심사 분리
- **기존 DB baseline 처리**: 이미 운영 중인 DB에 Flyway를 적용하기 위해 `FLYWAY_BASELINE_ON_MIGRATE=true` 옵션 사용 → 첫 배포 후 제거 예정

## 💬 리뷰 중점사항

- `V1__baseline.sql` 스키마가 현재 운영 DB와 일치하는지 확인
- `docker-compose.yml`의 배포 순서(migrate → app) 흐름 검토
- **첫 배포 후 할 일**: baseline 확인 후 `FLYWAY_BASELINE_ON_MIGRATE`, `FLYWAY_BASELINE_VERSION` 옵션 제거
- **별도 작업 필요**: GitHub Secret `APPLICATION_YML`의 prod 프로필에서 `ddl-auto: none`, `flyway.enabled: false` 반영

## 🔗관련 이슈
- Close #287 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 데이터베이스 기반 스키마 구성을 완료하였습니다. 애플리케이션의 핵심 데이터 저장소 구조가 확립되어 사용자 정보, 동아리 관리, 지원 신청, 면접 예약 등의 기능을 위한 데이터베이스 기초가 마련되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->