### PR TITLE
[FIX] prometheus datasources에 uid 중복 제거

### DIFF
--- a/monitoring/grafana/provisioning/datasources/datasources.yml
+++ b/monitoring/grafana/provisioning/datasources/datasources.yml
@@ -4,7 +4,6 @@ datasources:
   - name: Prometheus
     uid: prometheus-datasource
     type: prometheus
-    uid: prometheus-datasource
     access: proxy
     url: http://prometheus:9090
     isDefault: true


### PR DESCRIPTION
## 🚀 작업 내용
모니터링이 계속 502 에러 떠서 확인해보니 
프로메테우스 datasrouces 파일에 uid가 중복 입력되어 있어서 수정했습니다. 
현재 배포된 ec2 파일에도 수정해둬서 들어갈 수 있습니다.

## ⏱️ 소요 시간
20분

## 🤔 고민했던 내용


## 💬 리뷰 중점사항
지금 그라파나 대쉬보드에서 로그 확인이 가능한데 이거 로그를 JSON 형식으로 찍히도록 하면 더 좋다고해서 고려해보면 좋을 것 같아요 
검색시에도 확인하기 편하다는 장점이 있는 것 같아요 


## 🔗관련 이슈
이슈 추가는 못했어요,,