### PR TITLE
[FEAT] 지원자 통계 API 계약 정의 (#335)

### DIFF
--- a/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/controller/StatisticsController.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/controller/StatisticsController.java
@@ -1,0 +1,135 @@
+package com.kakaotech.team18.backend_server.domain.statistics.controller;
+
+import com.kakaotech.team18.backend_server.domain.statistics.dto.StatisticsResponseDto;
+import com.kakaotech.team18.backend_server.domain.statistics.entity.StatisticsDimension;
+import com.kakaotech.team18.backend_server.domain.statistics.service.StatisticsService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 지원자 통계 공개 API.
+ * <p>
+ * 지원폼 단위로 집계하며, 지원자에게 공개되므로 <strong>비로그인 상태에서도 조회할 수 있다.</strong>
+ * ({@code SecurityConfig}에 permitAll로 등록되어 있다)
+ */
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/club-apply-forms/{clubApplyFormId}")
+@Tag(name = "Statistics", description = "지원자 통계 API")
+public class StatisticsController {
+
+    private final StatisticsService statisticsService;
+
+    @Operation(
+            summary = "지원폼 단위 지원자 통계 조회",
+            description = """
+                    지원폼에 접수된 지원자의 성별·학번·학부 분포와 일자별 지원 추이를 반환합니다.
+                    비로그인 상태에서도 조회할 수 있습니다.
+
+                    - `dimensions`를 생략하면 모든 항목을 반환합니다.
+                    - 소수 버킷은 재식별 방지를 위해 '기타'로 병합되거나 비공개 처리됩니다.
+                    - 누적 지원자 수가 최소 공개 기준에 미달하면 `results`가 빈 배열로 나갑니다.
+                    - 응답에는 지원자를 식별할 수 있는 값(이름·이메일·전화번호·6자리 학번)이 포함되지 않습니다.
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(
+                            schema = @Schema(implementation = StatisticsResponseDto.class),
+                            examples = @ExampleObject(name = "모집 진행 중", value = """
+                                    {
+                                      "clubApplyFormId": 12,
+                                      "totalApplicants": 214,
+                                      "snapshot": false,
+                                      "calculatedAt": "2026-03-14T23:59:30+09:00",
+                                      "results": [
+                                        {
+                                          "dimension": "GENDER",
+                                          "type": "CATEGORICAL",
+                                          "buckets": [
+                                            { "key": "MALE", "label": "남성", "count": 121, "ratio": 0.565 },
+                                            { "key": "FEMALE", "label": "여성", "count": 91, "ratio": 0.425 },
+                                            { "key": "UNKNOWN", "label": "미입력", "count": 2, "ratio": 0.010 }
+                                          ]
+                                        },
+                                        {
+                                          "dimension": "ADMISSION_YEAR",
+                                          "type": "ORDINAL",
+                                          "buckets": [
+                                            { "key": "2022", "label": "22학번", "count": 58, "ratio": 0.271 }
+                                          ]
+                                        },
+                                        {
+                                          "dimension": "FACULTY",
+                                          "type": "CATEGORICAL",
+                                          "buckets": [
+                                            { "key": "ENGINEERING", "label": "공과대학", "count": 74, "ratio": 0.346 },
+                                            { "key": "NATURAL_SCIENCES", "label": "자연과학대학", "count": 37, "ratio": 0.173 },
+                                            { "key": "ETC", "label": "기타", "count": 20, "ratio": 0.093 }
+                                          ]
+                                        },
+                                        {
+                                          "dimension": "DAILY_APPLICATIONS",
+                                          "type": "TIME_SERIES",
+                                          "buckets": [
+                                            { "key": "2026-03-02", "label": "3월 2일", "count": 4 }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                    """)
+                    )
+            ),
+            @ApiResponse(responseCode = "400", description = "지원하지 않는 dimension", content = @Content),
+            @ApiResponse(responseCode = "404", description = "지원폼을 찾을 수 없음", content = @Content)
+    })
+    @GetMapping("/statistics")
+    public ResponseEntity<StatisticsResponseDto> getStatistics(
+            @Parameter(description = "지원폼 ID", example = "12")
+            @PathVariable Long clubApplyFormId,
+
+            @Parameter(description = "조회할 집계 항목. 생략하면 전체를 반환합니다.",
+                    example = "GENDER,FACULTY")
+            @RequestParam(name = "dimensions", required = false) List<String> dimensions
+    ) {
+        List<StatisticsDimension> requested = resolveDimensions(dimensions);
+
+        log.info("지원자 통계 조회 clubApplyFormId={}, dimensions={}", clubApplyFormId, requested);
+
+        return ResponseEntity.ok(statisticsService.getStatistics(clubApplyFormId, requested));
+    }
+
+    /**
+     * 쿼리 파라미터를 dimension 목록으로 변환합니다. 지정하지 않으면 전체를 조회합니다.
+     * <p>
+     * 문자열을 직접 파싱하는 이유는, 정의되지 않은 값이 들어왔을 때 사용 가능한 목록까지 담은 400을 돌려주기
+     * 위해서다. 컨트롤러 파라미터를 Enum으로 바로 바인딩하면 어떤 값이 왜 틀렸는지 알기 어렵다.
+     */
+    private List<StatisticsDimension> resolveDimensions(List<String> raw) {
+        if (raw == null || raw.isEmpty()) {
+            return StatisticsDimension.defaults();
+        }
+        return raw.stream()
+                .map(StatisticsDimension::from)
+                .distinct()
+                .toList();
+    }
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/dto/RawBucket.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/dto/RawBucket.java
@@ -1,0 +1,27 @@
+package com.kakaotech.team18.backend_server.domain.statistics.dto;
+
+/**
+ * 마스킹·비율 계산 전의 집계 버킷.
+ * <p>
+ * 서비스 내부 전용이며 응답으로 나가지 않는다. 응답용 버킷은 {@link StatisticsResponseDto.Bucket}이다.
+ *
+ * @param key            표기 변경에 영향받지 않는 코드값
+ * @param label          화면 표시용 문자열
+ * @param count          지원자 수
+ * @param distinctValues '기타' 버킷에 병합된 원래 값의 종류 수 (그 외에는 null)
+ */
+public record RawBucket(
+        String key,
+        String label,
+        long count,
+        Integer distinctValues
+) {
+
+    public static RawBucket of(String key, String label, long count) {
+        return new RawBucket(key, label, count, null);
+    }
+
+    public RawBucket plus(long more) {
+        return new RawBucket(key, label, count + more, distinctValues);
+    }
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/dto/StatisticsResponseDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/dto/StatisticsResponseDto.java
@@ -1,0 +1,78 @@
+package com.kakaotech.team18.backend_server.domain.statistics.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.kakaotech.team18.backend_server.domain.statistics.entity.DimensionType;
+import com.kakaotech.team18.backend_server.domain.statistics.entity.StatisticsDimension;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.List;
+
+/**
+ * 지원자 통계 공개 응답.
+ * <p>
+ * <strong>이 DTO에는 지원자를 식별할 수 있는 값이 절대 들어가서는 안 된다.</strong> 이름·이메일·전화번호·지원서 ID는
+ * 물론, 6자리 학번 전체도 포함하지 않는다. 학번은 앞 2자리에서 유도한 입학연도만 노출한다.
+ */
+@Schema(description = "지원폼 단위 지원자 통계")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record StatisticsResponseDto(
+
+        @Schema(description = "통계 대상 지원폼 ID", example = "12")
+        Long clubApplyFormId,
+
+        @Schema(description = "누적 지원자 수", example = "214")
+        long totalApplicants,
+
+        @Schema(description = "모집 종료 후 확정된 스냅샷이면 true, 진행 중 집계본이면 false", example = "false")
+        boolean snapshot,
+
+        @Schema(description = "집계가 수행된 시각", example = "2026-03-14T23:59:30+09:00")
+        OffsetDateTime calculatedAt,
+
+        @Schema(description = "dimension별 집계 결과. 최소 공개 기준에 미달하면 빈 배열이다.")
+        List<DimensionResult> results
+) {
+
+    @Schema(description = "단일 dimension의 집계 결과")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record DimensionResult(
+
+            @Schema(description = "집계 항목", example = "GENDER")
+            StatisticsDimension dimension,
+
+            @Schema(description = "데이터 성격. 표현 방식은 프론트엔드가 정한다.", example = "CATEGORICAL")
+            DimensionType type,
+
+            @Schema(description = "상위 N개로 잘렸으면 true. 잘리지 않았으면 응답에서 생략된다.", example = "true")
+            Boolean truncated,
+
+            @Schema(description = "표기 파편화 등 해석 시 주의사항. 없으면 생략된다.")
+            String notice,
+
+            @Schema(description = "집계 버킷")
+            List<Bucket> buckets
+    ) {
+    }
+
+    @Schema(description = "집계 버킷 하나")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record Bucket(
+
+            @Schema(description = "표기 변경에 영향받지 않는 코드값", example = "MALE")
+            String key,
+
+            @Schema(description = "화면 표시용 문자열", example = "남성")
+            String label,
+
+            @Schema(description = "해당 버킷의 지원자 수", example = "121")
+            long count,
+
+            @Schema(description = "전체 대비 비율(소수점 3자리 고정). 시계열 등 비율이 의미 없는 버킷에서는 생략된다.", example = "0.565")
+            BigDecimal ratio,
+
+            @Schema(description = "'기타' 버킷에 병합된 원래 값의 종류 수. 그 외 버킷에서는 생략된다.", example = "23")
+            Integer distinctValues
+    ) {
+    }
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/entity/DimensionType.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/entity/DimensionType.java
@@ -1,0 +1,18 @@
+package com.kakaotech.team18.backend_server.domain.statistics.entity;
+
+/**
+ * 통계 dimension의 데이터 성격.
+ * <p>
+ * 백엔드는 버킷과 이 타입만 제공하고, 어떤 차트로 그릴지는 프론트엔드가 정한다.
+ */
+public enum DimensionType {
+
+    /** 순서가 없는 범주형. 보통 파이/도넛으로 표현한다. (성별, 학부) */
+    CATEGORICAL,
+
+    /** 순서가 있는 범주형. 버킷 순서를 그대로 유지해야 한다. (학번) */
+    ORDINAL,
+
+    /** 시간축 위의 값. 버킷 순서를 그대로 유지해야 한다. (일자별 지원 추이) */
+    TIME_SERIES
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/entity/StatisticsDimension.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/entity/StatisticsDimension.java
@@ -1,0 +1,49 @@
+package com.kakaotech.team18.backend_server.domain.statistics.entity;
+
+import com.kakaotech.team18.backend_server.global.exception.exceptions.UnsupportedStatisticsDimensionException;
+import java.util.Arrays;
+import java.util.List;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 공개 통계로 제공하는 집계 항목.
+ * <p>
+ * dimension마다 별도 쿼리로 집계한다. 두 항목을 교차 집계(예: 학부 x 성별)하면 버킷 수가 곱으로 늘어 소수 버킷이
+ * 급증하고 재식별 위험이 커지므로, 1차 범위에서는 교차 집계를 제공하지 않는다.
+ */
+@Getter
+@RequiredArgsConstructor
+public enum StatisticsDimension {
+
+    GENDER(DimensionType.CATEGORICAL),
+    ADMISSION_YEAR(DimensionType.ORDINAL),
+    FACULTY(DimensionType.CATEGORICAL),
+    DAILY_APPLICATIONS(DimensionType.TIME_SERIES);
+
+    private final DimensionType type;
+
+    /**
+     * 쿼리 파라미터로 들어온 문자열을 dimension으로 변환합니다.
+     *
+     * @param raw 클라이언트가 요청한 dimension 이름
+     * @return 대응하는 dimension
+     * @throws UnsupportedStatisticsDimensionException 정의되지 않은 이름인 경우 (400)
+     */
+    public static StatisticsDimension from(String raw) {
+        if (raw == null || raw.isBlank()) {
+            throw new UnsupportedStatisticsDimensionException("dimension 값이 비어 있습니다.");
+        }
+        try {
+            return StatisticsDimension.valueOf(raw.trim().toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new UnsupportedStatisticsDimensionException(
+                    "지원하지 않는 dimension: " + raw + " (사용 가능: " + Arrays.toString(values()) + ")");
+        }
+    }
+
+    /** 클라이언트가 dimension을 지정하지 않았을 때 사용할 기본 목록. */
+    public static List<StatisticsDimension> defaults() {
+        return List.of(values());
+    }
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/repository/ApplicationStatisticsRepository.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/repository/ApplicationStatisticsRepository.java
@@ -1,0 +1,31 @@
+package com.kakaotech.team18.backend_server.domain.statistics.repository;
+
+import com.kakaotech.team18.backend_server.domain.application.entity.Application;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.query.Param;
+
+/**
+ * 통계 집계 전용 조회 리포지토리.
+ * <p>
+ * 지원자 속성(성별·학부·학번)은 지원서가 아니라 {@code User}에 저장되므로, 모든 집계는 지원폼으로 필터한
+ * {@code Application}에 {@code User}를 조인해 수행한다.
+ * <p>
+ * <strong>운영진을 제외하지 않는다.</strong> 합격자는 승인 시 {@code ClubMember.role}이
+ * {@code APPLICANT}에서 {@code CLUB_MEMBER}로 바뀌므로, 역할로 필터하면 합격자가 집계에서 빠져나가
+ * 모집이 진행될수록 분포가 왜곡된다. 여기서는 해당 지원폼에 접수된 지원서 전체를 센다.
+ * <p>
+ * dimension별 집계 쿼리는 각 dimension 구현 단계에서 추가한다.
+ */
+public interface ApplicationStatisticsRepository extends Repository<Application, Long> {
+
+    /**
+     * 지원폼의 누적 지원자 수.
+     */
+    @Query("""
+            SELECT count(a.id)
+            FROM Application a
+            WHERE a.clubApplyForm.id = :clubApplyFormId
+            """)
+    long countByClubApplyFormId(@Param("clubApplyFormId") Long clubApplyFormId);
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/service/StatisticsAggregator.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/service/StatisticsAggregator.java
@@ -1,0 +1,55 @@
+package com.kakaotech.team18.backend_server.domain.statistics.service;
+
+import com.kakaotech.team18.backend_server.domain.clubApplyForm.entity.ClubApplyForm;
+import com.kakaotech.team18.backend_server.domain.statistics.dto.RawBucket;
+import com.kakaotech.team18.backend_server.domain.statistics.entity.StatisticsDimension;
+import com.kakaotech.team18.backend_server.domain.statistics.repository.ApplicationStatisticsRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/**
+ * dimension별 원본 집계를 수행합니다.
+ * <p>
+ * 이 단계(계약 정의)에서는 집계 뼈대만 두고 각 dimension은 빈 버킷을 반환한다. 실제 집계는 dimension별 후속
+ * 단계에서 구현한다.
+ * <p>
+ * 마스킹·상위 N 절단·비율 계산은 하지 않는다. 그 처리는 {@code StatisticsServiceImpl}이 담당한다.
+ * dimension마다 별도 쿼리로 처리해 교차 집계로 인한 조합 폭발을 피한다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StatisticsAggregator {
+
+    /** 값이 없는 버킷의 코드값. */
+    public static final String UNKNOWN_KEY = "UNKNOWN";
+
+    /** 값이 없는 버킷의 표시 문자열. */
+    public static final String UNKNOWN_LABEL = "미입력";
+
+    private final ApplicationStatisticsRepository statisticsRepository;
+
+    /**
+     * 지원폼의 누적 지원자 수를 조회합니다.
+     */
+    public long countApplicants(Long clubApplyFormId) {
+        return statisticsRepository.countByClubApplyFormId(clubApplyFormId);
+    }
+
+    /**
+     * 요청된 dimension의 원본 버킷을 계산합니다.
+     * <p>
+     * 아직 각 dimension의 집계는 구현되지 않아 빈 버킷을 반환한다.
+     *
+     * @param form      집계 대상 지원폼
+     * @param dimension 집계 항목
+     * @return 정렬까지 마친 원본 버킷 목록
+     */
+    public List<RawBucket> aggregate(ClubApplyForm form, StatisticsDimension dimension) {
+        return switch (dimension) {
+            case GENDER, ADMISSION_YEAR, FACULTY, DAILY_APPLICATIONS -> List.of();
+        };
+    }
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/service/StatisticsService.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/service/StatisticsService.java
@@ -1,0 +1,17 @@
+package com.kakaotech.team18.backend_server.domain.statistics.service;
+
+import com.kakaotech.team18.backend_server.domain.statistics.dto.StatisticsResponseDto;
+import com.kakaotech.team18.backend_server.domain.statistics.entity.StatisticsDimension;
+import java.util.List;
+
+public interface StatisticsService {
+
+    /**
+     * 지원폼의 공개 통계를 조회합니다.
+     *
+     * @param clubApplyFormId 지원폼 ID
+     * @param dimensions      조회할 집계 항목
+     * @return 공개 가능한 형태로 가공된 통계 응답
+     */
+    StatisticsResponseDto getStatistics(Long clubApplyFormId, List<StatisticsDimension> dimensions);
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/service/StatisticsServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/service/StatisticsServiceImpl.java
@@ -1,0 +1,114 @@
+package com.kakaotech.team18.backend_server.domain.statistics.service;
+
+import com.kakaotech.team18.backend_server.domain.clubApplyForm.entity.ClubApplyForm;
+import com.kakaotech.team18.backend_server.domain.clubApplyForm.repository.ClubApplyFormRepository;
+import com.kakaotech.team18.backend_server.domain.statistics.dto.RawBucket;
+import com.kakaotech.team18.backend_server.domain.statistics.dto.StatisticsResponseDto;
+import com.kakaotech.team18.backend_server.domain.statistics.entity.DimensionType;
+import com.kakaotech.team18.backend_server.domain.statistics.entity.StatisticsDimension;
+import com.kakaotech.team18.backend_server.global.exception.exceptions.ClubApplyFormNotFoundException;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class StatisticsServiceImpl implements StatisticsService {
+
+    /** 모든 일자·시각 집계의 기준 시간대. */
+    public static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+    /** 비율의 소수점 자릿수. 모든 dimension에서 동일하게 고정한다. */
+    private static final int RATIO_SCALE = 3;
+
+    private final ClubApplyFormRepository clubApplyFormRepository;
+    private final StatisticsAggregator aggregator;
+
+    @Override
+    public StatisticsResponseDto getStatistics(Long clubApplyFormId, List<StatisticsDimension> dimensions) {
+        ClubApplyForm form = clubApplyFormRepository.findById(clubApplyFormId)
+                .orElseThrow(() -> new ClubApplyFormNotFoundException("clubApplyFormId = " + clubApplyFormId));
+
+        return calculate(form, dimensions);
+    }
+
+    /**
+     * 지원폼의 통계를 실제로 집계합니다.
+     * <p>
+     * 조회 경로와 스케줄러 사전 계산 경로가 같은 결과를 내도록 이 메서드를 공유한다.
+     */
+    public StatisticsResponseDto calculate(ClubApplyForm form, List<StatisticsDimension> dimensions) {
+        long totalApplicants = aggregator.countApplicants(form.getId());
+
+        List<StatisticsResponseDto.DimensionResult> results = new ArrayList<>();
+        for (StatisticsDimension dimension : dimensions) {
+            // 지원자가 없으면 버킷은 빈 배열이 된다. dimension 자체는 응답에 그대로 남겨,
+            // 클라이언트가 '아직 데이터가 없음'과 '해당 항목을 요청하지 않음'을 구분할 수 있게 한다.
+            List<RawBucket> raw = aggregator.aggregate(form, dimension);
+            results.add(toResult(dimension, raw, totalApplicants, null, null));
+        }
+
+        return new StatisticsResponseDto(
+                form.getId(),
+                totalApplicants,
+                false,
+                OffsetDateTime.now(KST),
+                results
+        );
+    }
+
+    /**
+     * 원본 버킷을 응답 버킷으로 변환하고 비율을 채웁니다.
+     * <p>
+     * 시계열은 전체 대비 비율이 의미가 없으므로 ratio를 채우지 않는다.
+     */
+    private StatisticsResponseDto.DimensionResult toResult(
+            StatisticsDimension dimension,
+            List<RawBucket> raw,
+            long totalApplicants,
+            Boolean truncated,
+            String notice
+    ) {
+        boolean withRatio = dimension.getType() != DimensionType.TIME_SERIES;
+
+        List<StatisticsResponseDto.Bucket> buckets = raw.stream()
+                .map(b -> new StatisticsResponseDto.Bucket(
+                        b.key(),
+                        b.label(),
+                        b.count(),
+                        withRatio ? ratio(b.count(), totalApplicants) : null,
+                        b.distinctValues()
+                ))
+                .toList();
+
+        return new StatisticsResponseDto.DimensionResult(
+                dimension,
+                dimension.getType(),
+                truncated,
+                notice,
+                buckets
+        );
+    }
+
+    /**
+     * 비율을 소수점 {@value #RATIO_SCALE}자리로 고정해 계산합니다.
+     * <p>
+     * BigDecimal을 쓰는 이유는 반올림 결과를 고정하고 {@code 0.010}처럼 끝자리 0까지 그대로 직렬화하기 위함이다.
+     */
+    private BigDecimal ratio(long count, long total) {
+        if (total <= 0) {
+            return BigDecimal.ZERO.setScale(RATIO_SCALE, RoundingMode.HALF_UP);
+        }
+        return BigDecimal.valueOf(count)
+                .divide(BigDecimal.valueOf(total), RATIO_SCALE, RoundingMode.HALF_UP);
+    }
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/global/config/SecurityConfig.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/config/SecurityConfig.java
@@ -86,6 +86,8 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.POST, "/api/clubs/*/apply-submit").permitAll()
                 // 동아리 후기 조회 및 등록 API (공개)
                 .requestMatchers("/api/clubs/*/reviews").permitAll()
+                // 지원자 통계 조회 API (공개) - 지원자에게 공개하는 통계이므로 비로그인 조회를 허용한다
+                .requestMatchers(HttpMethod.GET, "/api/club-apply-forms/*/statistics").permitAll()
                 // 헬스체크 (공개)
                 .requestMatchers("/actuator/health","/actuator/health/**").permitAll()
                 .anyRequest().authenticated()

--- a/src/main/java/com/kakaotech/team18/backend_server/global/exception/code/ErrorCode.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/exception/code/ErrorCode.java
@@ -40,6 +40,7 @@ public enum ErrorCode {
     INVALID_EXCEL_DATA("엑셀 데이터 검증 실패", HttpStatus.BAD_REQUEST),
     CANNOT_DELETE_SELF("자기 자신은 삭제할 수 없습니다. 권한 위임 후 탈퇴해주세요.", HttpStatus.BAD_REQUEST),
     UNSCHEDULED_ACCEPTED_APPLICANT_EXISTS("면접 시간을 결정하지 않은 합격자가 존재합니다. 모든 합격자의 면접 시간을 결정해주세요.", HttpStatus.BAD_REQUEST),
+    UNSUPPORTED_STATISTICS_DIMENSION("지원하지 않는 통계 항목입니다.", HttpStatus.BAD_REQUEST),
 
     // 401 UNAUTHORIZED: 인증되지 않은 사용자
     UNAUTHENTICATED_USER("인증되지 않은 사용자입니다.", HttpStatus.UNAUTHORIZED),

--- a/src/main/java/com/kakaotech/team18/backend_server/global/exception/exceptions/UnsupportedStatisticsDimensionException.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/exception/exceptions/UnsupportedStatisticsDimensionException.java
@@ -1,0 +1,10 @@
+package com.kakaotech.team18.backend_server.global.exception.exceptions;
+
+import com.kakaotech.team18.backend_server.global.exception.code.ErrorCode;
+
+public class UnsupportedStatisticsDimensionException extends CustomException {
+
+    public UnsupportedStatisticsDimensionException(String detail) {
+        super(ErrorCode.UNSUPPORTED_STATISTICS_DIMENSION, detail);
+    }
+}

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/statistics/controller/StatisticsControllerTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/statistics/controller/StatisticsControllerTest.java
@@ -1,0 +1,94 @@
+package com.kakaotech.team18.backend_server.domain.statistics.controller;
+
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.kakaotech.team18.backend_server.domain.statistics.dto.StatisticsResponseDto;
+import com.kakaotech.team18.backend_server.domain.statistics.dto.StatisticsResponseDto.Bucket;
+import com.kakaotech.team18.backend_server.domain.statistics.dto.StatisticsResponseDto.DimensionResult;
+import com.kakaotech.team18.backend_server.domain.statistics.entity.DimensionType;
+import com.kakaotech.team18.backend_server.domain.statistics.entity.StatisticsDimension;
+import com.kakaotech.team18.backend_server.domain.statistics.service.StatisticsService;
+import com.kakaotech.team18.backend_server.global.config.SecurityConfig;
+import com.kakaotech.team18.backend_server.global.config.TestSecurityConfig;
+import com.kakaotech.team18.backend_server.global.exception.code.ErrorCode;
+import com.kakaotech.team18.backend_server.global.security.JwtAuthenticationFilter;
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(
+        controllers = StatisticsController.class,
+        excludeFilters = {
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = SecurityConfig.class),
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JwtAuthenticationFilter.class)
+        }
+)
+@Import(TestSecurityConfig.class)
+@DisplayName("StatisticsController - 통계 조회 API")
+class StatisticsControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private StatisticsService statisticsService;
+
+    private StatisticsResponseDto sampleResponse() {
+        return new StatisticsResponseDto(
+                12L, 200L, false, OffsetDateTime.now(),
+                List.of(new DimensionResult(
+                        StatisticsDimension.GENDER, DimensionType.CATEGORICAL, null, null,
+                        List.of(new Bucket("MALE", "남성", 121, new BigDecimal("0.605"), null))
+                ))
+        );
+    }
+
+    @Test
+    @DisplayName("유효한 dimension 요청 → 200과 통계 응답")
+    void getStatistics_ok() throws Exception {
+        given(statisticsService.getStatistics(eq(12L), anyList())).willReturn(sampleResponse());
+
+        mockMvc.perform(get("/api/club-apply-forms/{id}/statistics", 12L)
+                        .param("dimensions", "GENDER")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.clubApplyFormId").value(12))
+                .andExpect(jsonPath("$.results[0].dimension").value("GENDER"))
+                .andExpect(jsonPath("$.results[0].buckets[0].key").value("MALE"));
+    }
+
+    @Test
+    @DisplayName("dimensions 생략 → 200 (전체 조회)")
+    void getStatistics_defaultDimensions_ok() throws Exception {
+        given(statisticsService.getStatistics(eq(12L), anyList())).willReturn(sampleResponse());
+
+        mockMvc.perform(get("/api/club-apply-forms/{id}/statistics", 12L)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("지원하지 않는 dimension → 400")
+    void getStatistics_unsupportedDimension_badRequest() throws Exception {
+        mockMvc.perform(get("/api/club-apply-forms/{id}/statistics", 12L)
+                        .param("dimensions", "NOT_A_DIMENSION")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error_code").value(ErrorCode.UNSUPPORTED_STATISTICS_DIMENSION.name()));
+    }
+}

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/statistics/service/StatisticsAggregatorTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/statistics/service/StatisticsAggregatorTest.java
@@ -1,0 +1,38 @@
+package com.kakaotech.team18.backend_server.domain.statistics.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.kakaotech.team18.backend_server.domain.clubApplyForm.entity.ClubApplyForm;
+import com.kakaotech.team18.backend_server.domain.statistics.entity.StatisticsDimension;
+import com.kakaotech.team18.backend_server.domain.statistics.repository.ApplicationStatisticsRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("StatisticsAggregator - 계약 골격")
+class StatisticsAggregatorTest {
+
+    private final ApplicationStatisticsRepository repository = mock(ApplicationStatisticsRepository.class);
+    private final StatisticsAggregator aggregator = new StatisticsAggregator(repository);
+
+    @Test
+    @DisplayName("countApplicants는 리포지토리 count에 위임한다")
+    void countApplicants_delegates() {
+        when(repository.countByClubApplyFormId(1L)).thenReturn(42L);
+
+        assertThat(aggregator.countApplicants(1L)).isEqualTo(42L);
+    }
+
+    @Test
+    @DisplayName("아직 어떤 dimension도 구현되지 않아 모두 빈 버킷을 반환한다")
+    void aggregate_allDimensionsEmpty() {
+        ClubApplyForm form = mock(ClubApplyForm.class);
+
+        for (StatisticsDimension dimension : StatisticsDimension.values()) {
+            assertThat(aggregator.aggregate(form, dimension))
+                    .as("dimension %s", dimension)
+                    .isEmpty();
+        }
+    }
+}

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/statistics/service/StatisticsServiceImplTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/statistics/service/StatisticsServiceImplTest.java
@@ -1,0 +1,76 @@
+package com.kakaotech.team18.backend_server.domain.statistics.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.kakaotech.team18.backend_server.domain.clubApplyForm.entity.ClubApplyForm;
+import com.kakaotech.team18.backend_server.domain.clubApplyForm.repository.ClubApplyFormRepository;
+import com.kakaotech.team18.backend_server.domain.statistics.dto.RawBucket;
+import com.kakaotech.team18.backend_server.domain.statistics.dto.StatisticsResponseDto;
+import com.kakaotech.team18.backend_server.domain.statistics.entity.StatisticsDimension;
+import com.kakaotech.team18.backend_server.global.exception.exceptions.ClubApplyFormNotFoundException;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("StatisticsServiceImpl - 통계 조회")
+class StatisticsServiceImplTest {
+
+    private final ClubApplyFormRepository clubApplyFormRepository = mock(ClubApplyFormRepository.class);
+    private final StatisticsAggregator aggregator = mock(StatisticsAggregator.class);
+    private final StatisticsServiceImpl service = new StatisticsServiceImpl(clubApplyFormRepository, aggregator);
+
+    @Test
+    @DisplayName("존재하지 않는 지원폼이면 예외(404 매핑)")
+    void notFound_throws() {
+        when(clubApplyFormRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.getStatistics(99L, List.of(StatisticsDimension.GENDER)))
+                .isInstanceOf(ClubApplyFormNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("집계기가 준 버킷을 응답으로 조립하고 비율을 소수점 3자리로 채운다")
+    void assemblesBucketsWithRatio() {
+        ClubApplyForm form = mock(ClubApplyForm.class);
+        when(form.getId()).thenReturn(1L);
+        when(clubApplyFormRepository.findById(1L)).thenReturn(Optional.of(form));
+        when(aggregator.countApplicants(1L)).thenReturn(200L);
+        when(aggregator.aggregate(form, StatisticsDimension.GENDER)).thenReturn(List.of(
+                RawBucket.of("MALE", "남성", 121),
+                RawBucket.of("FEMALE", "여성", 79)
+        ));
+
+        StatisticsResponseDto res = service.getStatistics(1L, List.of(StatisticsDimension.GENDER));
+
+        assertThat(res.clubApplyFormId()).isEqualTo(1L);
+        assertThat(res.totalApplicants()).isEqualTo(200L);
+        assertThat(res.snapshot()).isFalse();
+        assertThat(res.results()).hasSize(1);
+
+        StatisticsResponseDto.DimensionResult gender = res.results().get(0);
+        assertThat(gender.dimension()).isEqualTo(StatisticsDimension.GENDER);
+        assertThat(gender.buckets()).extracting(b -> b.ratio())
+                .containsExactly(new BigDecimal("0.605"), new BigDecimal("0.395"));
+    }
+
+    @Test
+    @DisplayName("지원자가 0명이면 빈 버킷과 totalApplicants=0을 반환한다")
+    void zeroApplicants_emptyButDimensionKept() {
+        ClubApplyForm form = mock(ClubApplyForm.class);
+        when(form.getId()).thenReturn(1L);
+        when(clubApplyFormRepository.findById(1L)).thenReturn(Optional.of(form));
+        when(aggregator.countApplicants(1L)).thenReturn(0L);
+        when(aggregator.aggregate(form, StatisticsDimension.GENDER)).thenReturn(List.of());
+
+        StatisticsResponseDto res = service.getStatistics(1L, List.of(StatisticsDimension.GENDER));
+
+        assertThat(res.totalApplicants()).isZero();
+        assertThat(res.results()).hasSize(1);
+        assertThat(res.results().get(0).buckets()).isEmpty();
+    }
+}


### PR DESCRIPTION
관련 이슈: #335

## 작업 내용

지원폼 단위 **공개 통계 API의 계약**(엔드포인트·응답 DTO·dimension·에러)만 정의한다. 집계 뼈대만 두고 각 dimension은 **빈 버킷을 반환**하며, 실제 dimension 집계(성별·학번·학부·추이)는 **각각 별도 PR**로 이어 붙인다.

> 원래 이 PR에 "성별 집계"까지 함께 있었으나, 계약 정의와 성별 집계는 다른 관심사이므로 분리했다. 성별 집계는 이 PR 머지 후 후속 PR로 올린다.

## API

```
GET /api/club-apply-forms/{clubApplyFormId}/statistics?dimensions=GENDER,FACULTY
```

- 비로그인 조회 허용(`SecurityConfig` permitAll)
- `dimensions` 생략 시 전체, 지원하지 않는 값은 **400**

## 포함 범위 (계약만)

- `StatisticsDimension`(GENDER, ADMISSION_YEAR, FACULTY, DAILY_APPLICATIONS) / `DimensionType`
- 응답 `StatisticsResponseDto`/`Bucket` ↔ 내부 집계 `RawBucket` 분리 (식별정보 차단)
- 컨트롤러·서비스(`calculate` 조립·비율)·집계기(골격, 모든 dimension 빈 버킷)
- 비율 소수점 3자리 고정
- 컨트롤러/서비스/집계기 테스트

## 이 PR에 없는 것

- 실제 dimension 집계(성별 포함) — 후속 PR
- 마스킹·사전계산·스냅샷 — 후속 PR

## 머지 전

- DB 변경 없음. `SecurityConfig` permitAll 1줄 + `ErrorCode` 상수 1개만 기존 파일 수정.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 지원폼별 지원자 통계 조회 기능을 추가했습니다.
  * 성별, 입학 연도, 단과대, 일별 지원 현황을 기준으로 통계를 확인할 수 있습니다.
  * 전체 지원자 수와 항목별 인원·비율을 제공합니다.
  * 통계 항목을 선택하거나 전체 항목을 한 번에 조회할 수 있습니다.
  * 지원자가 없는 경우에도 정상적인 빈 통계 결과를 제공합니다.

* **오류 개선**
  * 지원하지 않는 통계 항목 요청 시 명확한 오류 응답을 제공합니다.

* **테스트**
  * 통계 조회, 비율 계산, 빈 결과 및 잘못된 요청에 대한 검증을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->