### PR TITLE
[REFACTOR] 면접 단계에서 합격자 중 면접 일정이 확정되지 않은 경우 결과 전송할 때 에러 반환하도록 수정 (#314)

### DIFF
--- a/src/main/java/com/kakaotech/team18/backend_server/domain/application/service/ApplicationServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/application/service/ApplicationServiceImpl.java
@@ -43,6 +43,7 @@ import com.kakaotech.team18.backend_server.global.exception.exceptions.InvalidAn
 import com.kakaotech.team18.backend_server.global.exception.exceptions.NoApplicationException;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.PendingApplicationsExistException;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.PresidentNotFoundException;
+import com.kakaotech.team18.backend_server.global.exception.exceptions.UnscheduledAcceptedApplicantExistsException;
 import com.kakaotech.team18.backend_server.global.util.DateUtil;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -380,7 +381,6 @@ public class ApplicationServiceImpl implements ApplicationService {
             if (hasPending) {
                 throw new PendingApplicationsExistException();
             }
-            form.updateInterviewMessage(requestDto.message());
             List<Application> approved = apps.stream()
                     .filter(a -> a.getStage() == stage)
                     .filter(a -> a.getStatus() == Status.APPROVED)
@@ -389,6 +389,15 @@ public class ApplicationServiceImpl implements ApplicationService {
                     .filter(a -> a.getStage() == stage)
                     .filter(a -> a.getStatus() == Status.REJECTED)
                     .toList();
+
+            boolean hasUnscheduledApproved = approved.stream()
+                    .anyMatch(a -> a.getInterviewDate() == null || a.getInterviewTime() == null);
+            if (hasUnscheduledApproved) {
+                throw new UnscheduledAcceptedApplicantExistsException();
+            }
+
+            form.updateInterviewMessage(requestDto.message());
+
             for(Application a : approved) {
                 ApplicationInfoDto applicationInfoDto = buildApplicationInfo(a,president);
                 Stage originalStage = a.getStage();

--- a/src/main/java/com/kakaotech/team18/backend_server/global/exception/code/ErrorCode.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/exception/code/ErrorCode.java
@@ -39,6 +39,7 @@ public enum ErrorCode {
     INVALID_TIME_SLOT("면접 시작 시간은 마감 시간보다 이전이어야 합니다.", HttpStatus.BAD_REQUEST),
     INVALID_EXCEL_DATA("엑셀 데이터 검증 실패", HttpStatus.BAD_REQUEST),
     CANNOT_DELETE_SELF("자기 자신은 삭제할 수 없습니다. 권한 위임 후 탈퇴해주세요.", HttpStatus.BAD_REQUEST),
+    UNSCHEDULED_ACCEPTED_APPLICANT_EXISTS("면접 시간을 결정하지 않은 합격자가 존재합니다. 모든 합격자의 면저 시간을 결정해주세요.", HttpStatus.BAD_REQUEST),
 
     // 401 UNAUTHORIZED: 인증되지 않은 사용자
     UNAUTHENTICATED_USER("인증되지 않은 사용자입니다.", HttpStatus.UNAUTHORIZED),

--- a/src/main/java/com/kakaotech/team18/backend_server/global/exception/code/ErrorCode.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/exception/code/ErrorCode.java
@@ -39,7 +39,7 @@ public enum ErrorCode {
     INVALID_TIME_SLOT("면접 시작 시간은 마감 시간보다 이전이어야 합니다.", HttpStatus.BAD_REQUEST),
     INVALID_EXCEL_DATA("엑셀 데이터 검증 실패", HttpStatus.BAD_REQUEST),
     CANNOT_DELETE_SELF("자기 자신은 삭제할 수 없습니다. 권한 위임 후 탈퇴해주세요.", HttpStatus.BAD_REQUEST),
-    UNSCHEDULED_ACCEPTED_APPLICANT_EXISTS("면접 시간을 결정하지 않은 합격자가 존재합니다. 모든 합격자의 면저 시간을 결정해주세요.", HttpStatus.BAD_REQUEST),
+    UNSCHEDULED_ACCEPTED_APPLICANT_EXISTS("면접 시간을 결정하지 않은 합격자가 존재합니다. 모든 합격자의 면접 시간을 결정해주세요.", HttpStatus.BAD_REQUEST),
 
     // 401 UNAUTHORIZED: 인증되지 않은 사용자
     UNAUTHENTICATED_USER("인증되지 않은 사용자입니다.", HttpStatus.UNAUTHORIZED),

--- a/src/main/java/com/kakaotech/team18/backend_server/global/exception/exceptions/UnscheduledAcceptedApplicantExistsException.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/exception/exceptions/UnscheduledAcceptedApplicantExistsException.java
@@ -1,0 +1,9 @@
+package com.kakaotech.team18.backend_server.global.exception.exceptions;
+
+import com.kakaotech.team18.backend_server.global.exception.code.ErrorCode;
+
+public class UnscheduledAcceptedApplicantExistsException extends CustomException {
+    public UnscheduledAcceptedApplicantExistsException() {
+        super(ErrorCode.UNSCHEDULED_ACCEPTED_APPLICANT_EXISTS);
+    }
+}

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/application/controller/ApplicationControllerTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/application/controller/ApplicationControllerTest.java
@@ -6,6 +6,7 @@ import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationApp
 import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationDetailResponseDto;
 import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationFixedInterviewRequestDto;
 import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationStatusUpdateRequestDto;
+import com.kakaotech.team18.backend_server.domain.application.entity.Stage;
 import com.kakaotech.team18.backend_server.domain.application.entity.Status;
 import com.kakaotech.team18.backend_server.domain.application.service.ApplicationService;
 import com.kakaotech.team18.backend_server.global.config.SecurityConfig;
@@ -13,6 +14,7 @@ import com.kakaotech.team18.backend_server.global.config.TestSecurityConfig;
 import com.kakaotech.team18.backend_server.global.dto.SuccessResponseDto;
 import com.kakaotech.team18.backend_server.global.exception.code.ErrorCode;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.ApplicationNotFoundException;
+import com.kakaotech.team18.backend_server.global.exception.exceptions.UnscheduledAcceptedApplicantExistsException;
 import com.kakaotech.team18.backend_server.global.security.JwtAuthenticationFilter;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.DisplayName;
@@ -276,6 +278,35 @@ class ApplicationControllerTest {
         // then
         resultActions.andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.error_code").value(ErrorCode.INVALID_INPUT_VALUE.name()));
+    }
+
+    @Test
+    @DisplayName("합/불 처리 및 메세지 전송 - 실패 (면접 시간이 미정인 합격자 존재)")
+    void sendPassFailMessage_fail_unscheduledAcceptedApplicantExists() throws Exception {
+        // given
+        Long clubId = 17L;
+        String requestBody = """
+                {
+                  "message": "면접 결과 공지"
+                }
+                """;
+
+        given(applicationService.sendPassFailMessage(eq(clubId), any(), eq(Stage.INTERVIEW)))
+                .willThrow(new UnscheduledAcceptedApplicantExistsException());
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                patch("/api/clubs/{clubId}/club-apply-form/result", clubId)
+                        .param("stage", "INTERVIEW")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody)
+        );
+
+        // then
+        resultActions.andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error_code").value(ErrorCode.UNSCHEDULED_ACCEPTED_APPLICANT_EXISTS.name()))
+                .andExpect(jsonPath("$.message")
+                        .value("면접 시간을 결정하지 않은 합격자가 존재합니다. 모든 합격자의 면저 시간을 결정해주세요."));
     }
 
     @Nested

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/application/controller/ApplicationControllerTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/application/controller/ApplicationControllerTest.java
@@ -306,7 +306,7 @@ class ApplicationControllerTest {
         resultActions.andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.error_code").value(ErrorCode.UNSCHEDULED_ACCEPTED_APPLICANT_EXISTS.name()))
                 .andExpect(jsonPath("$.message")
-                        .value("면접 시간을 결정하지 않은 합격자가 존재합니다. 모든 합격자의 면저 시간을 결정해주세요."));
+                        .value("면접 시간을 결정하지 않은 합격자가 존재합니다. 모든 합격자의 면접 시간을 결정해주세요."));
     }
 
     @Nested

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/email/service/EmailServiceUnitTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/email/service/EmailServiceUnitTest.java
@@ -23,6 +23,7 @@ import com.kakaotech.team18.backend_server.domain.email.template.EmailTemplateRe
 import com.kakaotech.team18.backend_server.domain.user.entity.User;
 import com.kakaotech.team18.backend_server.global.dto.SuccessResponseDto;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.PendingApplicationsExistException;
+import com.kakaotech.team18.backend_server.global.exception.exceptions.UnscheduledAcceptedApplicantExistsException;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -462,6 +463,41 @@ class EmailServiceUnitTest {
         // 부수효과 없음
         verify(publisher, never()).publishEvent(any());
         // 단건 삭제/참조 끊기
+        verify(applicationRepository, never()).delete(any(Application.class));
+        verify(clubMemberRepository, never()).clearApplicationByApplicationId(anyLong());
+        verify(clubApplyForm, never()).updateInterviewMessage(anyString());
+        verify(clubApplyForm, never()).updateFinalMessage(anyString());
+    }
+
+    @Test
+    @DisplayName("stage=interview, APPROVED 중 면접 시간이 비어있으면 예외를 던지고 발송하지 않음")
+    void interviewStage_flow_unscheduledApprovedExists_throws() {
+        // given
+        Long clubId = 101L;
+        User president = User.builder()
+                .email("president@club.com")
+                .build();
+        when(clubMemberRepository.findUserByClubIdAndRoleAndStatus(clubId, Role.CLUB_ADMIN, ActiveStatus.ACTIVE))
+                .thenReturn(Optional.of(president));
+
+        when(clubApplyFormRepository.findByClubId(clubId)).thenReturn(Optional.of(clubApplyForm));
+
+        Application appApprovedWithoutSchedule = mock(Application.class);
+        when(appApprovedWithoutSchedule.getStage()).thenReturn(Stage.INTERVIEW);
+        when(appApprovedWithoutSchedule.getStatus()).thenReturn(Status.APPROVED);
+        when(appApprovedWithoutSchedule.getInterviewDate()).thenReturn(null);
+
+        when(applicationRepository.findAllByClubIdAndRoleAndStage(clubId, Role.APPLICANT, Stage.INTERVIEW))
+                .thenReturn(List.of(appApprovedWithoutSchedule));
+
+        ApplicationApprovedRequestDto req = new ApplicationApprovedRequestDto("message");
+
+        // when / then
+        assertThatThrownBy(() -> serviceImpl.sendPassFailMessage(clubId, req, Stage.INTERVIEW))
+                .isInstanceOf(UnscheduledAcceptedApplicantExistsException.class);
+
+        // 부수효과 없음
+        verify(publisher, never()).publishEvent(any());
         verify(applicationRepository, never()).delete(any(Application.class));
         verify(clubMemberRepository, never()).clearApplicationByApplicationId(anyLong());
         verify(clubApplyForm, never()).updateInterviewMessage(anyString());


### PR DESCRIPTION
## 🚀 작업 내용
면접 단계에서 합격자 중 면접 일정이 확정되지 않은 경우 결과 전송할 때 에러 반환하도록 수정했습니다. 

반환할 400 에러 UnscheduledAcceptedApplicantExistsException를 추가했고 

INTERVIEW 단계의 합격자들에 대해서 한명이라도 면접 일정이 확정되지 않은 지원자가 있다면 이 에러를 반환하도록 했고, message 값은 이 검증을 통과한뒤 채워지도록 코드를 밑으로 내렸습니다. 

## ⏱️ 소요 시간
30분 

## 🤔 고민했던 내용


## 💬 리뷰 중점사항


## 🔗관련 이슈
- Close #314 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 합격자 가운데 면접일/시간이 비어있는 경우, 합격·불합격 메시지 발송 시 검증을 추가하여 오류를 반환합니다. 오류 메시지: "면접 시간을 결정하지 않은 합격자가 존재합니다. 모든 합격자의 면접 시간을 결정해주세요."

* **Tests**
  * 미정 면접 일정 검증 동작을 확인하는 단위/통합 테스트 케이스가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->