### PR TITLE
[REFACTOR] 전화번호 공개 여부를 선택할 수 있도록 isTelNoOpen 필드 추가 (#328)

### DIFF
--- a/src/main/java/com/kakaotech/team18/backend_server/domain/club/dto/ClubDetailRequestDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/club/dto/ClubDetailRequestDto.java
@@ -4,7 +4,6 @@ import com.kakaotech.team18.backend_server.domain.club.entity.Category;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import java.util.List;
 import lombok.Builder;
 
 @Builder
@@ -51,6 +50,9 @@ public record ClubDetailRequestDto(
         String presidentName,
 
         String presidentPhoneNumber,
+
+        @Schema(description = "전화번호 상세페이지 공개 여부", example = "true")
+        boolean isTelNoOpen,
 
         @Schema(description = "등록/수정할 동아리 지원 유의사항", example = "지원 시 유의사항을 반드시 확인해주세요.")
         @NotBlank(message = "지원 유의사항은 필수입니다.")

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/club/dto/ClubDetailResponseDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/club/dto/ClubDetailResponseDto.java
@@ -27,6 +27,7 @@ public record ClubDetailResponseDto(
         @Schema(description = "모집 상태", example = "모집중") String recruitStatus,
         @Schema(description = "동아리 회장 이름", example = "김회장") String presidentName,
         @Schema(description = "동아리 회장 연락처", example = "010-1234-5678") String presidentPhoneNumber,
+        @Schema(description = "전화번호 상세페이지 공개 여부", example = "true") boolean isTelNoOpen,
         @Schema(description = "모집 시작일") LocalDateTime recruitStart,
         @Schema(description = "모집 마감일") LocalDateTime recruitEnd,
         @Schema(description = "동아리 지원 유의사항 목록") String applicationNotice,
@@ -57,6 +58,7 @@ public record ClubDetailResponseDto(
                 recruitStatus(RecruitStatusCalculator.calculate(club.getRecruitStart(), club.getRecruitEnd()).getDisplayName()).
                 presidentName(user.getName()).
                 presidentPhoneNumber(user.getPhoneNumber()).
+                isTelNoOpen(club.isTelNoOpen()).
                 recruitStart(club.getRecruitStart()).
                 recruitEnd(club.getRecruitEnd()).
                 applicationNotice(club.getCaution()).

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/club/dto/ClubDetailResponseDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/club/dto/ClubDetailResponseDto.java
@@ -57,8 +57,8 @@ public record ClubDetailResponseDto(
                 regularMeetingInfo(club.getRegularMeetingInfo()).
                 recruitStatus(RecruitStatusCalculator.calculate(club.getRecruitStart(), club.getRecruitEnd()).getDisplayName()).
                 presidentName(user.getName()).
-                presidentPhoneNumber(user.getPhoneNumber()).
                 isTelNoOpen(club.isTelNoOpen()).
+                presidentPhoneNumber(club.isTelNoOpen() ? user.getPhoneNumber() : null).
                 recruitStart(club.getRecruitStart()).
                 recruitEnd(club.getRecruitEnd()).
                 applicationNotice(club.getCaution()).

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/club/entity/Club.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/club/entity/Club.java
@@ -70,6 +70,9 @@ public class Club extends BaseEntity {
     @Column(nullable = false)
     private Boolean isRegistered;
 
+    @Column(nullable = false)
+    private boolean isTelNoOpen;
+
     @Column(length = 2048)
     private String everyTimeUrl;
 
@@ -96,6 +99,7 @@ public class Club extends BaseEntity {
             LocalTime interviewEndTime,
             String regularMeetingInfo,
             Boolean isRegistered,
+            boolean isTelNoOpen,
             String everyTimeUrl,
             String googleFormUrl,
             String instagramUrl) {
@@ -114,6 +118,7 @@ public class Club extends BaseEntity {
         this.interviewEndTime = interviewEndTime;
         this.regularMeetingInfo = regularMeetingInfo;
         this.isRegistered = (isRegistered != null) ? isRegistered : false;
+        this.isTelNoOpen = isTelNoOpen;
         this.everyTimeUrl = everyTimeUrl;
         this.googleFormUrl = googleFormUrl;
         this.instagramUrl = instagramUrl;
@@ -126,6 +131,7 @@ public class Club extends BaseEntity {
         this.shortIntroduction = dto.shortIntroduction();
         this.caution = dto.applicationNotice();
         this.regularMeetingInfo = dto.regularMeetingInfo();
+        this.isTelNoOpen = dto.isTelNoOpen();
         this.everyTimeUrl = dto.everyTimeUrl();
         this.googleFormUrl = dto.googleFormUrl();
         this.instagramUrl = dto.instagramUrl();

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/club/controller/ClubControllerTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/club/controller/ClubControllerTest.java
@@ -160,6 +160,7 @@ class ClubControllerTest {
                 .recruitStatus("모집중")
                 .presidentName("김춘식")
                 .presidentPhoneNumber("010-1234-5678")
+                .isTelNoOpen(true)
                 .recruitStart(LocalDateTime.of(2025, 9, 3, 0, 0))
                 .recruitEnd(LocalDateTime.of(2025, 9, 20, 23, 59))
                 .applicationNotice("주의사항")
@@ -173,6 +174,7 @@ class ClubControllerTest {
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.clubId").value(clubId))
+                .andExpect(jsonPath("$.isTelNoOpen").value(true))
                 .andExpect(jsonPath("$.instagramUrl").value("https://www.instagram.com/test"));
     }
 
@@ -328,6 +330,7 @@ class ClubControllerTest {
                 .introductionIdeal("new ideal")
                 .applicationNotice("주의사항")
                 .regularMeetingInfo("매주 수 18:00")
+                .isTelNoOpen(true)
                 .build();
 
         //when

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/club/controller/ClubControllerTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/club/controller/ClubControllerTest.java
@@ -178,6 +178,42 @@ class ClubControllerTest {
                 .andExpect(jsonPath("$.instagramUrl").value("https://www.instagram.com/test"));
     }
 
+    @DisplayName("동아리 상세 페이지 조회시 전화번호 비공개이면 전화번호는 null로 응답한다.")
+    @Test
+    void getClubDetail_telNoClosed_test() throws Exception {
+        //given
+        long clubId = 1L;
+
+        ClubDetailResponseDto expected = ClubDetailResponseDto.builder()
+                .clubId(clubId)
+                .clubName("카태켐")
+                .location("공대7호관 201호")
+                .category(LITERATURE)
+                .shortIntroduction("카카오 부트캠프")
+                .introductionImages(List.of())
+                .introductionOverview("개발자로 성장할 수 있는 부트캠프입니다.")
+                .introductionActivity("총 3단계로 이루어진 코스")
+                .introductionIdeal("열심열심")
+                .regularMeetingInfo("매주 화요일 오후 6시")
+                .recruitStatus("모집중")
+                .presidentName("김춘식")
+                .presidentPhoneNumber(null)
+                .isTelNoOpen(false)
+                .recruitStart(LocalDateTime.of(2025, 9, 3, 0, 0))
+                .recruitEnd(LocalDateTime.of(2025, 9, 20, 23, 59))
+                .applicationNotice("주의사항")
+                .build();
+
+        when(clubService.getClubDetail(clubId)).thenReturn(expected);
+
+        //when //then
+        mockMvc.perform(get("/api/clubs/{clubId}", clubId))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isTelNoOpen").value(false))
+                .andExpect(jsonPath("$.presidentPhoneNumber").isEmpty());
+    }
+
     @DisplayName("동아리 대쉬보드 페이지를 조회한다.")
     @Test
     void getClubDashboard_test() throws Exception {

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/club/entity/ClubTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/club/entity/ClubTest.java
@@ -44,6 +44,7 @@ class ClubTest {
                 .introductionActivity("Updated activities")
                 .introductionIdeal("Updated ideal")
                 .regularMeetingInfo("Updated regular meeting info")
+                .isTelNoOpen(true)
                 .applicationNotice("Updated caution")
                 .everyTimeUrl("https://everytime.kr/test")
                 .googleFormUrl("https://docs.google.com/forms/test")
@@ -58,6 +59,7 @@ class ClubTest {
         assertThat(club.getShortIntroduction()).isEqualTo(dto.shortIntroduction());
         assertThat(club.getCaution()).isEqualTo(dto.applicationNotice());
         assertThat(club.getRegularMeetingInfo()).isEqualTo(dto.regularMeetingInfo());
+        assertThat(club.isTelNoOpen()).isEqualTo(dto.isTelNoOpen());
         assertThat(club.getIntroduction().getOverview()).isEqualTo(dto.introductionOverview());
         assertThat(club.getIntroduction().getActivities()).isEqualTo(dto.introductionActivity());
         assertThat(club.getIntroduction().getIdeal()).isEqualTo(dto.introductionIdeal());

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/club/service/ClubServiceMockTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/club/service/ClubServiceMockTest.java
@@ -271,6 +271,7 @@ public class ClubServiceMockTest {
                 LocalTime.of(21, 0)
         );
         ReflectionTestUtils.setField(club, "id", 1L);
+        ReflectionTestUtils.setField(club, "isTelNoOpen", true);
         User user = createUser("loginId", "123456");
         ReflectionTestUtils.setField(user, "id", 1L);
         ClubMember clubMember = createClubMember(user, club, mock(Application.class), Role.CLUB_ADMIN, ActiveStatus.ACTIVE);
@@ -300,6 +301,7 @@ public class ClubServiceMockTest {
                     "모집중", // mock이 반환할 값과 일치
                     "김춘식",
                     "010-1234-5678",
+                    true,
                     LocalDateTime.of(2025, 9, 3, 0, 0),
                     LocalDateTime.of(2025, 9, 20, 23, 59),
                     "주의사항",
@@ -407,6 +409,7 @@ public class ClubServiceMockTest {
                 .introductionIdeal("new ideal")
                 .applicationNotice("주의사항")
                 .regularMeetingInfo("매주 수 18:00")
+                .isTelNoOpen(true)
                 .build();
 
         // when
@@ -421,6 +424,7 @@ public class ClubServiceMockTest {
         assertThat(club.getShortIntroduction()).isEqualTo("new short");
         assertThat(club.getCaution()).isEqualTo("주의사항");
         assertThat(club.getRegularMeetingInfo()).isEqualTo("매주 수 18:00");
+        assertThat(club.isTelNoOpen()).isTrue();
 
         // introduction 교체 확인
         assertThat(club.getIntroduction()).isNotNull();

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/club/service/ClubServiceMockTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/club/service/ClubServiceMockTest.java
@@ -321,6 +321,41 @@ public class ClubServiceMockTest {
         }
     }
 
+    @DisplayName("Club Detail 조회시 전화번호 비공개 설정이면 회장 전화번호를 null로 반환한다.")
+    @Test
+    void getClubDetailWithClosedTelNo() {
+        //given
+        Long clubId = 1L;
+        ClubIntroduction clubIntroduction = createClubIntroduction();
+        Club club = createClub(clubIntroduction,
+                LocalDateTime.of(2025, 9, 3, 0, 0),
+                LocalDateTime.of(2025, 9, 20, 23, 59),
+                true,
+                LocalDateTime.of(2025, 9, 5, 0, 0),
+                LocalDateTime.of(2025, 9, 10, 0, 0),
+                LocalTime.of(9, 10),
+                LocalTime.of(21, 0)
+        );
+        ReflectionTestUtils.setField(club, "id", clubId);
+        User user = createUser("loginId", "123456");
+        ClubMember clubMember = createClubMember(user, club, mock(Application.class), Role.CLUB_ADMIN, ActiveStatus.ACTIVE);
+
+        try (MockedStatic<RecruitStatusCalculator> mockedCalculator = Mockito.mockStatic(RecruitStatusCalculator.class)) {
+            mockedCalculator.when(() -> RecruitStatusCalculator.calculate(club.getRecruitStart(), club.getRecruitEnd()))
+                    .thenReturn(RecruitStatus.RECRUITING);
+
+            given(clubRepository.findClubDetailById(eq(clubId))).willReturn(Optional.of(club));
+            given(clubMemberRepository.findClubAdminByClubIdAndRole(eq(clubId), eq(Role.CLUB_ADMIN))).willReturn(Optional.of(clubMember));
+
+            //when
+            ClubDetailResponseDto actual = clubService.getClubDetail(clubId);
+
+            //then
+            assertThat(actual.isTelNoOpen()).isFalse();
+            assertThat(actual.presidentPhoneNumber()).isNull();
+        }
+    }
+
     @DisplayName("Club Detail 조회시 존재하지 않는 clubId를 사용할 때 ClubNotFoundException이 실행된다.")
     @Test
     void getClubDetailWithWrongClubId() {


### PR DESCRIPTION
## 🚀 작업 내용
동아리 상세페이지에서 동아리 회장이 전화번호 공개 여부를 선택할 수 있도록 동아리 상세페이지 Request, Response DTO에 각각 `boolean : isTelNoOpen` 필드를 추가했습니다. 

Request를 통해 백엔드로 데이터가 전달되면 이 값을 Club 엔티티 isTelNoOpen 칼럼에 저장하고 상세 페이지 조회시 이 값을 클라이언트에 전달합니다. 

전화번호를 공개하고 싶지 않을 때는 null 값을 반환해서 개발자 모드에서도 확인할 수 없도록 했습니다. 

## ⏱️ 소요 시간
30분 

## 🤔 고민했던 내용


## 💬 리뷰 중점사항

## 🔗관련 이슈
- Close #328 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 클럽의 전화번호 공개 여부를 제어하는 기능 추가
  * 전화번호 공개 설정 시에만 회장의 전화번호가 노출되도록 변경

* **Tests**
  * 전화번호 공개/비공개 상태에 따른 동작 검증 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->