### PR TITLE
[REFACTOR] 회원가입시 자동으로 운영진 권한 주는 로직 삭제 (#312)

### DIFF
--- a/src/main/java/com/kakaotech/team18/backend_server/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/auth/service/AuthServiceImpl.java
@@ -10,16 +10,11 @@ import com.kakaotech.team18.backend_server.domain.auth.dto.RegistrationRequiredR
 import com.kakaotech.team18.backend_server.domain.auth.dto.ReissueResponseDto;
 import com.kakaotech.team18.backend_server.domain.auth.entity.RefreshToken;
 import com.kakaotech.team18.backend_server.domain.auth.repository.RefreshTokenRepository;
-import com.kakaotech.team18.backend_server.domain.club.entity.Club;
-import com.kakaotech.team18.backend_server.domain.club.repository.ClubRepository;
 import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubListInfoDto;
-import com.kakaotech.team18.backend_server.domain.clubMember.entity.ActiveStatus;
-import com.kakaotech.team18.backend_server.domain.clubMember.entity.ClubMember;
 import com.kakaotech.team18.backend_server.domain.clubMember.entity.Role;
 import com.kakaotech.team18.backend_server.domain.clubMember.repository.ClubMemberRepository;
 import com.kakaotech.team18.backend_server.domain.user.entity.User;
 import com.kakaotech.team18.backend_server.domain.user.repository.UserRepository;
-import com.kakaotech.team18.backend_server.global.exception.exceptions.ClubNotFoundException;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.DuplicateKakaoIdException;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.ExpiredRefreshTokenException;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.LoggedOutUserException;
@@ -67,7 +62,6 @@ public class AuthServiceImpl implements AuthService {
     private final RefreshTokenRepository refreshTokenRepository;
     private final JwtProperties jwtProperties;
     private final ClubMemberRepository clubMemberRepository;
-    private final ClubRepository clubRepository;
     private final RedisTemplate<String, String> redisTemplate;
 
     @Value("${spring.security.oauth2.client.registration.kakao.client-id}")
@@ -183,8 +177,6 @@ public class AuthServiceImpl implements AuthService {
                     .department(registerRequestDto.department())
                     .build();
             userRepository.save(user);
-            //TODO 테스트 기간 이후에는 제거 필요
-            registerDefaultClubMemberships(user);
         }
 
         //clubId, Role 전달
@@ -341,25 +333,5 @@ public class AuthServiceImpl implements AuthService {
     private boolean isSystemAdmin(User user) {
         return clubMemberRepository.findByUser(user).stream()
                 .anyMatch(cm -> cm.getRole() == Role.SYSTEM_ADMIN);
-    }
-
-    private void registerDefaultClubMemberships(User user) {
-        List<Long> defaultClubs = List.of(1L, 2L, 3L);
-
-        defaultClubs.forEach(clubId -> {
-            Club club = clubRepository.findById(clubId)
-                    .orElseThrow(() -> {
-                        log.error("Default club not found: {}", clubId);
-                        return new ClubNotFoundException("Default club not found: " + clubId);
-                    });
-
-            clubMemberRepository.save(ClubMember.builder()
-                    .user(user)
-                    .club(club)
-                    .activeStatus(ActiveStatus.ACTIVE)
-                    .role(Role.CLUB_EXECUTIVE)
-                    .build());
-            log.info("User {} registered as CLUB_EXECUTIVE in club {}", user.getId(), club.getName());
-        });
     }
 }

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/auth/service/AuthServiceImplTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/auth/service/AuthServiceImplTest.java
@@ -17,8 +17,6 @@ import com.kakaotech.team18.backend_server.domain.auth.dto.RegistrationRequiredR
 import com.kakaotech.team18.backend_server.domain.auth.dto.ReissueResponseDto;
 import com.kakaotech.team18.backend_server.domain.auth.entity.RefreshToken;
 import com.kakaotech.team18.backend_server.domain.auth.repository.RefreshTokenRepository;
-import com.kakaotech.team18.backend_server.domain.club.entity.Club;
-import com.kakaotech.team18.backend_server.domain.club.repository.ClubRepository;
 import com.kakaotech.team18.backend_server.domain.clubMember.repository.ClubMemberRepository;
 import com.kakaotech.team18.backend_server.domain.user.entity.User;
 import com.kakaotech.team18.backend_server.domain.user.repository.UserRepository;
@@ -55,8 +53,6 @@ class AuthServiceImplTest {
 
     @Mock
     private UserRepository userRepository;
-    @Mock
-    private ClubRepository clubRepository;
     @Mock
     private JwtProvider jwtProvider;
     @Mock
@@ -341,19 +337,11 @@ class AuthServiceImplTest {
                 .build();
         ReflectionTestUtils.setField(newUser, "id", 1L);
 
-        Club mockClub1 = Club.builder().build();
-        Club mockClub2 = Club.builder().build();
-        Club mockClub3 = Club.builder().build();
-
         given(jwtProvider.extractToken(bearerToken)).willReturn(temporaryToken);
         given(jwtProvider.verify(temporaryToken)).willReturn(claims);
         given(userRepository.findByStudentId(studentId)).willReturn(Optional.empty());
         given(jwtProvider.createAccessToken(any(User.class))).willReturn("newAccessToken");
         given(jwtProvider.createRefreshToken(any(User.class))).willReturn("newRefreshToken");
-        given(clubRepository.findById(1L)).willReturn(Optional.of(mockClub1));
-        given(clubRepository.findById(2L)).willReturn(Optional.of(mockClub2));
-        given(clubRepository.findById(3L)).willReturn(Optional.of(mockClub3));
-        given(clubMemberRepository.save(any())).willAnswer(invocation -> invocation.getArgument(0));
 
         // when
         LoginSuccessResponseDto result = authService.register(bearerToken, requestDto);


### PR DESCRIPTION
## 🚀 작업 내용
AutuServiceImpl 클래스의 registerDefaultClubMemberships 메서드를 제거후 관련 테스트도 함께 삭제했습니다. 

## ⏱️ 소요 시간
10분 

## 🤔 고민했던 내용


## 💬 리뷰 중점사항


## 🔗관련 이슈
- Close #312 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **리팩토링**
  * 신규 사용자 등록 시 자동으로 할당되던 기본 클럽 멤버십 설정 기능이 제거되었습니다.
  * 더 이상 필요하지 않은 클럽 관련 의존성과 참조가 정리되었습니다.
  * 관련된 테스트 코드도 함께 정리되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->