### PR TITLE
[FEAT] 지원자 성별 수집 (#335)

### DIFF
--- a/src/main/java/com/kakaotech/team18/backend_server/domain/application/dto/ApplicationApplyRequestDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/application/dto/ApplicationApplyRequestDto.java
@@ -1,10 +1,12 @@
 package com.kakaotech.team18.backend_server.domain.application.dto;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.kakaotech.team18.backend_server.domain.user.entity.Gender;
 import com.kakaotech.team18.backend_server.global.annotation.NoSpecialChar;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 
 import java.util.List;
@@ -30,6 +32,10 @@ public record ApplicationApplyRequestDto(
 
         @NotBlank(message = "학과는 필수입니다.")
         String department,
+
+        @Schema(description = "성별 (필수, 통계 집계용)", requiredMode = Schema.RequiredMode.REQUIRED, example = "MALE")
+        @NotNull(message = "성별은 필수입니다.")
+        Gender gender,
 
         List<AnswerDto> answers
 ) {

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/application/service/ApplicationServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/application/service/ApplicationServiceImpl.java
@@ -179,12 +179,21 @@ public class ApplicationServiceImpl implements ApplicationService {
                                 .name(request.name())
                                 .phoneNumber(request.phoneNumber())
                                 .department(request.department())
+                                .gender(request.gender())
                                 .build();
                         return userRepository.save(newUser);
                     } catch (Exception e) {
                         log.warn("나머지 정보가 다른데, 이미 존재하는 학번으로 접수. 학번 : "+request.studentId());
                         throw new ExistingUserStudentIdException("나머지 정보가 다른데, 이미존재하는 학번으로 접수, 학번 : "+request.studentId());}
                 });
+
+        //2.1 기존 User를 재사용한 경우, 성별이 비어 있으면 이번 제출값으로 채운다.
+        //    (이 처리가 없으면 성별 필드 추가 이전에 생성된 User의 성별은 영원히 수집되지 않는다)
+        //    같은 학번으로 동시에 제출되는 경우를 대비해 DB 조건부 UPDATE로 원자적으로 처리한다.
+        if (request.gender() != null && userRepository.updateGenderIfAbsent(user.getId(), request.gender()) == 1) {
+            user.fillGenderIfAbsent(request.gender());
+            log.info("기존 User의 성별을 이번 지원서 제출값으로 채움. userId={}", user.getId());
+        }
 
         //3. (폼+학번)으로 지원내역이 있는지 찾기
         Optional<Application> existingApplicationOptional = applicationRepository.findByStudentIdAndClubApplyForm(request.studentId(), form);

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/user/entity/Gender.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/user/entity/Gender.java
@@ -1,0 +1,21 @@
+package com.kakaotech.team18.backend_server.domain.user.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 지원자 성별.
+ * <p>
+ * 통계 집계에만 사용되며, 선택 입력이다. 미입력(null)은 통계에서 {@code UNKNOWN} 버킷으로 노출된다.
+ * <p>
+ * <strong>반드시 {@code @Enumerated(EnumType.STRING)}으로 저장한다.</strong> 순서값으로 저장하면 상수를 추가하는 순간
+ * 기존 데이터의 의미가 바뀐다.
+ */
+@Getter
+@RequiredArgsConstructor
+public enum Gender {
+    MALE("남성"),
+    FEMALE("여성");
+
+    private final String label;
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/user/entity/User.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/user/entity/User.java
@@ -3,6 +3,8 @@ package com.kakaotech.team18.backend_server.domain.user.entity;
 import com.kakaotech.team18.backend_server.domain.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -41,6 +43,14 @@ public class User extends BaseEntity {
     @Column(name = "department",  nullable = false)
     private String department;
 
+    /**
+     * 성별. 선택 입력이며, 이 필드가 추가되기 전에 생성된 User는 null이다.
+     * 통계에서는 null을 '미입력' 버킷으로 집계한다.
+     */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "gender")
+    private Gender gender;
+
     @Builder
     private User(
             Long kakaoId,
@@ -48,7 +58,8 @@ public class User extends BaseEntity {
             String name,
             String studentId,
             String phoneNumber,
-            String department
+            String department,
+            Gender gender
     ) {
         this.kakaoId = kakaoId;
         this.email = email;
@@ -56,6 +67,7 @@ public class User extends BaseEntity {
         this.studentId = studentId;
         this.phoneNumber = phoneNumber;
         this.department = department;
+        this.gender = gender;
     }
 
     /**
@@ -64,5 +76,23 @@ public class User extends BaseEntity {
      */
     public void connectKakaoId(Long kakaoId) {
         this.kakaoId = kakaoId;
+    }
+
+    /**
+     * 성별이 아직 없을 때만 채워 넣습니다.
+     * <p>
+     * 지원서 제출 시 User는 학번으로 조회되어 재사용되므로(재지원·타 동아리 지원), 이 처리가 없으면 성별 필드 추가
+     * 이전에 만들어진 User의 성별은 영원히 null로 남습니다. 이미 값이 있으면 덮어쓰지 않아, 뒤늦은 제출이 기존 응답을
+     * 바꾸지 못하게 합니다.
+     *
+     * @param gender 새로 접수된 성별 (null이면 아무 것도 하지 않음)
+     * @return 실제로 값이 채워졌으면 true
+     */
+    public boolean fillGenderIfAbsent(Gender gender) {
+        if (this.gender != null || gender == null) {
+            return false;
+        }
+        this.gender = gender;
+        return true;
     }
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/user/repository/UserRepository.java
@@ -1,10 +1,14 @@
 package com.kakaotech.team18.backend_server.domain.user.repository;
 
+import com.kakaotech.team18.backend_server.domain.user.entity.Gender;
 import com.kakaotech.team18.backend_server.domain.user.entity.User;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
@@ -33,4 +37,17 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByEmail(String email);
 
     boolean existsByPhoneNumber(String s);
+
+    /**
+     * gender가 아직 없는 User에 한해 원자적으로 채워 넣습니다.
+     * <p>
+     * WHERE 절의 {@code gender IS NULL}이 DB 레벨에서 조건을 재확인하므로, 같은 학번으로 두 요청이 동시에
+     * 들어와도 먼저 커밋되는 한 요청만 값을 채우고 나머지는 0건 갱신으로 끝납니다. 애플리케이션 레벨에서 읽은
+     * User 엔티티의 gender 값만으로 판단하면 이 경합을 막을 수 없습니다.
+     *
+     * @return 실제로 갱신된 행 수 (0 또는 1)
+     */
+    @Modifying
+    @Query("UPDATE User u SET u.gender = :gender WHERE u.id = :id AND u.gender IS NULL")
+    int updateGenderIfAbsent(@Param("id") Long id, @Param("gender") Gender gender);
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/global/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/exception/handler/GlobalExceptionHandler.java
@@ -173,9 +173,7 @@ public class GlobalExceptionHandler {
 
 
     @ExceptionHandler(MissingServletRequestPartException.class)
-    public ResponseEntity<ErrorResponseDto> handleMissingServletRequestPartException(
-            MissingServletRequestPartException e)
-    {
+    public ResponseEntity<ErrorResponseDto> handleMissingServletRequestPartException(MissingServletRequestPartException e) {
         final ErrorCode errorCode = ErrorCode.INVALID_INPUT_VALUE;
         final ErrorResponseDto response = ErrorResponseDto.from(errorCode);
         log.warn("MissingServletRequestPartException: {}", errorCode.getMessage(), e);

--- a/src/main/java/com/kakaotech/team18/backend_server/global/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/exception/handler/GlobalExceptionHandler.java
@@ -10,6 +10,7 @@ import com.kakaotech.team18.backend_server.global.exception.exceptions.StatusNot
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.convert.ConversionFailedException;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.authorization.AuthorizationDeniedException;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
@@ -136,6 +137,27 @@ public class GlobalExceptionHandler {
      * @param e MissingRequestCookieException
      * @return 400 Bad Request 상태 코드와 표준 에러 응답
      */
+    /**
+     * HttpMessageNotReadableException 예외를 처리
+     * <p>
+     * 요청 본문(JSON)을 DTO로 역직렬화하지 못했을 때 발생합니다. 정의되지 않은 Enum 상수(예: 성별에 잘못된 값)나
+     * 깨진 JSON이 여기에 해당합니다. 이 핸들러가 없으면 전역 {@code Exception} 핸들러로 떨어져 500이 나가므로,
+     * 클라이언트 입력 오류를 400으로 명확히 구분하기 위해 별도로 처리합니다.
+     *
+     * @return 400 Bad Request 상태 코드와 표준 에러 응답
+     */
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    protected ResponseEntity<ErrorResponseDto> handleHttpMessageNotReadableException(
+            final HttpMessageNotReadableException e) {
+
+        final ErrorCode errorCode = ErrorCode.INVALID_INPUT_VALUE;
+        final ErrorResponseDto response = ErrorResponseDto.from(errorCode);
+
+        log.warn("HttpMessageNotReadableException: {}", errorCode.getMessage(), e);
+
+        return new ResponseEntity<>(response, errorCode.getHttpStatus());
+    }
+
     @ExceptionHandler(MissingRequestCookieException.class)
     protected ResponseEntity<ErrorResponseDto> handleMissingRequestCookieException(final MissingRequestCookieException e) {
         final ErrorCode errorCode = ErrorCode.REQUIRED_COOKIE_NOT_FOUND;

--- a/src/main/resources/db/migration/README.md
+++ b/src/main/resources/db/migration/README.md
@@ -1,0 +1,15 @@
+# 운영 DB 마이그레이션
+
+`prod` 프로필은 `spring.jpa.hibernate.ddl-auto: none`(`application.yml`)이므로 스키마가 자동으로 반영되지 않는다.
+개발 프로필은 `create` / `create-drop`이라 마이그레이션을 빠뜨려도 로컬에서는 드러나지 않으니, **엔티티를 바꿀 때마다
+여기에 대응하는 SQL을 반드시 추가한다.**
+
+Flyway·Liquibase는 도입되어 있지 않다. 아래 파일은 **배포 시 운영 DB에 순서대로 직접 실행**한다.
+
+| 순서 | 파일 | 내용 |
+|---|---|---|
+| 1 | `V1__add_user_gender.sql` | `users.gender` 컬럼 추가 |
+
+실행 전 확인:
+
+- 각 스크립트는 재실행해도 안전하도록 작성되어 있지 않다. 한 번만 실행한다.

--- a/src/main/resources/db/migration/V1__add_user_gender.sql
+++ b/src/main/resources/db/migration/V1__add_user_gender.sql
@@ -1,0 +1,10 @@
+-- 지원자 통계(#335) 1단계: 성별 수집
+--
+-- 대상: 운영(MySQL). prod 프로필은 ddl-auto: none 이므로 수동 실행이 필요하다.
+
+-- 성별 컬럼 추가.
+-- 반드시 NULL 허용으로 추가한다. 이 컬럼이 생기기 전에 접수된 지원자는 성별을 알 수 없고,
+-- NOT NULL로 만들면 기존 행에 임의의 기본값이 들어가 통계가 왜곡된다.
+-- 값은 Enum 이름(MALE / FEMALE)으로 저장된다. @Enumerated(EnumType.STRING)
+ALTER TABLE users
+    ADD COLUMN gender VARCHAR(20) NULL COMMENT '성별(MALE/FEMALE). NULL은 미입력';

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/application/controller/ApplicationControllerTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/application/controller/ApplicationControllerTest.java
@@ -321,6 +321,7 @@ class ApplicationControllerTest {
           "studentId":"202312",
           "phoneNumber":"010-0000-0000",
           "department":"컴퓨터공학과",
+          "gender":"MALE",
           "answers": [
           {"questionNum":0,"question":"q","answer":"자기소개입니다"},
           {"questionNum":1,"question":"q","answer":"여"},

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/application/service/ApplicationServiceImplTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/application/service/ApplicationServiceImplTest.java
@@ -263,7 +263,7 @@ class ApplicationServiceImplTest {
         // questionNum을 0L로 설정 (FormQuestion의 displayOrder가 1L일 때, 서비스 로직에서 disp-1 = 0을 조회하므로)
         AnswerDto answerDto = new AnswerDto(0L, "면접 가능 날짜는?", interviewTimeNode);
         ApplicationApplyRequestDto requestDto = new ApplicationApplyRequestDto(
-                "test@test.com", "김지원", studentId, "010-1234-5678", "컴퓨터공학과", List.of(answerDto)
+                "test@test.com", "김지원", studentId, "010-1234-5678", "컴퓨터공학과", null, List.of(answerDto)
         );
 
         ClubApplyForm mockForm = mock(ClubApplyForm.class);

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/application/service/ApplicationServiceSubmitApplicationTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/application/service/ApplicationServiceSubmitApplicationTest.java
@@ -206,7 +206,7 @@ class ApplicationServiceSubmitApplicationTest {
                     .thenReturn(Optional.of(president));
 
             ApplicationApplyRequestDto req = new ApplicationApplyRequestDto(
-                    "stud@example.com", "홍길동", "20231234", "010-0000-0000", "컴공",
+                    "stud@example.com", "홍길동", "20231234", "010-0000-0000", "컴공", null,
                     List.of(
                             new ApplicationApplyRequestDto.AnswerDto(0L, "q", tn("안녕하세요")),
                             new ApplicationApplyRequestDto.AnswerDto(1L, "q", tn("여")),
@@ -274,7 +274,7 @@ class ApplicationServiceSubmitApplicationTest {
                     .thenReturn(Optional.of(existing));
 
             ApplicationApplyRequestDto req = new ApplicationApplyRequestDto(
-                    "stud@example.com", "홍길동", "20231234", "010-0000-0000", "컴공",
+                    "stud@example.com", "홍길동", "20231234", "010-0000-0000", "컴공", null,
                     List.of(
                             new ApplicationApplyRequestDto.AnswerDto(0L, "q", tn("수정본문")),
                             new ApplicationApplyRequestDto.AnswerDto(1L, "q", tn("남")),
@@ -338,7 +338,7 @@ class ApplicationServiceSubmitApplicationTest {
                     .thenReturn(Optional.of(president));
 
             ApplicationApplyRequestDto req = new ApplicationApplyRequestDto(
-                    "stud@example.com", "홍길동", "20231234", "010-0000-0000", "컴퓨터공학과",
+                    "stud@example.com", "홍길동", "20231234", "010-0000-0000", "컴퓨터공학과", null,
                     List.of(
                             new ApplicationApplyRequestDto.AnswerDto(0L, "q", tn("수정본문")),
                             new ApplicationApplyRequestDto.AnswerDto(1L, "q", tn("여")),

--- a/src/test/java/com/kakaotech/team18/backend_server/global/exception/handler/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/global/exception/handler/GlobalExceptionHandlerTest.java
@@ -84,6 +84,13 @@ class GlobalExceptionHandlerTest {
 
         @NotBlank(message = "이름은 비워둘 수 없습니다.")
         private String name;
+
+        // 잘못된 값이 오면 Jackson 역직렬화 단계에서 HttpMessageNotReadableException이 발생하는 enum 필드
+        private Kind kind;
+    }
+
+    enum Kind {
+        MALE, FEMALE
     }
 
     @Test
@@ -142,6 +149,44 @@ class GlobalExceptionHandlerTest {
                 .andExpect(jsonPath("$.error_code").value(errorCode.name()))
                 .andExpect(jsonPath("$.message").value(errorCode.getMessage()))
                 .andExpect(jsonPath("$.detail").value("name: 이름은 비워둘 수 없습니다."));
+    }
+
+    @Test
+    @DisplayName("깨진 JSON 요청 본문 → HttpMessageNotReadableException → 400 INVALID_INPUT_VALUE")
+    void handleHttpMessageNotReadable_malformedJson_test() throws Exception {
+        // given: 닫히지 않은 JSON (파싱 자체가 실패)
+        final String url = "/test/validation-Exception";
+        final String malformedJson = "{\"name\": \"홍길동\"";
+        final ErrorCode errorCode = ErrorCode.INVALID_INPUT_VALUE;
+
+        // when
+        ResultActions resultActions = mockMvc.perform(post(url)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(malformedJson));
+
+        // then
+        resultActions.andExpect(status().is(errorCode.getHttpStatus().value()))
+                .andExpect(jsonPath("$.error_code").value(errorCode.name()))
+                .andExpect(jsonPath("$.message").value(errorCode.getMessage()));
+    }
+
+    @Test
+    @DisplayName("정의되지 않은 enum 값 → HttpMessageNotReadableException → 400 INVALID_INPUT_VALUE")
+    void handleHttpMessageNotReadable_invalidEnum_test() throws Exception {
+        // given: kind에 enum에 없는 값을 넣어 역직렬화 실패 유발
+        final String url = "/test/validation-Exception";
+        final String requestBody = "{\"name\": \"홍길동\", \"kind\": \"UNKNOWN\"}";
+        final ErrorCode errorCode = ErrorCode.INVALID_INPUT_VALUE;
+
+        // when
+        ResultActions resultActions = mockMvc.perform(post(url)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody));
+
+        // then
+        resultActions.andExpect(status().is(errorCode.getHttpStatus().value()))
+                .andExpect(jsonPath("$.error_code").value(errorCode.name()))
+                .andExpect(jsonPath("$.message").value(errorCode.getMessage()));
     }
 
     @Test


### PR DESCRIPTION
관련 이슈: #335

## 작업 내용

- `Gender` enum 추가 (`MALE`/`FEMALE`), `User.gender`를 nullable + `@Enumerated(EnumType.STRING)`으로 저장
- 지원서 제출 시 `gender` 접수, 기존 User 재사용 시 성별이 비어 있으면 채우도록 처리 (`User.fillGenderIfAbsent`)
  - 이 처리가 없으면 성별 필드 추가 이전에 생성된 User의 성별은 영원히 수집되지 않음
- `HttpMessageNotReadableException` 400 처리 추가 (정의되지 않은 Gender 값 등 역직렬화 실패 시 500 대신 400)
- 운영 DB용 마이그레이션 SQL 추가: `V1__add_user_gender.sql` (`users.gender` 컬럼 추가, nullable)

## 머지 전 필요한 작업

- `prod`는 `ddl-auto: none`이므로 `V1__add_user_gender.sql`을 운영 DB에 수동 실행해야 합니다.

## 테스트

- 기존 테스트 스위트로 검증

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 지원서 제출 시 성별(남성/여성)을 필수로 입력할 수 있습니다.
  * 사용자의 성별 정보가 등록되며, 기존 정보가 없는 경우에만 보완됩니다.
* **버그 수정**
  * 잘못된 JSON 요청을 명확한 입력 오류로 안내합니다.
* **문서**
  * 사용자 성별 관련 운영 마이그레이션 절차와 스크립트를 추가했습니다.
* **테스트**
  * 성별 필드 반영에 맞춰 관련 테스트 입력을 조정했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->