### PR TITLE
[FEATURE] 유저 활동 내역 기록 필터, 테이블 추가 

### DIFF
--- a/src/main/java/com/kakaotech/team18/backend_server/domain/activity/entity/ActivityDaily.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/activity/entity/ActivityDaily.java
@@ -1,0 +1,90 @@
+package com.kakaotech.team18.backend_server.domain.activity.entity;
+
+import com.kakaotech.team18.backend_server.domain.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+        name = "activity_daily",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_activity_daily_user", columnNames = {"activity_date", "user_id"}),
+                @UniqueConstraint(name = "uk_activity_daily_anonymous", columnNames = {"activity_date", "anonymous_id"})
+        }
+)
+public class ActivityDaily extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "activity_daily_id")
+    private Long id;
+
+    @Column(name = "activity_date", nullable = false)
+    private LocalDate activityDate;
+
+    @Column(name = "anonymous_id")
+    private String anonymousId;
+
+    @Column(name = "user_id")
+    private Long userId;
+
+    @Column(name = "first_seen_at", nullable = false)
+    private LocalDateTime firstSeenAt;
+
+    @Column(name = "last_seen_at", nullable = false)
+    private LocalDateTime lastSeenAt;
+
+    @Column(name = "hit_count", nullable = false)
+    private Integer hitCount;
+
+    @Builder
+    private ActivityDaily(LocalDate activityDate, String anonymousId, Long userId,
+            LocalDateTime firstSeenAt, LocalDateTime lastSeenAt, Integer hitCount) {
+        this.activityDate = activityDate;
+        this.anonymousId = anonymousId;
+        this.userId = userId;
+        this.firstSeenAt = firstSeenAt;
+        this.lastSeenAt = lastSeenAt;
+        this.hitCount = hitCount;
+    }
+
+    public static ActivityDaily forUser(LocalDate activityDate, Long userId, LocalDateTime now) {
+        return ActivityDaily.builder()
+                .activityDate(activityDate)
+                .userId(userId)
+                .anonymousId(null)
+                .firstSeenAt(now)
+                .lastSeenAt(now)
+                .hitCount(1)
+                .build();
+    }
+
+    public static ActivityDaily forAnonymous(LocalDate activityDate, String anonymousId, LocalDateTime now) {
+        return ActivityDaily.builder()
+                .activityDate(activityDate)
+                .userId(null)
+                .anonymousId(anonymousId)
+                .firstSeenAt(now)
+                .lastSeenAt(now)
+                .hitCount(1)
+                .build();
+    }
+
+    public void touch(LocalDateTime now) {
+        this.lastSeenAt = now;
+        this.hitCount = this.hitCount + 1;
+    }
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/activity/repository/ActivityDailyRepository.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/activity/repository/ActivityDailyRepository.java
@@ -1,0 +1,12 @@
+package com.kakaotech.team18.backend_server.domain.activity.repository;
+
+import com.kakaotech.team18.backend_server.domain.activity.entity.ActivityDaily;
+import java.time.LocalDate;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ActivityDailyRepository extends JpaRepository<ActivityDaily, Long> {
+    Optional<ActivityDaily> findByActivityDateAndUserId(LocalDate activityDate, Long userId);
+
+    Optional<ActivityDaily> findByActivityDateAndAnonymousId(LocalDate activityDate, String anonymousId);
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/activity/service/ActivityTrackingService.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/activity/service/ActivityTrackingService.java
@@ -1,0 +1,47 @@
+package com.kakaotech.team18.backend_server.domain.activity.service;
+
+import com.kakaotech.team18.backend_server.domain.activity.entity.ActivityDaily;
+import com.kakaotech.team18.backend_server.domain.activity.repository.ActivityDailyRepository;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ActivityTrackingService {
+
+    private final ActivityDailyRepository activityDailyRepository;
+
+    @Transactional
+    public void track(String anonymousId, Long userId) {
+        LocalDate today = LocalDate.now();
+        LocalDateTime now = LocalDateTime.now();
+        if (userId != null) {
+            ActivityDaily row = activityDailyRepository.findByActivityDateAndUserId(today, userId)
+                    .orElse(null);
+            if (row == null) {
+                activityDailyRepository.save(ActivityDaily.forUser(today, userId, now));
+                return;
+            }
+            row.touch(now);
+            activityDailyRepository.save(row);
+            return;
+        }
+        if (anonymousId == null || anonymousId.isBlank()) {
+            log.warn("Skip activity tracking: anonymousId is missing");
+            return;
+        }
+        ActivityDaily row = activityDailyRepository.findByActivityDateAndAnonymousId(today, anonymousId)
+                .orElse(null);
+        if (row == null) {
+            activityDailyRepository.save(ActivityDaily.forAnonymous(today, anonymousId, now));
+            return;
+        }
+        row.touch(now);
+        activityDailyRepository.save(row);
+    }
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/global/config/SecurityConfig.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/config/SecurityConfig.java
@@ -1,18 +1,20 @@
 package com.kakaotech.team18.backend_server.global.config;
 
+import com.kakaotech.team18.backend_server.domain.activity.service.ActivityTrackingService;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.ForbiddenAccessException;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.UnauthenticatedUserException;
+import com.kakaotech.team18.backend_server.global.security.ActivityTrackingFilter;
 import com.kakaotech.team18.backend_server.global.security.JwtAuthenticationFilter;
 import com.kakaotech.team18.backend_server.global.security.JwtProperties;
 import com.kakaotech.team18.backend_server.global.security.JwtProvider;
 import com.kakaotech.team18.backend_server.global.security.PrincipalDetailsService;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.http.HttpMethod;
-import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -36,15 +38,18 @@ public class SecurityConfig {
     private final JwtProvider jwtProvider;
     private final PrincipalDetailsService principalDetailsService;
     private final RedisTemplate<String, String> redisTemplate;
+    private final ObjectProvider<ActivityTrackingFilter> activityTrackingFilterProvider;
 
     public SecurityConfig(@Qualifier("handlerExceptionResolver") HandlerExceptionResolver resolver,
             JwtProvider jwtProvider,
             PrincipalDetailsService principalDetailsService,
-            RedisTemplate<String, String> redisTemplate) {
+            RedisTemplate<String, String> redisTemplate,
+            ObjectProvider<ActivityTrackingFilter> activityTrackingFilterProvider) {
         this.resolver = resolver;
         this.jwtProvider = jwtProvider;
         this.principalDetailsService = principalDetailsService;
         this.redisTemplate = redisTemplate;
+        this.activityTrackingFilterProvider = activityTrackingFilterProvider;
     }
 
     /**
@@ -95,8 +100,18 @@ public class SecurityConfig {
         http.addFilterBefore(
                 new JwtAuthenticationFilter(jwtProvider, principalDetailsService, resolver, redisTemplate),
                 UsernamePasswordAuthenticationFilter.class);
+        ActivityTrackingFilter activityTrackingFilter = activityTrackingFilterProvider.getIfAvailable();
+        if (activityTrackingFilter != null) {
+            http.addFilterAfter(activityTrackingFilter, JwtAuthenticationFilter.class);
+        }
 
         return http.build();
+    }
+
+    @Bean
+    @ConditionalOnBean(ActivityTrackingService.class)
+    public ActivityTrackingFilter activityTrackingFilter(ActivityTrackingService activityTrackingService) {
+        return new ActivityTrackingFilter(activityTrackingService);
     }
 
     private AuthenticationEntryPoint authenticationEntryPoint() {

--- a/src/main/java/com/kakaotech/team18/backend_server/global/security/ActivityTrackingFilter.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/security/ActivityTrackingFilter.java
@@ -1,0 +1,89 @@
+package com.kakaotech.team18.backend_server.global.security;
+
+import com.kakaotech.team18.backend_server.domain.activity.service.ActivityTrackingService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ActivityTrackingFilter extends OncePerRequestFilter {
+
+    private static final String ANONYMOUS_COOKIE_NAME = "anonymous_id";
+    private static final int ANONYMOUS_COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 365;
+
+    private final ActivityTrackingService activityTrackingService;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String requestUri = request.getRequestURI();
+        if (!isTrackTarget(requestUri, request.getMethod())) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String anonymousId = getCookieValue(request, ANONYMOUS_COOKIE_NAME);
+        if (anonymousId == null || anonymousId.isBlank()) {
+            anonymousId = UUID.randomUUID().toString();
+            Cookie cookie = new Cookie(ANONYMOUS_COOKIE_NAME, anonymousId);
+            cookie.setPath("/");
+            cookie.setHttpOnly(true);
+            cookie.setMaxAge(ANONYMOUS_COOKIE_MAX_AGE_SECONDS);
+            cookie.setSecure(request.isSecure());
+            response.addCookie(cookie);
+        }
+
+        try {
+            Long userId = extractUserId();
+            activityTrackingService.track(anonymousId, userId);
+        } catch (Exception e) {
+            // MAU 추적 실패가 비즈니스 요청 실패로 이어지지 않도록 보호
+            log.warn("Failed to track activity for uri={}: {}", requestUri, e.getMessage());
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private boolean isTrackTarget(String uri, String method) {
+        if (uri == null || !uri.startsWith("/api/")) {
+            return false;
+        }
+        if ("OPTIONS".equalsIgnoreCase(method)) {
+            return false;
+        }
+        return true;
+    }
+
+    private String getCookieValue(HttpServletRequest request, String cookieName) {
+        if (request.getCookies() == null) {
+            return null;
+        }
+        return Arrays.stream(request.getCookies())
+                .filter(c -> cookieName.equals(c.getName()))
+                .map(Cookie::getValue)
+                .findFirst()
+                .orElse(null);
+    }
+
+    private Long extractUserId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !(authentication.getPrincipal() instanceof PrincipalDetails principalDetails)) {
+            return null;
+        }
+        return principalDetails.getUserId();
+    }
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/global/security/ActivityTrackingFilter.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/security/ActivityTrackingFilter.java
@@ -13,10 +13,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
-@Component
 @RequiredArgsConstructor
 @Slf4j
 public class ActivityTrackingFilter extends OncePerRequestFilter {

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/activity/service/ActivityTrackingServiceTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/activity/service/ActivityTrackingServiceTest.java
@@ -1,0 +1,76 @@
+package com.kakaotech.team18.backend_server.domain.activity.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.kakaotech.team18.backend_server.domain.activity.entity.ActivityDaily;
+import com.kakaotech.team18.backend_server.domain.activity.repository.ActivityDailyRepository;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(MockitoExtension.class)
+class ActivityTrackingServiceTest {
+
+    @Mock
+    private ActivityDailyRepository activityDailyRepository;
+
+    private ActivityTrackingService activityTrackingService;
+
+    @BeforeEach
+    void setUp() {
+        activityTrackingService = new ActivityTrackingService(activityDailyRepository);
+    }
+
+    @Test
+    @DisplayName("익명 방문자 첫 활동은 hit_count=1로 저장된다")
+    void track_anonymous_firstSeen() {
+        String anonymousId = "anon-1";
+        when(activityDailyRepository.findByActivityDateAndAnonymousId(any(LocalDate.class), any(String.class)))
+                .thenReturn(Optional.empty());
+
+        activityTrackingService.track(anonymousId, null);
+
+        ArgumentCaptor<ActivityDaily> captor = ArgumentCaptor.forClass(ActivityDaily.class);
+        verify(activityDailyRepository).save(captor.capture());
+        ActivityDaily saved = captor.getValue();
+        assertThat(saved.getAnonymousId()).isEqualTo(anonymousId);
+        assertThat(saved.getUserId()).isNull();
+        assertThat(saved.getHitCount()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("로그인 사용자 기존 활동이 있으면 hit_count가 증가한다")
+    void track_user_existingRow_touch() {
+        Long userId = 10L;
+        LocalDate today = LocalDate.now();
+        ActivityDaily existing = ActivityDaily.forUser(today, userId, LocalDateTime.now().minusHours(1));
+        existing.touch(LocalDateTime.now().minusMinutes(30)); // 현재 hit_count=2
+
+        when(activityDailyRepository.findByActivityDateAndUserId(any(LocalDate.class), any(Long.class)))
+                .thenReturn(Optional.of(existing));
+
+        activityTrackingService.track("anon-ignored", userId);
+
+        verify(activityDailyRepository).save(existing);
+        assertThat(existing.getHitCount()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("익명 식별자가 없으면 저장하지 않는다")
+    void track_missingAnonymousId_skip() {
+        activityTrackingService.track("   ", null);
+
+        verify(activityDailyRepository, never()).save(any(ActivityDaily.class));
+    }
+}


### PR DESCRIPTION
## 🚀 작업 내용
유저 활동을 기록해서 서비스 활성도를 파악하기 위해 acitivity_dailiy 테이블을 추가 

```
activity_daily_id
PK
activity_date
활동 일자(YYYY-MM-DD). MAU/DAU 집계의 기준 날짜

anonymous_id
비로그인 방문자 식별자(쿠키 anonymous_id 값).
로그인 사용자는 null

user_id
로그인 사용자 ID.
비로그인은 null

first_seen_at
해당 날짜에 처음 기록된 시각

last_seen_at
해당 날짜에 마지막으로 기록된 시각

hit_count
해당 날짜에 추적된 요청 횟수(동일 식별자 기준)
```

예상 필터 호출 흐름 
로그인, 비로그인 기준으로 달라지고 `/api/ ...`  API에만 동작합니다

```
비로그인 사용자:
1. 사용자가 서비스 접속 후 프론트가 /api/** 요청
2. ActivityTrackingFilter가 요청 가로챔
3. anonymous_id 쿠키 확인
4. 없으면 UUID 생성해서 쿠키 발급
5. SecurityContext에 로그인 정보 없음 → user_id = null
6. activity_daily에서 (오늘 날짜, anonymous_id) row 조회
7. 없으면 새 row 생성 first_seen_at=now, last_seen_at=now, hit_count=1
8. 있으면 업데이트 last_seen_at=now, hit_count += 1
9. 응답 반환
10. 사용자가 나갈 때 별도 종료 이벤트는 없음(마지막 호출 시점이 last_seen_at)

로그인 사용자:
1. 사용자가 /api/** 요청
2. JwtAuthenticationFilter가 먼저 동작해 인증 성공 시 SecurityContext에 PrincipalDetails(userId) 저장
3. ActivityTrackingFilter 동작
4. 쿠키는 확인/없으면 발급하지만, 집계 키는 user_id 우선
5. activity_daily에서 (오늘 날짜, user_id) row 조회
6. 없으면 새 row 생성 first_seen_at=now, last_seen_at=now, hit_count=1, anonymous_id=null
7. 있으면 업데이트 last_seen_at=now, hit_count += 1
8. 응답 반환
9. 나갈 때 별도 처리 없음

현재 기준 요약:
집계 트리거: /api/** 요청(OPTIONS 제외)
하루 단위 활동 row를 upsert하는 구조
비로그인 식별은 쿠키, 로그인 식별은 userId
```

이를 통해 파악할 수 있는 것들 
```
지금 구조로 바로 파악 가능한 건 아래입니다.
1.
DAU/MAU
로그인 사용자 DAU/MAU (user_id 기준)
비로그인 방문자 DAU/MAU (anonymous_id 기준)

2.
트래픽 강도
일자별 총 호출량 (hit_count 합)
사용자 1인당 평균 호출수

3.
재방문 패턴(거칠게)
같은 anonymous_id/user_id가 여러 날짜에 등장하는지
비로그인 재방문률 추정

4.
로그인 전환 관찰(간접)
같은 날짜에 비로그인 활동 대비 로그인 활동 규모 비교
“방문은 많은데 로그인은 적다” 같은 퍼널 병목 파악

5.
운영 모니터링 보조
특정 날짜 급증/급감 감지
배포 이후 활동량 변화 체크


한계
페이지 단위/기능 단위 어디서 활동했는지 모름 (URI 저장 안 함)
세션 길이/이탈 시점 정확히 모름 (종료 이벤트 없음)
비로그인 식별은 쿠키라 삭제/브라우저 변경 시 분리됨
```

일단 러프하게 LLM으로 만들어봤습니다. 

이게 세큐리티 컨피그랑 필터가 추가된거라 가능하면 LLM과 같이 리뷰 꼼꼼히 해주시고 에러 발생 여부가 조금이라도 있으면 미뤄도 될 것 같아요. 

그리고 merge 전에 잊지말고 mysql에 스키마 반영해야하고요 


## ⏱️ 소요 시간
30분 

## 🤔 고민했던 내용


## 💬 리뷰 중점사항
LLM으로 만든거라 리뷰 가능하면 꼼꼼하게 부탁드립니다.. 그리고 서비스 활성도를 파악하기 위한 다은 대안이 있으면 의견 주세요

## 🔗관련 이슈
- 못만들었습니다..ㅎ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 사용자 및 익명 방문자의 일일 활동 추적 기능이 추가되었습니다.
  * 미식별 방문자에게 자동으로 고유 식별자가 부여되며, 방문 날짜 및 상호작용 빈도가 기록됩니다.
  * API 요청 시 활동 데이터가 자동으로 수집됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->