### PR TITLE
[FIX] 지원자 성별을 프론트 전환기 동안 선택 입력으로 완화 (#335)

### DIFF
--- a/src/main/java/com/kakaotech/team18/backend_server/domain/application/dto/ApplicationApplyRequestDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/application/dto/ApplicationApplyRequestDto.java
@@ -6,7 +6,6 @@ import com.kakaotech.team18.backend_server.global.annotation.NoSpecialChar;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 
 import java.util.List;
@@ -33,8 +32,7 @@ public record ApplicationApplyRequestDto(
         @NotBlank(message = "학과는 필수입니다.")
         String department,
 
-        @Schema(description = "성별 (필수, 통계 집계용)", requiredMode = Schema.RequiredMode.REQUIRED, example = "MALE")
-        @NotNull(message = "성별은 필수입니다.")
+        @Schema(description = "성별 (선택, 통계 집계용). 프론트 전환기에는 미전송(null)을 허용하며 통계에서 '미입력' 버킷으로 집계된다.", requiredMode = Schema.RequiredMode.NOT_REQUIRED, example = "MALE")
         Gender gender,
 
         List<AnswerDto> answers


### PR DESCRIPTION
관련 이슈: #335

## 문제

`gender`가 `@NotNull`로 이미 develop에 머지돼 있는데, **프론트는 아직 gender를 보내지 않는다.** 이대로 배포되면 지원서 제출(`POST /api/clubs/{clubId}/apply-submit`)이 전부 `400 "성별은 필수입니다."`로 막힌다. (모집 미개시로 실트래픽이 없어 아직 드러나지 않았을 뿐)

## 변경

- `ApplicationApplyRequestDto.gender`의 `@NotNull` 제거 → **선택 입력(nullable)**
- 사용되지 않게 된 `NotNull` import 제거
- 미전송(null)은 통계에서 '미입력' 버킷으로 집계 (gender 3-state 설계 그대로)

## 롤아웃 (expand/contract)

1. (이 PR) gender 선택 입력으로 완화 → 구/신 프론트 모두 동작
2. 프론트가 gender를 보내도록 배포·검증
3. 별도 PR에서 다시 `@NotNull`로 필수화

동일 사유로 신규 `faculty`도 선택 입력으로 시작한다(PR #339).

## 영향 없음

- 응답·DB·스키마 변경 없음. read 경로 무관.
- gender 필수를 단독 검증하는 테스트는 없어 깨지는 테스트 없음.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 지원서 제출 시 성별 정보를 선택적으로 입력할 수 있도록 변경했습니다.
  * 성별 정보를 입력하지 않아도 제출할 수 있으며, 미입력 값이 정상적으로 처리됩니다.
  * API 문서에 성별 항목이 선택 사항임을 반영했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->