### PR TITLE
[FEAT] 지원자 통계 - 학부 집계 구현 (#335)

### DIFF
--- a/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/repository/ApplicationStatisticsRepository.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/repository/ApplicationStatisticsRepository.java
@@ -1,6 +1,7 @@
 package com.kakaotech.team18.backend_server.domain.statistics.repository;
 
 import com.kakaotech.team18.backend_server.domain.application.entity.Application;
+import com.kakaotech.team18.backend_server.domain.user.entity.Faculty;
 import com.kakaotech.team18.backend_server.domain.user.entity.Gender;
 import java.util.List;
 import org.springframework.data.jpa.repository.Query;
@@ -47,6 +48,26 @@ public interface ApplicationStatisticsRepository extends Repository<Application,
     interface GenderCount {
 
         Gender getGender();
+
+        long getCount();
+    }
+
+    /**
+     * 학부 분포. 학부가 없는(null) 지원자도 하나의 그룹으로 반환된다.
+     */
+    @Query("""
+            SELECT u.faculty AS faculty, count(a.id) AS count
+            FROM Application a
+            JOIN a.user u
+            WHERE a.clubApplyForm.id = :clubApplyFormId
+            GROUP BY u.faculty
+            """)
+    List<FacultyCount> aggregateFaculty(@Param("clubApplyFormId") Long clubApplyFormId);
+
+    /** 학부 집계 결과 projection. */
+    interface FacultyCount {
+
+        Faculty getFaculty();
 
         long getCount();
     }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/service/StatisticsAggregator.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/service/StatisticsAggregator.java
@@ -4,6 +4,7 @@ import com.kakaotech.team18.backend_server.domain.clubApplyForm.entity.ClubApply
 import com.kakaotech.team18.backend_server.domain.statistics.dto.RawBucket;
 import com.kakaotech.team18.backend_server.domain.statistics.entity.StatisticsDimension;
 import com.kakaotech.team18.backend_server.domain.statistics.repository.ApplicationStatisticsRepository;
+import com.kakaotech.team18.backend_server.domain.user.entity.Faculty;
 import com.kakaotech.team18.backend_server.domain.user.entity.Gender;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -50,7 +51,8 @@ public class StatisticsAggregator {
     public List<RawBucket> aggregate(ClubApplyForm form, StatisticsDimension dimension) {
         return switch (dimension) {
             case GENDER -> aggregateGender(form.getId());
-            case ADMISSION_YEAR, FACULTY, DAILY_APPLICATIONS -> List.of();
+            case FACULTY -> aggregateFaculty(form.getId());
+            case ADMISSION_YEAR, DAILY_APPLICATIONS -> List.of();
         };
     }
 
@@ -77,6 +79,37 @@ public class StatisticsAggregator {
         }
 
         buckets.sort(Comparator.comparingInt(b -> Gender.valueOf(b.key()).ordinal()));
+
+        if (unknownCount > 0) {
+            buckets.add(RawBucket.of(UNKNOWN_KEY, UNKNOWN_LABEL, unknownCount));
+        }
+        return buckets;
+    }
+
+    /**
+     * 학부 분포를 집계합니다.
+     * <p>
+     * 학부가 null인 지원자(비지원 경로로 생성됐거나 미입력)는 '미입력' 버킷으로 모은다. 목록에 없는 학부는
+     * 이미 {@code Faculty.ETC}(기타)로 수집되어 있어 정상 버킷으로 나온다. 버킷은 Enum 선언 순서를 따르고,
+     * '미입력'은 항상 마지막에 둔다.
+     */
+    private List<RawBucket> aggregateFaculty(Long clubApplyFormId) {
+        List<ApplicationStatisticsRepository.FacultyCount> counts =
+                statisticsRepository.aggregateFaculty(clubApplyFormId);
+
+        List<RawBucket> buckets = new ArrayList<>();
+        long unknownCount = 0;
+
+        for (ApplicationStatisticsRepository.FacultyCount row : counts) {
+            Faculty faculty = row.getFaculty();
+            if (faculty == null) {
+                unknownCount += row.getCount();
+                continue;
+            }
+            buckets.add(RawBucket.of(faculty.name(), faculty.getLabel(), row.getCount()));
+        }
+
+        buckets.sort(Comparator.comparingInt(b -> Faculty.valueOf(b.key()).ordinal()));
 
         if (unknownCount > 0) {
             buckets.add(RawBucket.of(UNKNOWN_KEY, UNKNOWN_LABEL, unknownCount));

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/statistics/repository/ApplicationStatisticsRepositoryIntegrationTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/statistics/repository/ApplicationStatisticsRepositoryIntegrationTest.java
@@ -26,7 +26,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
  */
 @DataJpaTest
 @DisplayName("ApplicationStatisticsRepository - 집계 쿼리")
-class ApplicationStatisticsRepositoryTest {
+class ApplicationStatisticsRepositoryIntegrationTest {
 
     @Autowired
     private TestEntityManager entityManager;

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/statistics/repository/ApplicationStatisticsRepositoryTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/statistics/repository/ApplicationStatisticsRepositoryTest.java
@@ -1,0 +1,128 @@
+package com.kakaotech.team18.backend_server.domain.statistics.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.kakaotech.team18.backend_server.domain.application.entity.Application;
+import com.kakaotech.team18.backend_server.domain.club.entity.Category;
+import com.kakaotech.team18.backend_server.domain.club.entity.Club;
+import com.kakaotech.team18.backend_server.domain.clubApplyForm.entity.ClubApplyForm;
+import com.kakaotech.team18.backend_server.domain.statistics.repository.ApplicationStatisticsRepository.FacultyCount;
+import com.kakaotech.team18.backend_server.domain.statistics.repository.ApplicationStatisticsRepository.GenderCount;
+import com.kakaotech.team18.backend_server.domain.user.entity.Faculty;
+import com.kakaotech.team18.backend_server.domain.user.entity.Gender;
+import com.kakaotech.team18.backend_server.domain.user.entity.User;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+/**
+ * 통계 집계 쿼리를 실제 스키마에 대해 검증한다. 집계기 단위 테스트는 리포지토리를 목킹하므로 JPQL의
+ * 조인·GROUP BY·null 그룹·projection 매핑이 실제로 동작하는지는 이 테스트가 확인한다.
+ */
+@DataJpaTest
+@DisplayName("ApplicationStatisticsRepository - 집계 쿼리")
+class ApplicationStatisticsRepositoryTest {
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Autowired
+    private ApplicationStatisticsRepository repository;
+
+    private ClubApplyForm form;
+
+    @BeforeEach
+    void setUp() {
+        form = persistForm("메인 동아리");
+
+        // 대상 폼: 성별/학부 조합 (일부는 null=미입력)
+        apply(form, Gender.MALE, Faculty.ENGINEERING, 1);
+        apply(form, Gender.MALE, Faculty.NATURAL_SCIENCES, 2);
+        apply(form, Gender.FEMALE, Faculty.ENGINEERING, 3);
+        apply(form, null, null, 4);
+        apply(form, Gender.FEMALE, Faculty.ETC, 5);
+
+        // 다른 폼: WHERE 필터가 이 지원서를 세지 않는지 확인용
+        ClubApplyForm otherForm = persistForm("다른 동아리");
+        apply(otherForm, Gender.MALE, Faculty.ENGINEERING, 99);
+
+        entityManager.flush();
+        entityManager.clear();
+    }
+
+    @Test
+    @DisplayName("누적 지원자 수는 해당 지원폼의 지원서만 센다")
+    void countByClubApplyFormId_countsOnlyThisForm() {
+        assertThat(repository.countByClubApplyFormId(form.getId())).isEqualTo(5L);
+    }
+
+    @Test
+    @DisplayName("성별 집계: 성별별로 묶고 null도 하나의 그룹으로 반환한다")
+    void aggregateGender_groupsIncludingNull() {
+        Map<Gender, Long> counts = new HashMap<>();
+        for (GenderCount row : repository.aggregateGender(form.getId())) {
+            counts.put(row.getGender(), row.getCount());
+        }
+
+        assertThat(counts).hasSize(3)
+                .containsEntry(Gender.MALE, 2L)
+                .containsEntry(Gender.FEMALE, 2L)
+                .containsEntry(null, 1L);
+    }
+
+    @Test
+    @DisplayName("학부 집계: 학부별로 묶고(ETC 포함) null도 하나의 그룹으로 반환한다")
+    void aggregateFaculty_groupsIncludingNull() {
+        Map<Faculty, Long> counts = new HashMap<>();
+        for (FacultyCount row : repository.aggregateFaculty(form.getId())) {
+            counts.put(row.getFaculty(), row.getCount());
+        }
+
+        assertThat(counts).hasSize(4)
+                .containsEntry(Faculty.ENGINEERING, 2L)
+                .containsEntry(Faculty.NATURAL_SCIENCES, 1L)
+                .containsEntry(Faculty.ETC, 1L)
+                .containsEntry(null, 1L);
+    }
+
+    private ClubApplyForm persistForm(String clubName) {
+        Club club = Club.builder()
+                .name(clubName)
+                .category(Category.STUDY)
+                .location("Seoul")
+                .shortIntroduction("intro")
+                .build();
+        entityManager.persist(club);
+
+        ClubApplyForm applyForm = ClubApplyForm.builder()
+                .club(club)
+                .title(clubName + " 지원폼")
+                .build();
+        entityManager.persist(applyForm);
+        return applyForm;
+    }
+
+    private void apply(ClubApplyForm applyForm, Gender gender, Faculty faculty, int seq) {
+        User user = User.builder()
+                .name("지원자" + seq)
+                .email("applicant" + seq + "@test.com")
+                .phoneNumber("010-0000-" + String.format("%04d", seq))
+                .studentId(String.format("23%04d", seq))
+                .department("학과")
+                .gender(gender)
+                .faculty(faculty)
+                .build();
+        entityManager.persist(user);
+
+        Application application = Application.builder()
+                .user(user)
+                .clubApplyForm(applyForm)
+                .build();
+        entityManager.persist(application);
+    }
+}

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/statistics/service/StatisticsAggregatorTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/statistics/service/StatisticsAggregatorTest.java
@@ -8,13 +8,15 @@ import com.kakaotech.team18.backend_server.domain.clubApplyForm.entity.ClubApply
 import com.kakaotech.team18.backend_server.domain.statistics.dto.RawBucket;
 import com.kakaotech.team18.backend_server.domain.statistics.entity.StatisticsDimension;
 import com.kakaotech.team18.backend_server.domain.statistics.repository.ApplicationStatisticsRepository;
+import com.kakaotech.team18.backend_server.domain.statistics.repository.ApplicationStatisticsRepository.FacultyCount;
 import com.kakaotech.team18.backend_server.domain.statistics.repository.ApplicationStatisticsRepository.GenderCount;
+import com.kakaotech.team18.backend_server.domain.user.entity.Faculty;
 import com.kakaotech.team18.backend_server.domain.user.entity.Gender;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-@DisplayName("StatisticsAggregator - 성별 집계")
+@DisplayName("StatisticsAggregator - 성별·학부 집계")
 class StatisticsAggregatorTest {
 
     private final ApplicationStatisticsRepository repository = mock(ApplicationStatisticsRepository.class);
@@ -27,6 +29,13 @@ class StatisticsAggregatorTest {
         when(gc.getGender()).thenReturn(gender);
         when(gc.getCount()).thenReturn(count);
         return gc;
+    }
+
+    private FacultyCount facultyCount(Faculty faculty, long count) {
+        FacultyCount fc = mock(FacultyCount.class);
+        when(fc.getFaculty()).thenReturn(faculty);
+        when(fc.getCount()).thenReturn(count);
+        return fc;
     }
 
     private ClubApplyForm form(long id) {
@@ -60,5 +69,24 @@ class StatisticsAggregatorTest {
         List<RawBucket> buckets = aggregator.aggregate(form(1L), StatisticsDimension.GENDER);
 
         assertThat(buckets).extracting(RawBucket::key).containsExactly("MALE", "FEMALE");
+    }
+
+    @Test
+    @DisplayName("학부는 enum 선언 순서로, ETC(기타)는 정상 버킷, null은 '미입력'으로 마지막에 둔다")
+    void aggregateFaculty_ordersAndUnknownLast() {
+        FacultyCount etc = facultyCount(Faculty.ETC, 20);
+        FacultyCount unknown = facultyCount(null, 3);
+        FacultyCount engineering = facultyCount(Faculty.ENGINEERING, 74);
+        FacultyCount natural = facultyCount(Faculty.NATURAL_SCIENCES, 37);
+        when(repository.aggregateFaculty(1L)).thenReturn(List.of(etc, unknown, engineering, natural));
+
+        List<RawBucket> buckets = aggregator.aggregate(form(1L), StatisticsDimension.FACULTY);
+
+        assertThat(buckets).extracting(RawBucket::key)
+                .containsExactly("ENGINEERING", "NATURAL_SCIENCES", "ETC", "UNKNOWN");
+        assertThat(buckets).extracting(RawBucket::count)
+                .containsExactly(74L, 37L, 20L, 3L);
+        assertThat(buckets.get(2).label()).isEqualTo("기타");
+        assertThat(buckets.get(3).label()).isEqualTo("미입력");
     }
 }


### PR DESCRIPTION
## 🚀 작업 내용

성별 집계(#344)에 이어 **학부(FACULTY) dimension 집계**를 구현했습니다. (성별과 동일 패턴)

- 리포지토리: `Application ⨝ User GROUP BY u.faculty` 쿼리 + `FacultyCount` projection 추가
- 집계기: `aggregate(FACULTY)` 구현
  - 학부가 `null`인 지원자는 `'미입력'(UNKNOWN)` 버킷으로 모아 **마지막**에
  - 목록에 없는 학부는 이미 `Faculty.ETC`(기타)로 수집되어 **정상 버킷**으로 나옴
  - 나머지는 `Faculty` enum 선언 순서로 정렬
- 테스트: 집계기 단위 테스트 + `@DataJpaTest`로 실제 쿼리(조인·GROUP BY·null 그룹·projection) 검증

## ⏱️ 소요 시간


## 🤔 고민했던 내용

- 성별 집계와 로직이 유사해 제네릭 헬퍼로 DRY 할지 고민했으나, "aggregator 역할이 불분명하다"는 피드백을 고려해 **명시적 두 메서드로 유지**했습니다. DRY 공통화가 필요하면 별도 refactor PR로 뺄 수 있습니다.
- 집계기 단위 테스트는 리포지토리를 목킹해 JPQL 자체는 검증되지 않아, `@DataJpaTest`로 실제 스키마 검증을 추가했습니다(성별 쿼리도 함께 커버).

## 💬 리뷰 중점사항

- `aggregateFaculty` JPQL과 `FacultyCount` projection 매핑
- `ETC`는 정상 '기타' 버킷으로, `null`만 '미입력'으로 분리하는 처리
- `@DataJpaTest` 픽스처 정확성

## 🔗관련 이슈
- #335 (지원자 통계 - 학부 집계 단계, 다단계 이슈라 Close 아님)