### PR TITLE
[FIX] kakao-auth 사용자 개인정보 동의가 되어 있지 않은 경우에도 프로세스 완주할 수 있도록 수정

### DIFF
--- a/src/main/java/com/kakaotech/team18/backend_server/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/auth/service/AuthServiceImpl.java
@@ -126,10 +126,15 @@ public class AuthServiceImpl implements AuthService {
             // 4-2. 신규 회원일 경우: 추가 정보 입력 필요
             log.info("신규 회원, 추가 정보 입력 필요");
 
+            String nickname = "익명";
+            if (kakaoUserInfo.getProperties() != null && kakaoUserInfo.getProperties().getNickname() != null) {
+                nickname = kakaoUserInfo.getProperties().getNickname();
+            }
+
             // 임시 토큰 발급
             String temporaryToken = jwtProvider.createTemporaryToken(
                     kakaoUserInfo.getId(),
-                    kakaoUserInfo.getProperties().getNickname()
+                    nickname
             );
 
             return new RegistrationRequiredResponseDto(AuthStatus.REGISTRATION_REQUIRED, temporaryToken);


### PR DESCRIPTION
## 🚀 작업 내용
카카오 로그인 및 회원가입 과정에서 
카카오 사용자 개인정보를 받아와서 '닉네임'을 뽑습니다.

사실 이 닉네임이 현재 활용되고 있지 않습니다. 
(기존에 닉네임이 회원가입 과정에서 이름에 자동으로 들어가있도록 구현하려고 했었는데 진행되지 않았습니다.)

카카오 사용자 개인정보 동의가 되어있지 않은 사용자의 경우 
닉네임에 null 이 들어가고 결과적으로 NPE가 발생하는 문제였습니다.

카카오 사용자 개인정보 동의가 되어있지 않은 사용자의 경우 
일단 닉네임에 "익명"이 들어가도록 로직 수정했습니다.
(참고: 이 닉네임은 사용자에게 나타나지 않습니다.) 

이를 통해 사용자 개인정보 동의가 되어있지 않아도 프로세스를 완주할 수 있습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 카카오 로그인 시 신규 사용자의 닉네임 처리 개선
  * 닉네임이 없는 경우 기본값으로 '익명'이 설정되도록 변경
  * 로그인 토큰 생성 시 더욱 안정적인 닉네임 처리 적용

<!-- end of auto-generated comment: release notes by coderabbit.ai -->