### PR TITLE
[FIX] 합격한 지원자의 Role을 applicant에서 club_member로 승격하도록 수정 (#306)

### DIFF
--- a/src/main/java/com/kakaotech/team18/backend_server/domain/application/service/ApplicationServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/application/service/ApplicationServiceImpl.java
@@ -432,6 +432,8 @@ public class ApplicationServiceImpl implements ApplicationService {
                 ApplicationInfoDto applicationInfoDto = buildApplicationInfo(a,president);
                 Stage originalStage = a.getStage();
                 a.updateStage(Stage.RESULT);
+                clubMemberRepository.updateRoleByApplicationId(a.getId(), Role.APPLICANT, Role.CLUB_MEMBER);
+
                 publisher.publishEvent(new FinalApprovedEvent(
                         applicationInfoDto,
                         a.getId(),
@@ -466,6 +468,7 @@ public class ApplicationServiceImpl implements ApplicationService {
                     .toList();
             for(Application a : approved) {
                 ApplicationInfoDto applicationInfoDto = buildApplicationInfo(a,president);
+                clubMemberRepository.updateRoleByApplicationId(a.getId(), Role.APPLICANT, Role.CLUB_MEMBER);
                 publisher.publishEvent(new FinalApprovedEvent(
                         applicationInfoDto,
                         a.getId(),

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/club/service/ClubServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/club/service/ClubServiceImpl.java
@@ -120,7 +120,7 @@ public class ClubServiceImpl implements ClubService {
                     log.warn("Club not found for id={}", clubId);
                     return new ClubNotFoundException("clubId = " + clubId);
                 });
-        ClubApplyForm clubApplyForm = clubApplyFormRepository
+        clubApplyFormRepository
                 .findByClubId(club.getId()).orElseThrow(() -> {
                     log.warn("ClubApplyForm not found for id={}", clubId);
                     return new ClubApplyFormNotFoundException("clubId = " + clubId);

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/repository/ClubMemberRepository.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubMember/repository/ClubMemberRepository.java
@@ -104,6 +104,15 @@ public interface ClubMemberRepository extends JpaRepository<ClubMember, Long> {
     @Query("update ClubMember cm set cm.application = null where cm.application.id = :applicationId")
     int clearApplicationByApplicationId(Long applicationId);
 
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            update ClubMember cm
+            set cm.role = :toRole
+            where cm.application.id = :applicationId
+              and cm.role = :fromRole
+            """)
+    int updateRoleByApplicationId(Long applicationId, Role fromRole, Role toRole);
+
     // User ID와 Club ID로 ClubMember 조회
     Optional<ClubMember> findByUserIdAndClubId(Long userId, Long clubId);
 }

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/email/service/EmailServiceUnitTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/email/service/EmailServiceUnitTest.java
@@ -320,6 +320,8 @@ class EmailServiceUnitTest {
         verify(appApproved, never()).updateStatus(any());
         verify(appRejected,times(1)).updateStage(Stage.RESULT);
         verify(appRejected, never()).updateStatus(any());
+        verify(clubMemberRepository, times(1))
+                .updateRoleByApplicationId(201L, Role.APPLICANT, Role.CLUB_MEMBER);
 
         // 참조 끊기 + 단건 삭제
         verify(clubMemberRepository, times(1)).clearApplicationByApplicationId(202L);
@@ -402,6 +404,8 @@ class EmailServiceUnitTest {
         verify(appApproved, never()).updateStatus(any());
         verify(appRejected, never()).updateStage(any());
         verify(appRejected, never()).updateStatus(any());
+        verify(clubMemberRepository, times(1))
+                .updateRoleByApplicationId(301L, Role.APPLICANT, Role.CLUB_MEMBER);
 
         // REJECTED만 참조 끊기 + 단건 삭제
         verify(clubMemberRepository, times(1)).clearApplicationByApplicationId(302L);


### PR DESCRIPTION
## 🚀 작업 내용
<img width="2474" height="558" alt="CleanShot 2026-02-28 at 17 46 55@2x" src="https://github.com/user-attachments/assets/6e4228c1-3200-422c-b1a1-91e69a4f800b" />
지원자 관리페이지에서 총 지원자를 가져오는 로직이 clubMemberRepository에서 해당 동아리의 applicant role을 가진 clubMember를 찾는 메서드를 통해 이루어지고 있었습니다. 

그런데 합격한 지원자들의 role이 계속 applicant로 남아있어서 집계할 때 이전에 합격한 인원들까지 집계되고 있었습니다.

이 문제를 해결하기 위해서 지원자들 결과를 전송할 때 지원자들이 final 단계이고 합격한 사람들이라면 role을 clubMember로 승격하도록 로직을 수정했습니다. 

entity에 메서드를 추가할 수도 있을 것 같지만 update 쿼리문을 활용해서 수정하도록해보았습니다. 


## ⏱️ 소요 시간
30분

## 🤔 고민했던 내용


## 💬 리뷰 중점사항


## 🔗관련 이슈
- Close #306 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 신청서가 승인되면 신청자가 자동으로 클럽 멤버로 승격됩니다.

* **테스트**
  * 클럽 멤버 승격 프로세스 검증 로직 추가

* **리팩토링**
  * 코드 간결성 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->