### PR TITLE
[feat]전체 동아리 목록 조회 시 누적 방문자 수 통계 추가

### DIFF
--- a/src/main/java/com/kakaotech/team18/backend_server/domain/activity/repository/ActivityDailyRepository.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/activity/repository/ActivityDailyRepository.java
@@ -4,9 +4,13 @@ import com.kakaotech.team18.backend_server.domain.activity.entity.ActivityDaily;
 import java.time.LocalDate;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ActivityDailyRepository extends JpaRepository<ActivityDaily, Long> {
     Optional<ActivityDaily> findByActivityDateAndUserId(LocalDate activityDate, Long userId);
 
     Optional<ActivityDaily> findByActivityDateAndAnonymousId(LocalDate activityDate, String anonymousId);
+
+    @Query("SELECT COALESCE(SUM(a.hitCount), 0) FROM ActivityDaily a")
+    long sumHitCount();
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/club/dto/ClubListResponseDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/club/dto/ClubListResponseDto.java
@@ -9,8 +9,13 @@ import java.util.List;
 
 @Schema(description = "동아리 목록 조회 시 응답되는 기본 정보")
 public record ClubListResponseDto(
-        List<ClubsInfo> clubs
+        List<ClubsInfo> clubs,
+        UserStats stats
 ) {
+    public record UserStats(
+            @Schema(description = "누적 방문자 수") long totalVisitors
+    ) {}
+
     public record ClubsInfo(
             @Schema(description = "동아리 고유 ID", example = "1") Long id,
             @Schema(description = "동아리 이름", example = "개발하는 사람들") String name,

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/club/dto/ClubListResponseDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/club/dto/ClubListResponseDto.java
@@ -13,7 +13,8 @@ public record ClubListResponseDto(
         UserStats stats
 ) {
     public record UserStats(
-            @Schema(description = "누적 방문자 수") long totalVisitors
+            @Schema(description = "누적 방문자 수") long totalVisitors,
+            @Schema(description = "누적 방문 횟수") long totalVisits
     ) {}
 
     public record ClubsInfo(

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/club/service/ClubServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/club/service/ClubServiceImpl.java
@@ -1,5 +1,6 @@
 package com.kakaotech.team18.backend_server.domain.club.service;
 
+import com.kakaotech.team18.backend_server.domain.activity.repository.ActivityDailyRepository;
 import com.kakaotech.team18.backend_server.domain.application.entity.Stage;
 import com.kakaotech.team18.backend_server.domain.application.entity.Status;
 import com.kakaotech.team18.backend_server.domain.application.repository.ApplicationRepository;
@@ -59,6 +60,7 @@ public class ClubServiceImpl implements ClubService {
     private final S3Service s3Service;
     private final ApplicationEventPublisher applicationEventPublisher;
     private final ClubImageRepository clubImageRepository;
+    private final ActivityDailyRepository activityDailyRepository;
 
 
     @Override
@@ -79,7 +81,7 @@ public class ClubServiceImpl implements ClubService {
 
     @Override
     public ClubListResponseDto getAllClubs() {
-        return mapToResponse(clubRepository.findAllProjectedBy());
+        return mapToResponse(clubRepository.findAllProjectedBy(), buildUserStats());
     }
 
     @Override
@@ -290,13 +292,20 @@ public class ClubServiceImpl implements ClubService {
     }
     // ---- private helpers ----
     private ClubListResponseDto mapToResponse(List<ClubSummary> summaries) {
+        return mapToResponse(summaries, null);
+    }
+
+    private ClubListResponseDto mapToResponse(List<ClubSummary> summaries, ClubListResponseDto.UserStats stats) {
         List<ClubListResponseDto.ClubsInfo> clubs = summaries.stream()
                 .map(summary -> ClubListResponseDto.from(
                         summary,
                         RecruitStatusCalculator.calculate(summary.getRecruitStart(), summary.getRecruitEnd()).getDisplayName()
                 ))
                 .toList();
+        return new ClubListResponseDto(clubs, stats);
+    }
 
-        return new ClubListResponseDto(clubs);
+    private ClubListResponseDto.UserStats buildUserStats() {
+        return new ClubListResponseDto.UserStats(activityDailyRepository.count());
     }
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/club/service/ClubServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/club/service/ClubServiceImpl.java
@@ -66,7 +66,7 @@ public class ClubServiceImpl implements ClubService {
     @Override
     public ClubListResponseDto getClubByCategory(String category) {
         if (category.equals("ALL")) {
-            return mapToResponse(clubRepository.findAllProjectedBy());
+            return mapToResponse(clubRepository.findAllProjectedBy(), buildUserStats());
         }
         return mapToResponse(clubRepository.findSummariesByCategory(Category.valueOf(category)));
     }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/club/service/ClubServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/club/service/ClubServiceImpl.java
@@ -306,6 +306,8 @@ public class ClubServiceImpl implements ClubService {
     }
 
     private ClubListResponseDto.UserStats buildUserStats() {
-        return new ClubListResponseDto.UserStats(activityDailyRepository.count());
+        return new ClubListResponseDto.UserStats(
+                activityDailyRepository.count(),
+                activityDailyRepository.sumHitCount());
     }
 }

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/club/controller/ClubControllerTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/club/controller/ClubControllerTest.java
@@ -84,7 +84,7 @@ class ClubControllerTest {
                 false
         );
 
-        ClubListResponseDto mockResponse = new ClubListResponseDto(List.of(club1, club2));
+        ClubListResponseDto mockResponse = new ClubListResponseDto(List.of(club1, club2), null);
 
         when(clubService.getAllClubs()).thenReturn(mockResponse);
 
@@ -123,7 +123,7 @@ class ClubControllerTest {
 
         String category = "STUDY";
 
-        ClubListResponseDto mockResponse = new ClubListResponseDto(List.of(club1));
+        ClubListResponseDto mockResponse = new ClubListResponseDto(List.of(club1), null);
 
         when(clubService.getClubByCategory(category)).thenReturn(mockResponse);
 

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/club/service/ClubServiceImplTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/club/service/ClubServiceImplTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import com.kakaotech.team18.backend_server.domain.activity.repository.ActivityDailyRepository;
 import com.kakaotech.team18.backend_server.domain.application.repository.ApplicationRepository;
 import com.kakaotech.team18.backend_server.domain.club.dto.ClubListResponseDto;
 import com.kakaotech.team18.backend_server.domain.club.dto.ClubSummary;
@@ -52,7 +53,8 @@ class ClubServiceImplTest {
         S3Service s3Service = mock(S3Service.class);
         ApplicationEventPublisher applicationEventPublisher = mock(ApplicationEventPublisher.class);
         ClubImageRepository clubImageRepository = mock(ClubImageRepository.class);
-        clubService = new ClubServiceImpl(clubRepository, applicationRepository, clubMemberRepository, clubApplyFormRepository, s3Service, applicationEventPublisher, clubImageRepository);
+        ActivityDailyRepository activityDailyRepository = mock(ActivityDailyRepository.class);
+        clubService = new ClubServiceImpl(clubRepository, applicationRepository, clubMemberRepository, clubApplyFormRepository, s3Service, applicationEventPublisher, clubImageRepository, activityDailyRepository);
     }
 
     @Getter

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/club/service/ClubServiceMockTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/club/service/ClubServiceMockTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
+import com.kakaotech.team18.backend_server.domain.activity.repository.ActivityDailyRepository;
 import com.kakaotech.team18.backend_server.domain.application.entity.Application;
 import com.kakaotech.team18.backend_server.domain.application.entity.Stage;
 import com.kakaotech.team18.backend_server.domain.application.entity.Status;
@@ -17,6 +18,8 @@ import com.kakaotech.team18.backend_server.domain.application.repository.Applica
 import com.kakaotech.team18.backend_server.domain.application.repository.InterviewSlotCountProjection;
 import com.kakaotech.team18.backend_server.domain.club.dto.ClubDashBoardResponseDto;
 import com.kakaotech.team18.backend_server.domain.club.dto.ClubDashboardApplicantResponseDto;
+import com.kakaotech.team18.backend_server.domain.club.dto.ClubListResponseDto;
+import com.kakaotech.team18.backend_server.domain.club.dto.ClubSummary;
 import com.kakaotech.team18.backend_server.domain.club.dto.ClubDetailRequestDto;
 import com.kakaotech.team18.backend_server.domain.club.dto.ClubDetailResponseDto;
 import com.kakaotech.team18.backend_server.domain.club.dto.ClubDetailResponseDto.ClubImageResponseDto;
@@ -82,9 +85,36 @@ public class ClubServiceMockTest {
     ClubImageRepository clubImageRepository;
     @Mock
     ApplicationEventPublisher applicationEventPublisher;
+    @Mock
+    ActivityDailyRepository activityDailyRepository;
 
     @InjectMocks
     ClubServiceImpl clubService;
+
+    @DisplayName("전체 동아리 목록과 이용자 통계를 함께 반환한다.")
+    @Test
+    void getAllClubs_returnsClubListWithStats() {
+        // given
+        ClubSummary summary = mock(ClubSummary.class);
+        given(summary.getId()).willReturn(1L);
+        given(summary.getName()).willReturn("카태켐");
+        given(summary.getCategory()).willReturn(Category.LITERATURE);
+        given(summary.getShortIntroduction()).willReturn("함께 배우는 카태켐");
+        given(summary.getRecruitStart()).willReturn(LocalDateTime.of(2025, 9, 1, 0, 0));
+        given(summary.getRecruitEnd()).willReturn(LocalDateTime.of(2025, 9, 30, 23, 59));
+        given(summary.getIsRegistered()).willReturn(true);
+
+        given(clubRepository.findAllProjectedBy()).willReturn(List.of(summary));
+        given(activityDailyRepository.count()).willReturn(100L);
+
+        // when
+        ClubListResponseDto result = clubService.getAllClubs();
+
+        // then
+        assertThat(result.clubs()).hasSize(1);
+        assertThat(result.stats()).isNotNull();
+        assertThat(result.stats().totalVisitors()).isEqualTo(100L);
+    }
 
     @DisplayName("동아리 대쉬보드를 조회합니다.")
     @Test

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/club/service/ClubServiceMockTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/club/service/ClubServiceMockTest.java
@@ -106,6 +106,7 @@ public class ClubServiceMockTest {
 
         given(clubRepository.findAllProjectedBy()).willReturn(List.of(summary));
         given(activityDailyRepository.count()).willReturn(100L);
+        given(activityDailyRepository.sumHitCount()).willReturn(500L);
 
         // when
         ClubListResponseDto result = clubService.getAllClubs();
@@ -114,6 +115,7 @@ public class ClubServiceMockTest {
         assertThat(result.clubs()).hasSize(1);
         assertThat(result.stats()).isNotNull();
         assertThat(result.stats().totalVisitors()).isEqualTo(100L);
+        assertThat(result.stats().totalVisits()).isEqualTo(500L);
     }
 
     @DisplayName("동아리 대쉬보드를 조회합니다.")


### PR DESCRIPTION
## 🚀 작업 내용
GET /api/clubs 응답에 activity_daily 테이블 전체 행 수를 기반으로 한 totalVisitors 필드를 포함하는 UserStats 추가

## ⏱️ 소요 시간


## 🤔 고민했던 내용


## 💬 리뷰 중점사항


## 🔗관련 이슈
- Close #325 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 클럽 목록 조회 응답에 전체 방문자·전체 방문수 통계(UserStats)가 추가됩니다.
  * 방문수 합계 집계 기능이 추가되어 전체 통계 제공이 가능해졌습니다.

* **버그 수정 / 변경**
  * 클럽 목록 응답 생성 흐름이 통계 포함을 지원하도록 업데이트되었습니다 (ALL 카테고리 조회 시 통계 포함).

* **테스트**
  * 클럽 목록과 방문자 통계를 검증하는 단위 테스트가 추가되고 기존 테스트가 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->