### PR TITLE
[FEAT] 지원자 학부 수집 (#335)

### DIFF
--- a/src/main/java/com/kakaotech/team18/backend_server/domain/application/dto/ApplicationApplyRequestDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/application/dto/ApplicationApplyRequestDto.java
@@ -1,6 +1,7 @@
 package com.kakaotech.team18.backend_server.domain.application.dto;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.kakaotech.team18.backend_server.domain.user.entity.Faculty;
 import com.kakaotech.team18.backend_server.domain.user.entity.Gender;
 import com.kakaotech.team18.backend_server.global.annotation.NoSpecialChar;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -36,6 +37,9 @@ public record ApplicationApplyRequestDto(
         @Schema(description = "성별 (필수, 통계 집계용)", requiredMode = Schema.RequiredMode.REQUIRED, example = "MALE")
         @NotNull(message = "성별은 필수입니다.")
         Gender gender,
+
+        @Schema(description = "학부 (선택, 통계 집계용). 목록에 없으면 ETC. 프론트 전환기에는 미전송(null)을 허용하며 통계에서 '미입력' 버킷으로 집계된다.", requiredMode = Schema.RequiredMode.NOT_REQUIRED, example = "ENGINEERING")
+        Faculty faculty,
 
         List<AnswerDto> answers
 ) {

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/application/service/ApplicationServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/application/service/ApplicationServiceImpl.java
@@ -180,6 +180,7 @@ public class ApplicationServiceImpl implements ApplicationService {
                                 .phoneNumber(request.phoneNumber())
                                 .department(request.department())
                                 .gender(request.gender())
+                                .faculty(request.faculty())
                                 .build();
                         return userRepository.save(newUser);
                     } catch (Exception e) {
@@ -193,6 +194,12 @@ public class ApplicationServiceImpl implements ApplicationService {
         if (request.gender() != null && userRepository.updateGenderIfAbsent(user.getId(), request.gender()) == 1) {
             user.fillGenderIfAbsent(request.gender());
             log.info("기존 User의 성별을 이번 지원서 제출값으로 채움. userId={}", user.getId());
+        }
+
+        //2.2 학부도 동일하게, 기존 User에 비어 있으면 이번 제출값으로 원자적으로 채운다.
+        if (request.faculty() != null && userRepository.updateFacultyIfAbsent(user.getId(), request.faculty()) == 1) {
+            user.fillFacultyIfAbsent(request.faculty());
+            log.info("기존 User의 학부를 이번 지원서 제출값으로 채움. userId={}", user.getId());
         }
 
         //3. (폼+학번)으로 지원내역이 있는지 찾기

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/user/entity/Faculty.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/user/entity/Faculty.java
@@ -1,0 +1,36 @@
+package com.kakaotech.team18.backend_server.domain.user.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 지원자 학부(단과대학).
+ * <p>
+ * 통계 집계에 사용된다. 자유 입력 학과({@link User#getDepartment()})와 달리 학부는 목록이 한정적이라 enum으로 고정해
+ * 표기 파편화 없이 정확히 집계한다. 목록에 없는 경우를 위해 {@link #ETC}(기타)를 둔다.
+ * <p>
+ * <strong>반드시 {@code @Enumerated(EnumType.STRING)}으로 저장한다.</strong> 순서값으로 저장하면 상수를 추가하거나
+ * 순서를 바꾸는 순간 기존 데이터의 의미가 바뀐다.
+ */
+@Getter
+@RequiredArgsConstructor
+public enum Faculty {
+    NURSING("간호대학"),
+    BUSINESS("경영대학"),
+    ENGINEERING("공과대학"),
+    AGRICULTURE_AND_LIFE_SCIENCES("농업생명과학대학"),
+    EDUCATION("사범대학"),
+    SOCIAL_SCIENCES("사회과학대학"),
+    HUMAN_ECOLOGY("생활과학대학"),
+    VETERINARY_MEDICINE("수의과대학"),
+    PHARMACY("약학대학"),
+    ARTS("예술대학"),
+    MEDICINE("의과대학"),
+    HUMANITIES("인문대학"),
+    NATURAL_SCIENCES("자연과학대학"),
+    AI_CONVERGENCE("AI융합대학"),
+    SELF_DESIGNED_MAJOR("자율전공학부"),
+    ETC("기타");
+
+    private final String label;
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/user/entity/User.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/user/entity/User.java
@@ -51,6 +51,14 @@ public class User extends BaseEntity {
     @Column(name = "gender")
     private Gender gender;
 
+    /**
+     * 학부(단과대학). 이 필드가 추가되기 전에 생성된 User나 비지원 경로(카카오·동아리원)로 생성된 User는 null이다.
+     * 통계에서는 null을 '미입력' 버킷으로 집계한다. 목록에 없는 학부는 {@link Faculty#ETC}로 수집된다.
+     */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "faculty")
+    private Faculty faculty;
+
     @Builder
     private User(
             Long kakaoId,
@@ -59,7 +67,8 @@ public class User extends BaseEntity {
             String studentId,
             String phoneNumber,
             String department,
-            Gender gender
+            Gender gender,
+            Faculty faculty
     ) {
         this.kakaoId = kakaoId;
         this.email = email;
@@ -68,6 +77,7 @@ public class User extends BaseEntity {
         this.phoneNumber = phoneNumber;
         this.department = department;
         this.gender = gender;
+        this.faculty = faculty;
     }
 
     /**
@@ -93,6 +103,24 @@ public class User extends BaseEntity {
             return false;
         }
         this.gender = gender;
+        return true;
+    }
+
+    /**
+     * 학부가 아직 없을 때만 채워 넣습니다.
+     * <p>
+     * 지원서 제출 시 User는 학번으로 조회되어 재사용되므로(재지원·타 동아리 지원), 이 처리가 없으면 학부 필드 추가
+     * 이전에 만들어진 User의 학부는 영원히 null로 남습니다. 이미 값이 있으면 덮어쓰지 않아, 뒤늦은 제출이 기존 응답을
+     * 바꾸지 못하게 합니다.
+     *
+     * @param faculty 새로 접수된 학부 (null이면 아무 것도 하지 않음)
+     * @return 실제로 값이 채워졌으면 true
+     */
+    public boolean fillFacultyIfAbsent(Faculty faculty) {
+        if (this.faculty != null || faculty == null) {
+            return false;
+        }
+        this.faculty = faculty;
         return true;
     }
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/user/repository/UserRepository.java
@@ -1,5 +1,6 @@
 package com.kakaotech.team18.backend_server.domain.user.repository;
 
+import com.kakaotech.team18.backend_server.domain.user.entity.Faculty;
 import com.kakaotech.team18.backend_server.domain.user.entity.Gender;
 import com.kakaotech.team18.backend_server.domain.user.entity.User;
 import jakarta.validation.constraints.Email;
@@ -50,4 +51,16 @@ public interface UserRepository extends JpaRepository<User, Long> {
     @Modifying
     @Query("UPDATE User u SET u.gender = :gender WHERE u.id = :id AND u.gender IS NULL")
     int updateGenderIfAbsent(@Param("id") Long id, @Param("gender") Gender gender);
+
+    /**
+     * faculty가 아직 없는 User에 한해 원자적으로 채워 넣습니다.
+     * <p>
+     * {@link #updateGenderIfAbsent}와 동일하게, WHERE 절의 {@code faculty IS NULL}이 DB 레벨에서 조건을
+     * 재확인하므로 같은 학번 동시 제출 시에도 먼저 커밋되는 한 요청만 값을 채웁니다.
+     *
+     * @return 실제로 갱신된 행 수 (0 또는 1)
+     */
+    @Modifying
+    @Query("UPDATE User u SET u.faculty = :faculty WHERE u.id = :id AND u.faculty IS NULL")
+    int updateFacultyIfAbsent(@Param("id") Long id, @Param("faculty") Faculty faculty);
 }

--- a/src/main/resources/db/migration/README.md
+++ b/src/main/resources/db/migration/README.md
@@ -9,6 +9,7 @@ Flyway·Liquibase는 도입되어 있지 않다. 아래 파일은 **배포 시 �
 | 순서 | 파일 | 내용 |
 |---|---|---|
 | 1 | `V1__add_user_gender.sql` | `users.gender` 컬럼 추가 |
+| 2 | `V2__add_user_faculty.sql` | `users.faculty` 컬럼 추가 |
 
 실행 전 확인:
 

--- a/src/main/resources/db/migration/V2__add_user_faculty.sql
+++ b/src/main/resources/db/migration/V2__add_user_faculty.sql
@@ -1,0 +1,9 @@
+-- 지원자 통계(#335): 학부 수집
+--
+-- 대상: 운영(MySQL). prod 프로필은 ddl-auto: none 이므로 수동 실행이 필요하다.
+
+-- 학부 컬럼 추가. NULL 허용으로 추가한다.
+-- 이 컬럼이 생기기 전에 접수된 지원자나 비지원 경로(카카오·동아리원)로 생성된 User는 학부를 알 수 없다.
+-- 값은 Enum 이름(NURSING/BUSINESS/.../ETC)으로 저장된다. @Enumerated(EnumType.STRING)
+ALTER TABLE users
+    ADD COLUMN faculty VARCHAR(40) NULL COMMENT '학부(Faculty enum 이름). NULL은 미입력';

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/application/controller/ApplicationControllerTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/application/controller/ApplicationControllerTest.java
@@ -322,6 +322,7 @@ class ApplicationControllerTest {
           "phoneNumber":"010-0000-0000",
           "department":"컴퓨터공학과",
           "gender":"MALE",
+          "faculty":"ENGINEERING",
           "answers": [
           {"questionNum":0,"question":"q","answer":"자기소개입니다"},
           {"questionNum":1,"question":"q","answer":"여"},

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/application/dto/ApplicationApplyRequestDtoValidationTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/application/dto/ApplicationApplyRequestDtoValidationTest.java
@@ -1,0 +1,71 @@
+package com.kakaotech.team18.backend_server.domain.application.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.kakaotech.team18.backend_server.domain.user.entity.Faculty;
+import com.kakaotech.team18.backend_server.domain.user.entity.Gender;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("ApplicationApplyRequestDto 검증 - 학부(faculty, 선택 입력)")
+class ApplicationApplyRequestDtoValidationTest {
+
+    private static ValidatorFactory factory;
+    private static Validator validator;
+
+    @BeforeAll
+    static void setUp() {
+        factory = Validation.buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+    }
+
+    @AfterAll
+    static void tearDown() {
+        factory.close();
+    }
+
+    private ApplicationApplyRequestDto dtoWithFaculty(Faculty faculty) {
+        return new ApplicationApplyRequestDto(
+                "stud@example.com", "홍길동", "202312", "010-0000-0000",
+                "컴퓨터공학과", Gender.MALE, faculty, List.of()
+        );
+    }
+
+    @Test
+    @DisplayName("faculty가 null이어도 검증 위반 없음 (프론트 전환기 미전송 허용)")
+    void faculty_null_isAllowed() {
+        Set<ConstraintViolation<ApplicationApplyRequestDto>> violations =
+                validator.validate(dtoWithFaculty(null));
+
+        assertThat(violations)
+                .noneMatch(v -> v.getPropertyPath().toString().equals("faculty"));
+    }
+
+    @Test
+    @DisplayName("유효한 faculty 값이면 faculty 관련 위반 없음")
+    void faculty_valid_noViolation() {
+        Set<ConstraintViolation<ApplicationApplyRequestDto>> violations =
+                validator.validate(dtoWithFaculty(Faculty.ENGINEERING));
+
+        assertThat(violations)
+                .noneMatch(v -> v.getPropertyPath().toString().equals("faculty"));
+    }
+
+    @Test
+    @DisplayName("목록에 없는 학부는 ETC로 접수 가능")
+    void faculty_etc_isAccepted() {
+        Set<ConstraintViolation<ApplicationApplyRequestDto>> violations =
+                validator.validate(dtoWithFaculty(Faculty.ETC));
+
+        assertThat(violations)
+                .noneMatch(v -> v.getPropertyPath().toString().equals("faculty"));
+    }
+}

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/application/service/ApplicationServiceImplTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/application/service/ApplicationServiceImplTest.java
@@ -263,7 +263,7 @@ class ApplicationServiceImplTest {
         // questionNum을 0L로 설정 (FormQuestion의 displayOrder가 1L일 때, 서비스 로직에서 disp-1 = 0을 조회하므로)
         AnswerDto answerDto = new AnswerDto(0L, "면접 가능 날짜는?", interviewTimeNode);
         ApplicationApplyRequestDto requestDto = new ApplicationApplyRequestDto(
-                "test@test.com", "김지원", studentId, "010-1234-5678", "컴퓨터공학과", null, List.of(answerDto)
+                "test@test.com", "김지원", studentId, "010-1234-5678", "컴퓨터공학과", null, null, List.of(answerDto)
         );
 
         ClubApplyForm mockForm = mock(ClubApplyForm.class);

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/application/service/ApplicationServiceSubmitApplicationTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/application/service/ApplicationServiceSubmitApplicationTest.java
@@ -206,7 +206,7 @@ class ApplicationServiceSubmitApplicationTest {
                     .thenReturn(Optional.of(president));
 
             ApplicationApplyRequestDto req = new ApplicationApplyRequestDto(
-                    "stud@example.com", "홍길동", "20231234", "010-0000-0000", "컴공", null,
+                    "stud@example.com", "홍길동", "20231234", "010-0000-0000", "컴공", null, null,
                     List.of(
                             new ApplicationApplyRequestDto.AnswerDto(0L, "q", tn("안녕하세요")),
                             new ApplicationApplyRequestDto.AnswerDto(1L, "q", tn("여")),
@@ -274,7 +274,7 @@ class ApplicationServiceSubmitApplicationTest {
                     .thenReturn(Optional.of(existing));
 
             ApplicationApplyRequestDto req = new ApplicationApplyRequestDto(
-                    "stud@example.com", "홍길동", "20231234", "010-0000-0000", "컴공", null,
+                    "stud@example.com", "홍길동", "20231234", "010-0000-0000", "컴공", null, null,
                     List.of(
                             new ApplicationApplyRequestDto.AnswerDto(0L, "q", tn("수정본문")),
                             new ApplicationApplyRequestDto.AnswerDto(1L, "q", tn("남")),
@@ -338,7 +338,7 @@ class ApplicationServiceSubmitApplicationTest {
                     .thenReturn(Optional.of(president));
 
             ApplicationApplyRequestDto req = new ApplicationApplyRequestDto(
-                    "stud@example.com", "홍길동", "20231234", "010-0000-0000", "컴퓨터공학과", null,
+                    "stud@example.com", "홍길동", "20231234", "010-0000-0000", "컴퓨터공학과", null, null,
                     List.of(
                             new ApplicationApplyRequestDto.AnswerDto(0L, "q", tn("수정본문")),
                             new ApplicationApplyRequestDto.AnswerDto(1L, "q", tn("여")),


### PR DESCRIPTION
관련 이슈: #335

## 작업 내용

통계 집계에 필요한 지원자 **학부(faculty)** 를 수집한다. 자유 입력 학과(`department`)와 달리 학부는 목록이 한정적이라 enum으로 고정해 표기 파편화 없이 정확히 집계한다.

- `Faculty` enum 추가 — 15개 학부 + 목록 밖을 위한 `ETC`(기타)
- `User.faculty`를 nullable + `@Enumerated(EnumType.STRING)`으로 저장
- 지원서의 `faculty`는 **선택 입력** — 프론트 전환기에는 미전송(null)을 허용하고 통계에서 '미입력' 버킷으로 집계
- 기존 User 재사용 시 학부가 비어 있으면 채우도록 처리 (`updateFacultyIfAbsent`, gender와 동일한 `IS NULL` 조건부 UPDATE)
- 기존 `department` 필드는 **그대로 유지** (기존 지원서 상세·이메일 호환)

## 왜 선택 입력인가 (하위호환 롤아웃)

프론트가 아직 `faculty`를 보내지 않는 상태다. 지금 `@NotNull`로 필수화하면 구 프론트의 지원서 제출이 전부 400으로 막힌다. 그래서 **선택 입력으로 먼저 배포**해 구/신 프론트 모두 동작하게 하고, 프론트가 필드를 보내도록 배포·검증된 뒤 **별도 PR에서 `@NotNull`로 필수화**한다(expand/contract).

## Faculty 값 (16개)

`NURSING`(간호), `BUSINESS`(경영), `ENGINEERING`(공과), `AGRICULTURE_AND_LIFE_SCIENCES`(농업생명과학), `EDUCATION`(사범), `SOCIAL_SCIENCES`(사회과학), `HUMAN_ECOLOGY`(생활과학), `VETERINARY_MEDICINE`(수의과), `PHARMACY`(약학), `ARTS`(예술), `MEDICINE`(의과), `HUMANITIES`(인문), `NATURAL_SCIENCES`(자연과학), `AI_CONVERGENCE`(AI융합), `SELF_DESIGNED_MAJOR`(자율전공학부), `ETC`(기타)

## 머지 전 필요한 작업

- `prod`는 `ddl-auto: none`이므로 `V2__add_user_faculty.sql`을 운영 DB에 수동 실행해야 합니다.
  ```sql
  ALTER TABLE users ADD COLUMN faculty VARCHAR(40) NULL COMMENT '학부(Faculty enum 이름). NULL은 미입력';
  ```

## 프론트 전달 필요

- 지원서 제출 요청 바디에 `faculty` 필드가 추가됐습니다(현재 **선택**). 값은 위 16개 enum 중 하나(대문자). 목록에 없으면 `ETC`.
- **목록 밖 값은 백엔드가 자동으로 ETC로 바꾸지 않고 400을 냅니다.** "기타" 선택 시 반드시 `"ETC"`를 보내야 합니다.
- 추후 필수(@NotNull)로 조일 예정이니, 프론트에서 학부 선택 UI를 준비해 주세요.

## 테스트

- `faculty` 선택 입력(null 허용) / 유효값 / `ETC` 접수 검증