### PR TITLE
[FEAT] 지원자 통계 - 성별 집계 구현 (#335)

### DIFF
--- a/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/repository/ApplicationStatisticsRepository.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/repository/ApplicationStatisticsRepository.java
@@ -1,6 +1,8 @@
 package com.kakaotech.team18.backend_server.domain.statistics.repository;
 
 import com.kakaotech.team18.backend_server.domain.application.entity.Application;
+import com.kakaotech.team18.backend_server.domain.user.entity.Gender;
+import java.util.List;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
 import org.springframework.data.repository.query.Param;
@@ -28,4 +30,24 @@ public interface ApplicationStatisticsRepository extends Repository<Application,
             WHERE a.clubApplyForm.id = :clubApplyFormId
             """)
     long countByClubApplyFormId(@Param("clubApplyFormId") Long clubApplyFormId);
+
+    /**
+     * 성별 분포. 성별이 없는(null) 지원자도 하나의 그룹으로 반환된다.
+     */
+    @Query("""
+            SELECT u.gender AS gender, count(a.id) AS count
+            FROM Application a
+            JOIN a.user u
+            WHERE a.clubApplyForm.id = :clubApplyFormId
+            GROUP BY u.gender
+            """)
+    List<GenderCount> aggregateGender(@Param("clubApplyFormId") Long clubApplyFormId);
+
+    /** 성별 집계 결과 projection. */
+    interface GenderCount {
+
+        Gender getGender();
+
+        long getCount();
+    }
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/service/StatisticsAggregator.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/service/StatisticsAggregator.java
@@ -4,6 +4,9 @@ import com.kakaotech.team18.backend_server.domain.clubApplyForm.entity.ClubApply
 import com.kakaotech.team18.backend_server.domain.statistics.dto.RawBucket;
 import com.kakaotech.team18.backend_server.domain.statistics.entity.StatisticsDimension;
 import com.kakaotech.team18.backend_server.domain.statistics.repository.ApplicationStatisticsRepository;
+import com.kakaotech.team18.backend_server.domain.user.entity.Gender;
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -12,8 +15,7 @@ import org.springframework.stereotype.Component;
 /**
  * dimension별 원본 집계를 수행합니다.
  * <p>
- * 이 단계(계약 정의)에서는 집계 뼈대만 두고 각 dimension은 빈 버킷을 반환한다. 실제 집계는 dimension별 후속
- * 단계에서 구현한다.
+ * 아직 구현되지 않은 dimension은 빈 버킷을 반환하며, 각 dimension은 후속 단계에서 구현한다.
  * <p>
  * 마스킹·상위 N 절단·비율 계산은 하지 않는다. 그 처리는 {@code StatisticsServiceImpl}이 담당한다.
  * dimension마다 별도 쿼리로 처리해 교차 집계로 인한 조합 폭발을 피한다.
@@ -40,8 +42,6 @@ public class StatisticsAggregator {
 
     /**
      * 요청된 dimension의 원본 버킷을 계산합니다.
-     * <p>
-     * 아직 각 dimension의 집계는 구현되지 않아 빈 버킷을 반환한다.
      *
      * @param form      집계 대상 지원폼
      * @param dimension 집계 항목
@@ -49,7 +49,38 @@ public class StatisticsAggregator {
      */
     public List<RawBucket> aggregate(ClubApplyForm form, StatisticsDimension dimension) {
         return switch (dimension) {
-            case GENDER, ADMISSION_YEAR, FACULTY, DAILY_APPLICATIONS -> List.of();
+            case GENDER -> aggregateGender(form.getId());
+            case ADMISSION_YEAR, FACULTY, DAILY_APPLICATIONS -> List.of();
         };
+    }
+
+    /**
+     * 성별 분포를 집계합니다.
+     * <p>
+     * 성별이 null인 지원자(성별 수집 이전에 접수됐거나 미입력)는 '미입력' 버킷으로 모은다. 버킷은 Enum 선언
+     * 순서를 따르고, '미입력'은 항상 마지막에 둔다.
+     */
+    private List<RawBucket> aggregateGender(Long clubApplyFormId) {
+        List<ApplicationStatisticsRepository.GenderCount> counts =
+                statisticsRepository.aggregateGender(clubApplyFormId);
+
+        List<RawBucket> buckets = new ArrayList<>();
+        long unknownCount = 0;
+
+        for (ApplicationStatisticsRepository.GenderCount row : counts) {
+            Gender gender = row.getGender();
+            if (gender == null) {
+                unknownCount += row.getCount();
+                continue;
+            }
+            buckets.add(RawBucket.of(gender.name(), gender.getLabel(), row.getCount()));
+        }
+
+        buckets.sort(Comparator.comparingInt(b -> Gender.valueOf(b.key()).ordinal()));
+
+        if (unknownCount > 0) {
+            buckets.add(RawBucket.of(UNKNOWN_KEY, UNKNOWN_LABEL, unknownCount));
+        }
+        return buckets;
     }
 }

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/statistics/service/StatisticsAggregatorTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/statistics/service/StatisticsAggregatorTest.java
@@ -1,0 +1,64 @@
+package com.kakaotech.team18.backend_server.domain.statistics.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.kakaotech.team18.backend_server.domain.clubApplyForm.entity.ClubApplyForm;
+import com.kakaotech.team18.backend_server.domain.statistics.dto.RawBucket;
+import com.kakaotech.team18.backend_server.domain.statistics.entity.StatisticsDimension;
+import com.kakaotech.team18.backend_server.domain.statistics.repository.ApplicationStatisticsRepository;
+import com.kakaotech.team18.backend_server.domain.statistics.repository.ApplicationStatisticsRepository.GenderCount;
+import com.kakaotech.team18.backend_server.domain.user.entity.Gender;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("StatisticsAggregator - 성별 집계")
+class StatisticsAggregatorTest {
+
+    private final ApplicationStatisticsRepository repository = mock(ApplicationStatisticsRepository.class);
+    private final StatisticsAggregator aggregator = new StatisticsAggregator(repository);
+
+    // 주의: mock을 when().thenReturn() 인자 안에서 만들면 stubbing이 중첩되어
+    // UnfinishedStubbingException이 난다. 반드시 먼저 만들어 변수에 담는다.
+    private GenderCount genderCount(Gender gender, long count) {
+        GenderCount gc = mock(GenderCount.class);
+        when(gc.getGender()).thenReturn(gender);
+        when(gc.getCount()).thenReturn(count);
+        return gc;
+    }
+
+    private ClubApplyForm form(long id) {
+        ClubApplyForm form = mock(ClubApplyForm.class);
+        when(form.getId()).thenReturn(id);
+        return form;
+    }
+
+    @Test
+    @DisplayName("MALE/FEMALE는 enum 선언 순서로, null은 '미입력' 버킷으로 항상 마지막에 둔다")
+    void aggregateGender_unknownLast() {
+        GenderCount female = genderCount(Gender.FEMALE, 91);
+        GenderCount unknown = genderCount(null, 2);
+        GenderCount male = genderCount(Gender.MALE, 121);
+        when(repository.aggregateGender(1L)).thenReturn(List.of(female, unknown, male));
+
+        List<RawBucket> buckets = aggregator.aggregate(form(1L), StatisticsDimension.GENDER);
+
+        assertThat(buckets).extracting(RawBucket::key).containsExactly("MALE", "FEMALE", "UNKNOWN");
+        assertThat(buckets).extracting(RawBucket::count).containsExactly(121L, 91L, 2L);
+        assertThat(buckets.get(2).label()).isEqualTo("미입력");
+    }
+
+    @Test
+    @DisplayName("미입력이 없으면 '미입력' 버킷도 없다")
+    void aggregateGender_noUnknownWhenAllPresent() {
+        GenderCount male = genderCount(Gender.MALE, 10);
+        GenderCount female = genderCount(Gender.FEMALE, 5);
+        when(repository.aggregateGender(1L)).thenReturn(List.of(male, female));
+
+        List<RawBucket> buckets = aggregator.aggregate(form(1L), StatisticsDimension.GENDER);
+
+        assertThat(buckets).extracting(RawBucket::key).containsExactly("MALE", "FEMALE");
+    }
+}


### PR DESCRIPTION
관련 이슈: #335

## 작업 내용

통계 API 계약(#343) 위에 **첫 dimension인 성별 집계**를 구현한다. 계약 단계에서 빈 버킷만 반환하던 `StatisticsAggregator.aggregate(GENDER)`에 실제 집계를 채운다.

## 커밋

1. `성별 분포 집계 쿼리 추가` — `ApplicationStatisticsRepository`에 `Application ⨝ User GROUP BY u.gender` 쿼리 + `GenderCount` projection
2. `성별 dimension 집계 구현` — 집계기에서 결과를 `RawBucket`으로 변환 + 집계기 테스트

## 동작

- 성별이 `null`인 지원자(성별 수집 이전 접수·미입력)는 **'미입력'(UNKNOWN) 버킷**으로 모아 **항상 마지막**에 둔다.
- 나머지는 `Gender` enum 선언 순서(MALE, FEMALE)로 정렬.
- 역할 필터 없음(합격자 포함) — 계약 PR의 count와 동일한 정책(승인으로 분포가 왜곡되지 않게).
- 마스킹·비율은 여기서 하지 않음(집계기는 원본만; 비율은 `StatisticsServiceImpl`, 마스킹은 후속 PR).

## 정리

- 계약 단계에서 미사용이던 `UNKNOWN_KEY/UNKNOWN_LABEL` 상수를 이 PR에서 실제 사용하게 됨.

## 테스트

- 성별 버킷: MALE/FEMALE enum 순서 + null→'미입력' 마지막 위치, 카운트 검증
- 미입력 없을 때 UNKNOWN 버킷도 없음 검증

## 머지 전

- DB 변경 없음. gender 컬럼은 앞 PR에서 이미 반영됨. 읽기 전용 집계 쿼리만 추가.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 지원서 통계에서 성별별 지원자 수를 확인할 수 있습니다.
  - 성별 정보가 없는 지원자는 ‘미입력’ 항목으로 별도 집계됩니다.
  - 성별별 통계는 정해진 순서로 표시되며, ‘미입력’ 항목은 항상 마지막에 표시됩니다.

- **테스트**
  - 성별별 집계, 정렬 순서, 성별 정보 누락 시 표시 방식에 대한 검증을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->