### PR TITLE
[feat] 인터뷰가 없는 동아리를 위한 로직 추가(#315)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -224,3 +224,9 @@ gradle-app.setting
 # End of https://www.toptal.com/developers/gitignore/api/java,gradle,windows,macos,dotenv,visualstudiocode,intellij+all
 
 src/main/resources/application.yml
+
+# Build output directory
+bin/
+
+# Claude Code settings
+.claude/

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/application/service/ApplicationServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/application/service/ApplicationServiceImpl.java
@@ -404,7 +404,10 @@ public class ApplicationServiceImpl implements ApplicationService {
                 if(isInterviewRequired) {
                     a.updateStage(Stage.FINAL);
                     a.updateStatus(Status.PENDING);
-                } else a.updateStage(Stage.RESULT);
+                } else {
+                    a.updateStage(Stage.RESULT);
+                    clubMemberRepository.updateRoleByApplicationId(a.getId(), Role.APPLICANT, Role.CLUB_MEMBER);
+                }
                 publisher.publishEvent(new InterviewApprovedEvent(
                         applicationInfoDto,
                         a.getId(),

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/application/service/ApplicationServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/application/service/ApplicationServiceImpl.java
@@ -16,6 +16,8 @@ import com.kakaotech.team18.backend_server.domain.application.entity.Application
 import com.kakaotech.team18.backend_server.domain.application.entity.Stage;
 import com.kakaotech.team18.backend_server.domain.application.entity.Status;
 import com.kakaotech.team18.backend_server.domain.application.repository.ApplicationRepository;
+import com.kakaotech.team18.backend_server.domain.club.entity.Club;
+import com.kakaotech.team18.backend_server.domain.club.repository.ClubRepository;
 import com.kakaotech.team18.backend_server.domain.clubApplyForm.entity.ClubApplyForm;
 import com.kakaotech.team18.backend_server.domain.clubApplyForm.repository.ClubApplyFormRepository;
 import com.kakaotech.team18.backend_server.domain.clubMember.entity.ActiveStatus;
@@ -36,6 +38,7 @@ import com.kakaotech.team18.backend_server.domain.user.repository.UserRepository
 import com.kakaotech.team18.backend_server.global.dto.SuccessResponseDto;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.ApplicationNotFoundException;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.ClubApplyFormNotFoundException;
+import com.kakaotech.team18.backend_server.global.exception.exceptions.ClubNotFoundException;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.ExistingUserEmailException;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.ExistingUserPhoneNumberException;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.ExistingUserStudentIdException;
@@ -68,6 +71,7 @@ public class ApplicationServiceImpl implements ApplicationService {
 
     private final ApplicationRepository applicationRepository;
     private final AnswerRepository answerRepository;
+    private final ClubRepository clubRepository;
     private final ClubApplyFormRepository clubApplyFormRepository;
     private final FormQuestionRepository formQuestionRepository;
     private final UserRepository userRepository;
@@ -367,6 +371,11 @@ public class ApplicationServiceImpl implements ApplicationService {
                             return new ClubApplyFormNotFoundException("clubId = " + clubId);
                         }
                 );
+
+        Club club = clubRepository.findById(clubId)
+                .orElseThrow(()->new ClubNotFoundException("clubId = " + clubId));
+        Boolean isInterviewRequired = club.getIsInterviewRequired();
+
         User president = clubMemberRepository
                 .findUserByClubIdAndRoleAndStatus(clubId, Role.CLUB_ADMIN, ActiveStatus.ACTIVE)
                 .orElseThrow(() -> new PresidentNotFoundException("clubId:" + clubId));
@@ -392,8 +401,11 @@ public class ApplicationServiceImpl implements ApplicationService {
             for(Application a : approved) {
                 ApplicationInfoDto applicationInfoDto = buildApplicationInfo(a,president);
                 Stage originalStage = a.getStage();
-                a.updateStage(Stage.FINAL);
-                a.updateStatus(Status.PENDING);
+                if(isInterviewRequired) {
+                    a.updateStage(Stage.FINAL);
+                    a.updateStatus(Status.PENDING);
+                }
+                a.updateStage(Stage.RESULT);
                 publisher.publishEvent(new InterviewApprovedEvent(
                         applicationInfoDto,
                         a.getId(),

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/application/service/ApplicationServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/application/service/ApplicationServiceImpl.java
@@ -404,8 +404,7 @@ public class ApplicationServiceImpl implements ApplicationService {
                 if(isInterviewRequired) {
                     a.updateStage(Stage.FINAL);
                     a.updateStatus(Status.PENDING);
-                }
-                a.updateStage(Stage.RESULT);
+                } else a.updateStage(Stage.RESULT);
                 publisher.publishEvent(new InterviewApprovedEvent(
                         applicationInfoDto,
                         a.getId(),

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/application/service/ApplicationServiceImplTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/application/service/ApplicationServiceImplTest.java
@@ -21,9 +21,12 @@ import com.kakaotech.team18.backend_server.domain.answer.repository.AnswerReposi
 import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationApplyRequestDto;
 import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationApplyRequestDto.AnswerDto;
 import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationApplyResponseDto;
+import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationApprovedRequestDto;
 import com.kakaotech.team18.backend_server.domain.application.dto.ApplicationFixedInterviewRequestDto;
 import com.kakaotech.team18.backend_server.domain.application.entity.InterviewPreference;
+import com.kakaotech.team18.backend_server.domain.application.entity.Stage;
 import com.kakaotech.team18.backend_server.domain.club.entity.Club;
+import com.kakaotech.team18.backend_server.domain.club.repository.ClubRepository;
 import com.kakaotech.team18.backend_server.domain.clubMember.entity.ActiveStatus;
 import com.kakaotech.team18.backend_server.domain.clubMember.entity.Role;
 import com.kakaotech.team18.backend_server.domain.clubMember.repository.ClubMemberRepository;
@@ -82,6 +85,9 @@ class ApplicationServiceImplTest {
 
     @Mock
     private FormQuestionRepository formQuestionRepository;
+
+    @Mock
+    private ClubRepository clubRepository;
 
     @Mock
     private ApplicationEventPublisher publisher;
@@ -351,6 +357,96 @@ class ApplicationServiceImplTest {
         assertTrue(responseDto.success());
         verify(applicationRepository, times(1)).findById(applicationId);
         verify(mockApplication, times(1)).updateInterviewInfo(newInterviewTime);
+    }
+
+    @Test
+    @DisplayName("sendPassFailMessage - 인터뷰 있는 동아리: INTERVIEW 합격 시 Stage.FINAL, Status.PENDING으로 변경")
+    void sendPassFailMessage_interview_withInterviewRequired_moveToFinalStage() {
+        // given
+        Long clubId = 1L;
+        ApplicationApprovedRequestDto requestDto = new ApplicationApprovedRequestDto("합격을 축하합니다");
+
+        ClubApplyForm mockClubApplyForm = mock(ClubApplyForm.class);
+        Club mockClub = mock(Club.class);
+        User mockPresident = mock(User.class);
+        User mockUser = mock(User.class);
+        Application mockApplication = mock(Application.class);
+
+        when(clubApplyFormRepository.findByClubId(clubId)).thenReturn(Optional.of(mockClubApplyForm));
+        when(clubRepository.findById(clubId)).thenReturn(Optional.of(mockClub));
+        when(mockClub.getIsInterviewRequired()).thenReturn(true);
+        when(clubMemberRepository.findUserByClubIdAndRoleAndStatus(clubId, Role.CLUB_ADMIN, ActiveStatus.ACTIVE))
+                .thenReturn(Optional.of(mockPresident));
+        when(applicationRepository.findAllByClubIdAndRoleAndStage(clubId, Role.APPLICANT, Stage.INTERVIEW))
+                .thenReturn(List.of(mockApplication));
+        when(mockApplication.getStage()).thenReturn(Stage.INTERVIEW);
+        when(mockApplication.getStatus()).thenReturn(Status.APPROVED);
+
+        when(mockApplication.getClubApplyForm()).thenReturn(mockClubApplyForm);
+        when(mockClubApplyForm.getClub()).thenReturn(mockClub);
+        when(mockClub.getName()).thenReturn("테스트 동아리");
+        when(mockClub.getId()).thenReturn(clubId);
+        when(mockApplication.getUser()).thenReturn(mockUser);
+        when(mockUser.getName()).thenReturn("김지원");
+        when(mockPresident.getEmail()).thenReturn("president@test.com");
+        when(mockUser.getStudentId()).thenReturn("20230001");
+        when(mockUser.getDepartment()).thenReturn("컴퓨터공학과");
+        when(mockUser.getPhoneNumber()).thenReturn("010-1234-5678");
+        when(mockUser.getEmail()).thenReturn("user@test.com");
+
+        // when
+        SuccessResponseDto result = applicationService.sendPassFailMessage(clubId, requestDto, Stage.INTERVIEW);
+
+        // then
+        assertTrue(result.success());
+        verify(mockApplication, times(1)).updateStage(Stage.FINAL);
+        verify(mockApplication, times(1)).updateStatus(Status.PENDING);
+        verify(mockApplication, never()).updateStage(Stage.RESULT);
+    }
+
+    @Test
+    @DisplayName("sendPassFailMessage - 인터뷰 없는 동아리: INTERVIEW 합격 시 Stage.RESULT로 변경")
+    void sendPassFailMessage_interview_withoutInterviewRequired_moveToResultStage() {
+        // given
+        Long clubId = 1L;
+        ApplicationApprovedRequestDto requestDto = new ApplicationApprovedRequestDto("합격을 축하합니다");
+
+        ClubApplyForm mockClubApplyForm = mock(ClubApplyForm.class);
+        Club mockClub = mock(Club.class);
+        User mockPresident = mock(User.class);
+        User mockUser = mock(User.class);
+        Application mockApplication = mock(Application.class);
+
+        when(clubApplyFormRepository.findByClubId(clubId)).thenReturn(Optional.of(mockClubApplyForm));
+        when(clubRepository.findById(clubId)).thenReturn(Optional.of(mockClub));
+        when(mockClub.getIsInterviewRequired()).thenReturn(false);
+        when(clubMemberRepository.findUserByClubIdAndRoleAndStatus(clubId, Role.CLUB_ADMIN, ActiveStatus.ACTIVE))
+                .thenReturn(Optional.of(mockPresident));
+        when(applicationRepository.findAllByClubIdAndRoleAndStage(clubId, Role.APPLICANT, Stage.INTERVIEW))
+                .thenReturn(List.of(mockApplication));
+        when(mockApplication.getStage()).thenReturn(Stage.INTERVIEW);
+        when(mockApplication.getStatus()).thenReturn(Status.APPROVED);
+
+        when(mockApplication.getClubApplyForm()).thenReturn(mockClubApplyForm);
+        when(mockClubApplyForm.getClub()).thenReturn(mockClub);
+        when(mockClub.getName()).thenReturn("테스트 동아리");
+        when(mockClub.getId()).thenReturn(clubId);
+        when(mockApplication.getUser()).thenReturn(mockUser);
+        when(mockUser.getName()).thenReturn("김지원");
+        when(mockPresident.getEmail()).thenReturn("president@test.com");
+        when(mockUser.getStudentId()).thenReturn("20230001");
+        when(mockUser.getDepartment()).thenReturn("컴퓨터공학과");
+        when(mockUser.getPhoneNumber()).thenReturn("010-1234-5678");
+        when(mockUser.getEmail()).thenReturn("user@test.com");
+
+        // when
+        SuccessResponseDto result = applicationService.sendPassFailMessage(clubId, requestDto, Stage.INTERVIEW);
+
+        // then
+        assertTrue(result.success());
+        verify(mockApplication, times(1)).updateStage(Stage.RESULT);
+        verify(mockApplication, never()).updateStage(Stage.FINAL);
+        verify(mockApplication, never()).updateStatus(Status.PENDING);
     }
 
     @Test

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/application/service/ApplicationServiceImplTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/application/service/ApplicationServiceImplTest.java
@@ -426,6 +426,7 @@ class ApplicationServiceImplTest {
                 .thenReturn(List.of(mockApplication));
         when(mockApplication.getStage()).thenReturn(Stage.INTERVIEW);
         when(mockApplication.getStatus()).thenReturn(Status.APPROVED);
+        when(mockApplication.getId()).thenReturn(10L);
 
         when(mockApplication.getClubApplyForm()).thenReturn(mockClubApplyForm);
         when(mockClubApplyForm.getClub()).thenReturn(mockClub);
@@ -447,6 +448,7 @@ class ApplicationServiceImplTest {
         verify(mockApplication, times(1)).updateStage(Stage.RESULT);
         verify(mockApplication, never()).updateStage(Stage.FINAL);
         verify(mockApplication, never()).updateStatus(Status.PENDING);
+        verify(clubMemberRepository, times(1)).updateRoleByApplicationId(10L, Role.APPLICANT, Role.CLUB_MEMBER);
     }
 
     @Test

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/email/service/EmailServiceUnitTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/email/service/EmailServiceUnitTest.java
@@ -7,6 +7,7 @@ import com.kakaotech.team18.backend_server.domain.application.entity.Status;
 import com.kakaotech.team18.backend_server.domain.application.repository.ApplicationRepository;
 import com.kakaotech.team18.backend_server.domain.application.service.ApplicationServiceImpl;
 import com.kakaotech.team18.backend_server.domain.club.entity.Club;
+import com.kakaotech.team18.backend_server.domain.club.repository.ClubRepository;
 import com.kakaotech.team18.backend_server.domain.clubApplyForm.entity.ClubApplyForm;
 import com.kakaotech.team18.backend_server.domain.clubApplyForm.repository.ClubApplyFormRepository;
 import com.kakaotech.team18.backend_server.domain.clubMember.entity.ActiveStatus;
@@ -77,6 +78,8 @@ class EmailServiceUnitTest {
     ClubApplyForm clubApplyForm;
     @Mock
     ClubApplyFormRepository clubApplyFormRepository;
+    @Mock
+    ClubRepository clubRepository;
 
     @Captor
     ArgumentCaptor<Map<String,Object>> modelCaptor;
@@ -179,6 +182,7 @@ class EmailServiceUnitTest {
 
         Club club1 = mock(Club.class);
         when(club1.getId()).thenReturn(77L);
+        when(club1.getIsInterviewRequired()).thenReturn(true);
         User president = User.builder()
                 .email("president@club.com")
                 .build();
@@ -193,6 +197,7 @@ class EmailServiceUnitTest {
         when(clubApplyForm.getClub()).thenReturn(club1);
         when(appRejected.getClubApplyForm()).thenReturn(clubApplyForm);
         when(clubApplyFormRepository.findByClubId(77L)).thenReturn(Optional.of(clubApplyForm));
+        when(clubRepository.findById(77L)).thenReturn(Optional.of(club1));
 
         // 공통: stage 초기값은 INTERVIEW
         final Stage[] approvedStageRef = { Stage.INTERVIEW }; // updateStage 호출 시 바뀌게 함
@@ -289,6 +294,7 @@ class EmailServiceUnitTest {
 
         when(clubApplyForm.getClub()).thenReturn(club1);
         when(clubApplyFormRepository.findByClubId(88L)).thenReturn(Optional.of(clubApplyForm));
+        when(clubRepository.findById(88L)).thenReturn(Optional.of(club1));
 
         when(appApproved.getStage()).thenReturn(Stage.FINAL);
         when(appRejected.getStage()).thenReturn(Stage.FINAL);
@@ -360,6 +366,7 @@ class EmailServiceUnitTest {
         Club clubN = mock(Club.class);
         when(clubN.getId()).thenReturn(clubId);
         when(clubApplyFormRepository.findByClubId(clubId)).thenReturn(Optional.of(clubApplyForm));
+        when(clubRepository.findById(clubId)).thenReturn(Optional.of(clubN));
         when(clubApplyForm.getClub()).thenReturn(clubN);
 
         // 앱들 (모두 stage == null)
@@ -445,6 +452,7 @@ class EmailServiceUnitTest {
         when(clubMemberRepository.findUserByClubIdAndRoleAndStatus(clubId, Role.CLUB_ADMIN, ActiveStatus.ACTIVE)).thenReturn(Optional.of(president));
 
         when(clubApplyFormRepository.findByClubId(clubId)).thenReturn(Optional.of(clubApplyForm));
+        when(clubRepository.findById(clubId)).thenReturn(Optional.of(mock(Club.class)));
 
         Application appPending = mock(Application.class);
         when(appPending.getStage()).thenReturn(Stage.INTERVIEW);
@@ -479,6 +487,7 @@ class EmailServiceUnitTest {
         when(clubMemberRepository.findUserByClubIdAndRoleAndStatus(clubId, Role.CLUB_ADMIN, ActiveStatus.ACTIVE)).thenReturn(Optional.of(president));
 
         when(clubApplyFormRepository.findByClubId(clubId)).thenReturn(Optional.of(clubApplyForm));
+        when(clubRepository.findById(clubId)).thenReturn(Optional.of(mock(Club.class)));
 
         Application appPending = mock(Application.class);
         when(appPending.getStage()).thenReturn(Stage.FINAL);
@@ -512,6 +521,7 @@ class EmailServiceUnitTest {
         when(clubMemberRepository.findUserByClubIdAndRoleAndStatus(clubId, Role.CLUB_ADMIN, ActiveStatus.ACTIVE)).thenReturn(Optional.of(president));
 
         when(clubApplyFormRepository.findByClubId(clubId)).thenReturn(Optional.of(clubApplyForm));
+        when(clubRepository.findById(clubId)).thenReturn(Optional.of(mock(Club.class)));
 
         Application appPending = mock(Application.class);
         when(appPending.getStatus()).thenReturn(Status.PENDING);


### PR DESCRIPTION
## 🚀 작업 내용
인터뷰가 없는 동아리는 전송하기를 누르면 지원자들이 결과로 이동하도록 수정

## ⏱️ 소요 시간


## 🤔 고민했던 내용


## 💬 리뷰 중점사항


## 🔗관련 이슈
- Close #315 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * 동아리의 인터뷰 필수 여부를 조회해 지원 처리 흐름에 반영하도록 로직 개선
  * 인터뷰 필요 시 기존처럼 최종 단계로 이동하고 대기 상태로 전환, 인터뷰 불필요 시 최종 단계(Result)로 바로 전환하도록 변경
  * 합격 처리 시 인터뷰 요구 여부와 상관없이 관련 승인 이벤트 발행을 계속 유지

* **테스트**
  * 인터뷰 필요/불필요 흐름을 검증하는 단위 테스트 추가 및 보강
<!-- end of auto-generated comment: release notes by coderabbit.ai -->