### PR TITLE
[FEATURE] 설문조사를 위해 mock 동아리 운영진 권한 임시 부여 기능 (#330)

### DIFF
--- a/src/main/java/com/kakaotech/team18/backend_server/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/auth/service/AuthServiceImpl.java
@@ -10,7 +10,11 @@ import com.kakaotech.team18.backend_server.domain.auth.dto.RegistrationRequiredR
 import com.kakaotech.team18.backend_server.domain.auth.dto.ReissueResponseDto;
 import com.kakaotech.team18.backend_server.domain.auth.entity.RefreshToken;
 import com.kakaotech.team18.backend_server.domain.auth.repository.RefreshTokenRepository;
+import com.kakaotech.team18.backend_server.domain.club.entity.Club;
+import com.kakaotech.team18.backend_server.domain.club.repository.ClubRepository;
 import com.kakaotech.team18.backend_server.domain.clubMember.dto.ClubListInfoDto;
+import com.kakaotech.team18.backend_server.domain.clubMember.entity.ActiveStatus;
+import com.kakaotech.team18.backend_server.domain.clubMember.entity.ClubMember;
 import com.kakaotech.team18.backend_server.domain.clubMember.entity.Role;
 import com.kakaotech.team18.backend_server.domain.clubMember.repository.ClubMemberRepository;
 import com.kakaotech.team18.backend_server.domain.user.entity.User;
@@ -56,12 +60,15 @@ import org.springframework.web.client.RestClientResponseException;
 @Transactional(readOnly = true)
 public class AuthServiceImpl implements AuthService {
 
+    private static final Long SURVEY_CLUB_ID = 84L;
+
     private final UserRepository userRepository;
     private final JwtProvider jwtProvider;
     private final RestClient restClient;
     private final RefreshTokenRepository refreshTokenRepository;
     private final JwtProperties jwtProperties;
     private final ClubMemberRepository clubMemberRepository;
+    private final ClubRepository clubRepository;
     private final RedisTemplate<String, String> redisTemplate;
 
     @Value("${spring.security.oauth2.client.registration.kakao.client-id}")
@@ -98,6 +105,9 @@ public class AuthServiceImpl implements AuthService {
             // 4-1. 기존 회원일 경우: 로그인 성공 처리
             User user = userOptional.get();
             log.info("기존 회원 로그인: {}", user.getId());
+
+            //TODO 설문조사 이후 꼭 삭제할 것!!
+            grantSurveyClubExecutiveRole(user);
 
             // 정식 토큰 발급
             String accessToken = jwtProvider.createAccessToken(user);
@@ -183,6 +193,9 @@ public class AuthServiceImpl implements AuthService {
                     .build();
             userRepository.save(user);
         }
+
+        //TODO 설문조사 이후 꼭 삭제할 것!!
+        grantSurveyClubExecutiveRole(user);
 
         //clubId, Role 전달
         List<ClubListInfoDto> clubIdAndRoleList = clubMemberRepository.findClubListInfoByUser(user);
@@ -338,5 +351,26 @@ public class AuthServiceImpl implements AuthService {
     private boolean isSystemAdmin(User user) {
         return clubMemberRepository.findByUser(user).stream()
                 .anyMatch(cm -> cm.getRole() == Role.SYSTEM_ADMIN);
+    }
+
+    //TODO 설문조사 이후 꼭 삭제할 것!!
+    private void grantSurveyClubExecutiveRole(User user) {
+        clubRepository.findById(SURVEY_CLUB_ID)
+                .ifPresentOrElse(club -> registerSurveyClubMembershipIfAbsent(user, club),
+                        () -> log.warn("Survey club not found. Skip executive role grant: clubId={}", SURVEY_CLUB_ID));
+    }
+
+    private void registerSurveyClubMembershipIfAbsent(User user, Club club) {
+        if (clubMemberRepository.findByUserIdAndClubId(user.getId(), SURVEY_CLUB_ID).isPresent()) {
+            return;
+        }
+
+        clubMemberRepository.save(ClubMember.builder()
+                .user(user)
+                .club(club)
+                .activeStatus(ActiveStatus.ACTIVE)
+                .role(Role.CLUB_EXECUTIVE)
+                .build());
+        log.info("User {} registered as CLUB_EXECUTIVE in survey club {}", user.getId(), club.getName());
     }
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/club/dto/ClubDetailRequestDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/club/dto/ClubDetailRequestDto.java
@@ -4,7 +4,6 @@ import com.kakaotech.team18.backend_server.domain.club.entity.Category;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import java.util.List;
 import lombok.Builder;
 
 @Builder
@@ -51,6 +50,9 @@ public record ClubDetailRequestDto(
         String presidentName,
 
         String presidentPhoneNumber,
+
+        @Schema(description = "전화번호 상세페이지 공개 여부", example = "true")
+        boolean isTelNoOpen,
 
         @Schema(description = "등록/수정할 동아리 지원 유의사항", example = "지원 시 유의사항을 반드시 확인해주세요.")
         @NotBlank(message = "지원 유의사항은 필수입니다.")

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/club/dto/ClubDetailResponseDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/club/dto/ClubDetailResponseDto.java
@@ -27,6 +27,7 @@ public record ClubDetailResponseDto(
         @Schema(description = "모집 상태", example = "모집중") String recruitStatus,
         @Schema(description = "동아리 회장 이름", example = "김회장") String presidentName,
         @Schema(description = "동아리 회장 연락처", example = "010-1234-5678") String presidentPhoneNumber,
+        @Schema(description = "전화번호 상세페이지 공개 여부", example = "true") boolean isTelNoOpen,
         @Schema(description = "모집 시작일") LocalDateTime recruitStart,
         @Schema(description = "모집 마감일") LocalDateTime recruitEnd,
         @Schema(description = "동아리 지원 유의사항 목록") String applicationNotice,
@@ -57,6 +58,7 @@ public record ClubDetailResponseDto(
                 recruitStatus(RecruitStatusCalculator.calculate(club.getRecruitStart(), club.getRecruitEnd()).getDisplayName()).
                 presidentName(user.getName()).
                 presidentPhoneNumber(user.getPhoneNumber()).
+                isTelNoOpen(club.isTelNoOpen()).
                 recruitStart(club.getRecruitStart()).
                 recruitEnd(club.getRecruitEnd()).
                 applicationNotice(club.getCaution()).

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/club/dto/ClubDetailResponseDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/club/dto/ClubDetailResponseDto.java
@@ -57,8 +57,8 @@ public record ClubDetailResponseDto(
                 regularMeetingInfo(club.getRegularMeetingInfo()).
                 recruitStatus(RecruitStatusCalculator.calculate(club.getRecruitStart(), club.getRecruitEnd()).getDisplayName()).
                 presidentName(user.getName()).
-                presidentPhoneNumber(user.getPhoneNumber()).
                 isTelNoOpen(club.isTelNoOpen()).
+                presidentPhoneNumber(club.isTelNoOpen() ? user.getPhoneNumber() : null).
                 recruitStart(club.getRecruitStart()).
                 recruitEnd(club.getRecruitEnd()).
                 applicationNotice(club.getCaution()).

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/club/entity/Club.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/club/entity/Club.java
@@ -70,6 +70,9 @@ public class Club extends BaseEntity {
     @Column(nullable = false)
     private Boolean isRegistered;
 
+    @Column(nullable = false)
+    private boolean isTelNoOpen;
+
     @Column(length = 2048)
     private String everyTimeUrl;
 
@@ -96,6 +99,7 @@ public class Club extends BaseEntity {
             LocalTime interviewEndTime,
             String regularMeetingInfo,
             Boolean isRegistered,
+            boolean isTelNoOpen,
             String everyTimeUrl,
             String googleFormUrl,
             String instagramUrl) {
@@ -114,6 +118,7 @@ public class Club extends BaseEntity {
         this.interviewEndTime = interviewEndTime;
         this.regularMeetingInfo = regularMeetingInfo;
         this.isRegistered = (isRegistered != null) ? isRegistered : false;
+        this.isTelNoOpen = isTelNoOpen;
         this.everyTimeUrl = everyTimeUrl;
         this.googleFormUrl = googleFormUrl;
         this.instagramUrl = instagramUrl;
@@ -126,6 +131,7 @@ public class Club extends BaseEntity {
         this.shortIntroduction = dto.shortIntroduction();
         this.caution = dto.applicationNotice();
         this.regularMeetingInfo = dto.regularMeetingInfo();
+        this.isTelNoOpen = dto.isTelNoOpen();
         this.everyTimeUrl = dto.everyTimeUrl();
         this.googleFormUrl = dto.googleFormUrl();
         this.instagramUrl = dto.instagramUrl();

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/auth/service/AuthServiceImplTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/auth/service/AuthServiceImplTest.java
@@ -17,6 +17,11 @@ import com.kakaotech.team18.backend_server.domain.auth.dto.RegistrationRequiredR
 import com.kakaotech.team18.backend_server.domain.auth.dto.ReissueResponseDto;
 import com.kakaotech.team18.backend_server.domain.auth.entity.RefreshToken;
 import com.kakaotech.team18.backend_server.domain.auth.repository.RefreshTokenRepository;
+import com.kakaotech.team18.backend_server.domain.club.entity.Club;
+import com.kakaotech.team18.backend_server.domain.club.repository.ClubRepository;
+import com.kakaotech.team18.backend_server.domain.clubMember.entity.ActiveStatus;
+import com.kakaotech.team18.backend_server.domain.clubMember.entity.ClubMember;
+import com.kakaotech.team18.backend_server.domain.clubMember.entity.Role;
 import com.kakaotech.team18.backend_server.domain.clubMember.repository.ClubMemberRepository;
 import com.kakaotech.team18.backend_server.domain.user.entity.User;
 import com.kakaotech.team18.backend_server.domain.user.repository.UserRepository;
@@ -63,6 +68,8 @@ class AuthServiceImplTest {
     private JwtProperties jwtProperties;
     @Mock
     private ClubMemberRepository clubMemberRepository;
+    @Mock
+    private ClubRepository clubRepository;
 
     // RestClient의 플루언트 API를 Mocking하기 위한 추가 Mock 객체들
     @Mock
@@ -350,6 +357,56 @@ class AuthServiceImplTest {
         assertThat(result.status()).isEqualTo(AuthStatus.REGISTER_SUCCESS);
         assertThat(result.accessToken()).isEqualTo("newAccessToken");
         assertThat(result.refreshToken()).isEqualTo("newRefreshToken");
+    }
+
+    @DisplayName("신규 회원 가입 시 설문조사용 84번 동아리 운영진 권한을 부여한다")
+    @Test
+    void register_newUser_grantsSurveyClubExecutiveRole() {
+        // given
+        String bearerToken = "Bearer testTemporaryToken";
+        String temporaryToken = "testTemporaryToken";
+        Long kakaoId = 12345L;
+        String studentId = "newStudent123";
+        Long userId = 1L;
+        Long surveyClubId = 84L;
+
+        RegisterRequestDto requestDto = new RegisterRequestDto(
+                "newUser", "new@example.com", studentId, "컴퓨터공학과", "01011112222"
+        );
+
+        Claims claims = Jwts.claims();
+        claims.setSubject(TokenType.TEMPORARY.name());
+        claims.put("kakaoId", kakaoId);
+
+        Club surveyClub = Club.builder()
+                .name("설문조사용 동아리")
+                .build();
+
+        given(jwtProvider.extractToken(bearerToken)).willReturn(temporaryToken);
+        given(jwtProvider.verify(temporaryToken)).willReturn(claims);
+        given(userRepository.findByStudentId(studentId)).willReturn(Optional.empty());
+        given(userRepository.save(any(User.class))).willAnswer(invocation -> {
+            User savedUser = invocation.getArgument(0);
+            ReflectionTestUtils.setField(savedUser, "id", userId);
+            return savedUser;
+        });
+        given(clubRepository.findById(surveyClubId)).willReturn(Optional.of(surveyClub));
+        given(clubMemberRepository.findByUserIdAndClubId(userId, surveyClubId)).willReturn(Optional.empty());
+        given(jwtProvider.createAccessToken(any(User.class))).willReturn("newAccessToken");
+        given(jwtProvider.createRefreshToken(any(User.class))).willReturn("newRefreshToken");
+
+        // when
+        authService.register(bearerToken, requestDto);
+
+        // then
+        ArgumentCaptor<ClubMember> clubMemberCaptor = ArgumentCaptor.forClass(ClubMember.class);
+        verify(clubMemberRepository).save(clubMemberCaptor.capture());
+
+        ClubMember savedClubMember = clubMemberCaptor.getValue();
+        assertThat(savedClubMember.getUser().getId()).isEqualTo(userId);
+        assertThat(savedClubMember.getClub()).isEqualTo(surveyClub);
+        assertThat(savedClubMember.getActiveStatus()).isEqualTo(ActiveStatus.ACTIVE);
+        assertThat(savedClubMember.getRole()).isEqualTo(Role.CLUB_EXECUTIVE);
     }
 
     @DisplayName("기존 사용자 계정 연결 성공")

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/club/controller/ClubControllerTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/club/controller/ClubControllerTest.java
@@ -160,6 +160,7 @@ class ClubControllerTest {
                 .recruitStatus("모집중")
                 .presidentName("김춘식")
                 .presidentPhoneNumber("010-1234-5678")
+                .isTelNoOpen(true)
                 .recruitStart(LocalDateTime.of(2025, 9, 3, 0, 0))
                 .recruitEnd(LocalDateTime.of(2025, 9, 20, 23, 59))
                 .applicationNotice("주의사항")
@@ -173,6 +174,7 @@ class ClubControllerTest {
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.clubId").value(clubId))
+                .andExpect(jsonPath("$.isTelNoOpen").value(true))
                 .andExpect(jsonPath("$.instagramUrl").value("https://www.instagram.com/test"));
     }
 
@@ -328,6 +330,7 @@ class ClubControllerTest {
                 .introductionIdeal("new ideal")
                 .applicationNotice("주의사항")
                 .regularMeetingInfo("매주 수 18:00")
+                .isTelNoOpen(true)
                 .build();
 
         //when

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/club/controller/ClubControllerTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/club/controller/ClubControllerTest.java
@@ -178,6 +178,42 @@ class ClubControllerTest {
                 .andExpect(jsonPath("$.instagramUrl").value("https://www.instagram.com/test"));
     }
 
+    @DisplayName("동아리 상세 페이지 조회시 전화번호 비공개이면 전화번호는 null로 응답한다.")
+    @Test
+    void getClubDetail_telNoClosed_test() throws Exception {
+        //given
+        long clubId = 1L;
+
+        ClubDetailResponseDto expected = ClubDetailResponseDto.builder()
+                .clubId(clubId)
+                .clubName("카태켐")
+                .location("공대7호관 201호")
+                .category(LITERATURE)
+                .shortIntroduction("카카오 부트캠프")
+                .introductionImages(List.of())
+                .introductionOverview("개발자로 성장할 수 있는 부트캠프입니다.")
+                .introductionActivity("총 3단계로 이루어진 코스")
+                .introductionIdeal("열심열심")
+                .regularMeetingInfo("매주 화요일 오후 6시")
+                .recruitStatus("모집중")
+                .presidentName("김춘식")
+                .presidentPhoneNumber(null)
+                .isTelNoOpen(false)
+                .recruitStart(LocalDateTime.of(2025, 9, 3, 0, 0))
+                .recruitEnd(LocalDateTime.of(2025, 9, 20, 23, 59))
+                .applicationNotice("주의사항")
+                .build();
+
+        when(clubService.getClubDetail(clubId)).thenReturn(expected);
+
+        //when //then
+        mockMvc.perform(get("/api/clubs/{clubId}", clubId))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isTelNoOpen").value(false))
+                .andExpect(jsonPath("$.presidentPhoneNumber").isEmpty());
+    }
+
     @DisplayName("동아리 대쉬보드 페이지를 조회한다.")
     @Test
     void getClubDashboard_test() throws Exception {

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/club/entity/ClubTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/club/entity/ClubTest.java
@@ -44,6 +44,7 @@ class ClubTest {
                 .introductionActivity("Updated activities")
                 .introductionIdeal("Updated ideal")
                 .regularMeetingInfo("Updated regular meeting info")
+                .isTelNoOpen(true)
                 .applicationNotice("Updated caution")
                 .everyTimeUrl("https://everytime.kr/test")
                 .googleFormUrl("https://docs.google.com/forms/test")
@@ -58,6 +59,7 @@ class ClubTest {
         assertThat(club.getShortIntroduction()).isEqualTo(dto.shortIntroduction());
         assertThat(club.getCaution()).isEqualTo(dto.applicationNotice());
         assertThat(club.getRegularMeetingInfo()).isEqualTo(dto.regularMeetingInfo());
+        assertThat(club.isTelNoOpen()).isEqualTo(dto.isTelNoOpen());
         assertThat(club.getIntroduction().getOverview()).isEqualTo(dto.introductionOverview());
         assertThat(club.getIntroduction().getActivities()).isEqualTo(dto.introductionActivity());
         assertThat(club.getIntroduction().getIdeal()).isEqualTo(dto.introductionIdeal());

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/club/service/ClubServiceMockTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/club/service/ClubServiceMockTest.java
@@ -271,6 +271,7 @@ public class ClubServiceMockTest {
                 LocalTime.of(21, 0)
         );
         ReflectionTestUtils.setField(club, "id", 1L);
+        ReflectionTestUtils.setField(club, "isTelNoOpen", true);
         User user = createUser("loginId", "123456");
         ReflectionTestUtils.setField(user, "id", 1L);
         ClubMember clubMember = createClubMember(user, club, mock(Application.class), Role.CLUB_ADMIN, ActiveStatus.ACTIVE);
@@ -300,6 +301,7 @@ public class ClubServiceMockTest {
                     "모집중", // mock이 반환할 값과 일치
                     "김춘식",
                     "010-1234-5678",
+                    true,
                     LocalDateTime.of(2025, 9, 3, 0, 0),
                     LocalDateTime.of(2025, 9, 20, 23, 59),
                     "주의사항",
@@ -407,6 +409,7 @@ public class ClubServiceMockTest {
                 .introductionIdeal("new ideal")
                 .applicationNotice("주의사항")
                 .regularMeetingInfo("매주 수 18:00")
+                .isTelNoOpen(true)
                 .build();
 
         // when
@@ -421,6 +424,7 @@ public class ClubServiceMockTest {
         assertThat(club.getShortIntroduction()).isEqualTo("new short");
         assertThat(club.getCaution()).isEqualTo("주의사항");
         assertThat(club.getRegularMeetingInfo()).isEqualTo("매주 수 18:00");
+        assertThat(club.isTelNoOpen()).isTrue();
 
         // introduction 교체 확인
         assertThat(club.getIntroduction()).isNotNull();

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/club/service/ClubServiceMockTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/club/service/ClubServiceMockTest.java
@@ -321,6 +321,41 @@ public class ClubServiceMockTest {
         }
     }
 
+    @DisplayName("Club Detail 조회시 전화번호 비공개 설정이면 회장 전화번호를 null로 반환한다.")
+    @Test
+    void getClubDetailWithClosedTelNo() {
+        //given
+        Long clubId = 1L;
+        ClubIntroduction clubIntroduction = createClubIntroduction();
+        Club club = createClub(clubIntroduction,
+                LocalDateTime.of(2025, 9, 3, 0, 0),
+                LocalDateTime.of(2025, 9, 20, 23, 59),
+                true,
+                LocalDateTime.of(2025, 9, 5, 0, 0),
+                LocalDateTime.of(2025, 9, 10, 0, 0),
+                LocalTime.of(9, 10),
+                LocalTime.of(21, 0)
+        );
+        ReflectionTestUtils.setField(club, "id", clubId);
+        User user = createUser("loginId", "123456");
+        ClubMember clubMember = createClubMember(user, club, mock(Application.class), Role.CLUB_ADMIN, ActiveStatus.ACTIVE);
+
+        try (MockedStatic<RecruitStatusCalculator> mockedCalculator = Mockito.mockStatic(RecruitStatusCalculator.class)) {
+            mockedCalculator.when(() -> RecruitStatusCalculator.calculate(club.getRecruitStart(), club.getRecruitEnd()))
+                    .thenReturn(RecruitStatus.RECRUITING);
+
+            given(clubRepository.findClubDetailById(eq(clubId))).willReturn(Optional.of(club));
+            given(clubMemberRepository.findClubAdminByClubIdAndRole(eq(clubId), eq(Role.CLUB_ADMIN))).willReturn(Optional.of(clubMember));
+
+            //when
+            ClubDetailResponseDto actual = clubService.getClubDetail(clubId);
+
+            //then
+            assertThat(actual.isTelNoOpen()).isFalse();
+            assertThat(actual.presidentPhoneNumber()).isNull();
+        }
+    }
+
     @DisplayName("Club Detail 조회시 존재하지 않는 clubId를 사용할 때 ClubNotFoundException이 실행된다.")
     @Test
     void getClubDetailWithWrongClubId() {


### PR DESCRIPTION
## 🚀 작업 내용
로그인, 회원가입 시 84 동아리가 있는지 확인하고, 있다면 clubMember에 등록되었는지 확인하고, 등록되지 않았다면 운영진 권한을 부여합니다. 


## ⏱️ 소요 시간
20분 

## 🤔 고민했던 내용


## 💬 리뷰 중점사항
- 회원가입 뿐만 아니라 로그인시에도 권한을 주도록 해서 기존 회원들도 사용할 수 있게 해뒀는데 괜찮을지 확인 부탁드립니다 

## 🔗관련 이슈
- Close #330 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **New Features**
  * 카카오 로그인 및 회원가입 시 특정 클럽에서 자동으로 관리자 역할 부여
  * 클럽 상세 정보에서 클럽장 전화번호 공개 여부를 제어할 수 있는 옵션 추가

* **Tests**
  * 클럽 관리자 역할 자동 부여 기능 테스트 추가
  * 전화번호 공개 여부 제어 기능 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->