### PR TITLE
[feat]동아리 인스타그램 URL 필드 추가#322

### DIFF
--- a/src/main/java/com/kakaotech/team18/backend_server/domain/club/dto/ClubDetailRequestDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/club/dto/ClubDetailRequestDto.java
@@ -60,5 +60,8 @@ public record ClubDetailRequestDto(
         String everyTimeUrl,
 
         @Schema(description = "구글 폼 URL", example = "https://docs.google.com/forms/d/e/1FAIpQLSc/viewform")
-        String googleFormUrl
+        String googleFormUrl,
+
+        @Schema(description = "인스타그램 URL", example = "https://www.instagram.com/example")
+        String instagramUrl
 ) {}

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/club/dto/ClubDetailResponseDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/club/dto/ClubDetailResponseDto.java
@@ -32,7 +32,8 @@ public record ClubDetailResponseDto(
         @Schema(description = "동아리 지원 유의사항 목록") String applicationNotice,
         @Schema(description = "서비스 등록 여부") Boolean isRegistered,
         @Schema(description = "에브리타임 홍보 게시글 URL") String everyTimeUrl,
-        @Schema(description = "구글 폼 URL") String googleFormUrl
+        @Schema(description = "구글 폼 URL") String googleFormUrl,
+        @Schema(description = "인스타그램 URL") String instagramUrl
 ) {
 
     public static ClubDetailResponseDto from(Club club, User user) {
@@ -62,6 +63,7 @@ public record ClubDetailResponseDto(
                 isRegistered(club.getIsRegistered()).
                 everyTimeUrl(club.getEveryTimeUrl()).
                 googleFormUrl(club.getGoogleFormUrl()).
+                instagramUrl(club.getInstagramUrl()).
                 build();
     }
     public record ClubImageResponseDto(

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/club/entity/Club.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/club/entity/Club.java
@@ -76,6 +76,9 @@ public class Club extends BaseEntity {
     @Column(length = 2048)
     private String googleFormUrl;
 
+    @Column(length = 2048)
+    private String instagramUrl;
+
     @Builder
     private Club(
             String name,
@@ -94,7 +97,8 @@ public class Club extends BaseEntity {
             String regularMeetingInfo,
             Boolean isRegistered,
             String everyTimeUrl,
-            String googleFormUrl) {
+            String googleFormUrl,
+            String instagramUrl) {
         this.name = name;
         this.category = category;
         this.location = location;
@@ -112,6 +116,7 @@ public class Club extends BaseEntity {
         this.isRegistered = (isRegistered != null) ? isRegistered : false;
         this.everyTimeUrl = everyTimeUrl;
         this.googleFormUrl = googleFormUrl;
+        this.instagramUrl = instagramUrl;
     }
 
     public void updateDetail(ClubDetailRequestDto dto) {
@@ -123,6 +128,7 @@ public class Club extends BaseEntity {
         this.regularMeetingInfo = dto.regularMeetingInfo();
         this.everyTimeUrl = dto.everyTimeUrl();
         this.googleFormUrl = dto.googleFormUrl();
+        this.instagramUrl = dto.instagramUrl();
         this.introduction.update(dto);
     }
 

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/club/controller/ClubControllerTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/club/controller/ClubControllerTest.java
@@ -163,6 +163,7 @@ class ClubControllerTest {
                 .recruitStart(LocalDateTime.of(2025, 9, 3, 0, 0))
                 .recruitEnd(LocalDateTime.of(2025, 9, 20, 23, 59))
                 .applicationNotice("주의사항")
+                .instagramUrl("https://www.instagram.com/test")
                 .build();
 
         when(clubService.getClubDetail(clubId)).thenReturn(expected);
@@ -171,7 +172,8 @@ class ClubControllerTest {
         mockMvc.perform(get("/api/clubs/{clubId}", clubId))
                 .andDo(print())
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.clubId").value(clubId));
+                .andExpect(jsonPath("$.clubId").value(clubId))
+                .andExpect(jsonPath("$.instagramUrl").value("https://www.instagram.com/test"));
     }
 
     @DisplayName("동아리 대쉬보드 페이지를 조회한다.")

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/club/entity/ClubTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/club/entity/ClubTest.java
@@ -47,6 +47,7 @@ class ClubTest {
                 .applicationNotice("Updated caution")
                 .everyTimeUrl("https://everytime.kr/test")
                 .googleFormUrl("https://docs.google.com/forms/test")
+                .instagramUrl("https://www.instagram.com/test")
                 .build();
 
         club.updateDetail(dto);
@@ -62,6 +63,7 @@ class ClubTest {
         assertThat(club.getIntroduction().getIdeal()).isEqualTo(dto.introductionIdeal());
         assertThat(club.getEveryTimeUrl()).isEqualTo(dto.everyTimeUrl());
         assertThat(club.getGoogleFormUrl()).isEqualTo(dto.googleFormUrl());
+        assertThat(club.getInstagramUrl()).isEqualTo(dto.instagramUrl());
         assertThat(club.getIntroduction().getImages())
                 .usingRecursiveComparison()
                 .isEqualTo(List.of(

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/club/service/ClubServiceMockTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/club/service/ClubServiceMockTest.java
@@ -273,6 +273,7 @@ public class ClubServiceMockTest {
                     "주의사항",
                     false,
                     null,
+                    null,
                     null
             );
 


### PR DESCRIPTION
## 🚀 작업 내용
Club 엔티티에 instagramUrl 컬럼 추가 및 상세 조회/수정 API에 반영

## ⏱️ 소요 시간


## 🤔 고민했던 내용


## 💬 리뷰 중점사항


## 🔗관련 이슈
- Close #322

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 동아리 상세 정보에 인스타그램 URL이 추가되어 사용자가 동아리의 인스타그램 계정에 더 쉽게 접근할 수 있습니다.

* **테스트**
  * 동아리 상세 응답에 인스타그램 URL 포함을 확인하도록 테스트가 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->