### PR TITLE
[FEAT] 지원자 통계 - 입학연도(학번) 집계 구현 (#335)

### DIFF
--- a/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/controller/StatisticsController.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/controller/StatisticsController.java
@@ -72,7 +72,7 @@ public class StatisticsController {
                                           "dimension": "ADMISSION_YEAR",
                                           "type": "ORDINAL",
                                           "buckets": [
-                                            { "key": "2022", "label": "22학번", "count": 58, "ratio": 0.271 }
+                                            { "key": "22", "label": "22학번", "count": 58, "ratio": 0.271 }
                                           ]
                                         },
                                         {

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/repository/ApplicationStatisticsRepository.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/repository/ApplicationStatisticsRepository.java
@@ -84,12 +84,4 @@ public interface ApplicationStatisticsRepository extends Repository<Application,
             GROUP BY u.studentId
             """)
     List<StudentIdCount> aggregateByStudentId(@Param("clubApplyFormId") Long clubApplyFormId);
-
-    /** 학번 집계 결과 projection. */
-    interface StudentIdCount {
-
-        String getStudentId();
-
-        long getCount();
-    }
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/repository/ApplicationStatisticsRepository.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/repository/ApplicationStatisticsRepository.java
@@ -71,4 +71,25 @@ public interface ApplicationStatisticsRepository extends Repository<Application,
 
         long getCount();
     }
+
+    /**
+     * 학번별 지원자 수. 입학연도로의 변환·버킷팅은 세기 판정이 필요해 애플리케이션에서 수행하므로,
+     * 여기서는 학번 그대로 그룹핑해 반환한다.
+     */
+    @Query("""
+            SELECT u.studentId AS studentId, count(a.id) AS count
+            FROM Application a
+            JOIN a.user u
+            WHERE a.clubApplyForm.id = :clubApplyFormId
+            GROUP BY u.studentId
+            """)
+    List<StudentIdCount> aggregateByStudentId(@Param("clubApplyFormId") Long clubApplyFormId);
+
+    /** 학번 집계 결과 projection. */
+    interface StudentIdCount {
+
+        String getStudentId();
+
+        long getCount();
+    }
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/repository/StudentIdCount.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/repository/StudentIdCount.java
@@ -1,0 +1,13 @@
+package com.kakaotech.team18.backend_server.domain.statistics.repository;
+
+/**
+ * 학번별 지원자 수 집계 결과 projection.
+ * <p>
+ * 입학연도로의 변환은 세기 판정이 필요해 애플리케이션에서 수행한다.
+ */
+public interface StudentIdCount {
+
+    String getStudentId();
+
+    long getCount();
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/service/StatisticsAggregator.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/service/StatisticsAggregator.java
@@ -6,6 +6,7 @@ import com.kakaotech.team18.backend_server.domain.clubApplyForm.entity.ClubApply
 import com.kakaotech.team18.backend_server.domain.statistics.dto.RawBucket;
 import com.kakaotech.team18.backend_server.domain.statistics.entity.StatisticsDimension;
 import com.kakaotech.team18.backend_server.domain.statistics.repository.ApplicationStatisticsRepository;
+import com.kakaotech.team18.backend_server.domain.statistics.repository.StudentIdCount;
 import com.kakaotech.team18.backend_server.domain.statistics.util.AdmissionYearBucketer;
 import com.kakaotech.team18.backend_server.domain.user.entity.Faculty;
 import com.kakaotech.team18.backend_server.domain.user.entity.Gender;
@@ -38,11 +39,17 @@ public class StatisticsAggregator {
     /** 값이 없는 버킷의 표시 문자열. */
     public static final String UNKNOWN_LABEL = "미입력";
 
+    /** 개별 연도로 나누기엔 오래된 입학연도를 하나로 묶는 버킷의 코드값. */
+    public static final String OLDER_KEY = "OLDER";
+
+    /** 오래된 입학연도 묶음 버킷의 표시 문자열. */
+    public static final String OLDER_LABEL = "그 이전";
+
     /**
-     * 유효 입학연도 하한을 기준 연도로부터 몇 년 전까지 볼지. 이보다 오래된 학번(또는 오타)은 '미입력'으로 분류한다.
-     * (설정값화는 후속 단계에서 StatisticsProperties 도입 시 진행)
+     * 입학연도를 개별 버킷으로 보여줄 최근 구간(년). 기준 연도로부터 이만큼 이전까지는 연도별로 나누고,
+     * 그보다 오래된 입학연도는 '그 이전'으로 묶는다. (설정값화는 후속 StatisticsProperties 도입 시)
      */
-    static final int ADMISSION_YEAR_LOOKBACK = 10;
+    static final int ADMISSION_YEAR_RECENT_YEARS = 6;
 
     private final ApplicationStatisticsRepository statisticsRepository;
 
@@ -143,29 +150,35 @@ public class StatisticsAggregator {
      * 학번 집계 결과를 입학연도 버킷으로 변환합니다.
      * <p>
      * 기준 연도(baseYear)를 인자로 받아 테스트에서 시점을 고정할 수 있게 한다({@code RecruitStatusCalculator}
-     * 패턴). 6자리 숫자가 아니거나 유효 범위를 벗어난 학번은 '미입력'으로 모은다. 버킷은 두 자리 문자열이 아니라
-     * <strong>네 자리 연도</strong> 기준으로 오름차순 정렬하고, '미입력'은 항상 마지막에 둔다.
+     * 패턴). 최근 {@link #ADMISSION_YEAR_RECENT_YEARS}년(기준 연도 - N 이상)은 연도별 개별 버킷으로,
+     * 그보다 오래된 입학연도는 '그 이전'({@link #OLDER_KEY}) 하나로 묶는다. 6자리 숫자가 아닌 학번만
+     * '미입력'으로 분류한다. 버킷 순서는 [그 이전 → 개별 연도 오름차순 → 미입력]이다.
      */
-    List<RawBucket> bucketAdmissionYears(
-            List<ApplicationStatisticsRepository.StudentIdCount> rows, int baseYear) {
-        int minYear = baseYear - ADMISSION_YEAR_LOOKBACK;
+    List<RawBucket> bucketAdmissionYears(List<StudentIdCount> rows, int baseYear) {
+        int oldestIndividualYear = baseYear - ADMISSION_YEAR_RECENT_YEARS;
 
         Map<Integer, Long> countByYear = new TreeMap<>();
+        long olderCount = 0;
         long unknownCount = 0;
 
-        for (ApplicationStatisticsRepository.StudentIdCount row : rows) {
-            Integer year = AdmissionYearBucketer.toAdmissionYear(row.getStudentId(), baseYear, minYear);
+        for (StudentIdCount row : rows) {
+            Integer year = AdmissionYearBucketer.toAdmissionYear(row.getStudentId(), baseYear);
             if (year == null) {
                 unknownCount += row.getCount();
-                continue;
+            } else if (year < oldestIndividualYear) {
+                olderCount += row.getCount();
+            } else {
+                countByYear.merge(year, row.getCount(), Long::sum);
             }
-            countByYear.merge(year, row.getCount(), Long::sum);
         }
 
         List<RawBucket> buckets = new ArrayList<>();
+        // '그 이전'은 가장 과거이므로 개별 연도들보다 앞에 둔다.
+        if (olderCount > 0) {
+            buckets.add(RawBucket.of(OLDER_KEY, OLDER_LABEL, olderCount));
+        }
         countByYear.forEach((year, count) ->
                 buckets.add(RawBucket.of(String.valueOf(year), AdmissionYearBucketer.toLabel(year), count)));
-
         if (unknownCount > 0) {
             buckets.add(RawBucket.of(UNKNOWN_KEY, UNKNOWN_LABEL, unknownCount));
         }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/service/StatisticsAggregator.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/service/StatisticsAggregator.java
@@ -1,14 +1,20 @@
 package com.kakaotech.team18.backend_server.domain.statistics.service;
 
+import static com.kakaotech.team18.backend_server.domain.statistics.service.StatisticsServiceImpl.KST;
+
 import com.kakaotech.team18.backend_server.domain.clubApplyForm.entity.ClubApplyForm;
 import com.kakaotech.team18.backend_server.domain.statistics.dto.RawBucket;
 import com.kakaotech.team18.backend_server.domain.statistics.entity.StatisticsDimension;
 import com.kakaotech.team18.backend_server.domain.statistics.repository.ApplicationStatisticsRepository;
+import com.kakaotech.team18.backend_server.domain.statistics.util.AdmissionYearBucketer;
 import com.kakaotech.team18.backend_server.domain.user.entity.Faculty;
 import com.kakaotech.team18.backend_server.domain.user.entity.Gender;
+import java.time.Year;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -32,6 +38,12 @@ public class StatisticsAggregator {
     /** 값이 없는 버킷의 표시 문자열. */
     public static final String UNKNOWN_LABEL = "미입력";
 
+    /**
+     * 유효 입학연도 하한을 기준 연도로부터 몇 년 전까지 볼지. 이보다 오래된 학번(또는 오타)은 '미입력'으로 분류한다.
+     * (설정값화는 후속 단계에서 StatisticsProperties 도입 시 진행)
+     */
+    static final int ADMISSION_YEAR_LOOKBACK = 10;
+
     private final ApplicationStatisticsRepository statisticsRepository;
 
     /**
@@ -52,7 +64,8 @@ public class StatisticsAggregator {
         return switch (dimension) {
             case GENDER -> aggregateGender(form.getId());
             case FACULTY -> aggregateFaculty(form.getId());
-            case ADMISSION_YEAR, DAILY_APPLICATIONS -> List.of();
+            case ADMISSION_YEAR -> aggregateAdmissionYear(form.getId());
+            case DAILY_APPLICATIONS -> List.of();
         };
     }
 
@@ -110,6 +123,48 @@ public class StatisticsAggregator {
         }
 
         buckets.sort(Comparator.comparingInt(b -> Faculty.valueOf(b.key()).ordinal()));
+
+        if (unknownCount > 0) {
+            buckets.add(RawBucket.of(UNKNOWN_KEY, UNKNOWN_LABEL, unknownCount));
+        }
+        return buckets;
+    }
+
+    /**
+     * 입학연도 분포를 집계합니다. 기준 연도는 현재 연도(KST)를 사용한다.
+     */
+    private List<RawBucket> aggregateAdmissionYear(Long clubApplyFormId) {
+        return bucketAdmissionYears(
+                statisticsRepository.aggregateByStudentId(clubApplyFormId),
+                Year.now(KST).getValue());
+    }
+
+    /**
+     * 학번 집계 결과를 입학연도 버킷으로 변환합니다.
+     * <p>
+     * 기준 연도(baseYear)를 인자로 받아 테스트에서 시점을 고정할 수 있게 한다({@code RecruitStatusCalculator}
+     * 패턴). 6자리 숫자가 아니거나 유효 범위를 벗어난 학번은 '미입력'으로 모은다. 버킷은 두 자리 문자열이 아니라
+     * <strong>네 자리 연도</strong> 기준으로 오름차순 정렬하고, '미입력'은 항상 마지막에 둔다.
+     */
+    List<RawBucket> bucketAdmissionYears(
+            List<ApplicationStatisticsRepository.StudentIdCount> rows, int baseYear) {
+        int minYear = baseYear - ADMISSION_YEAR_LOOKBACK;
+
+        Map<Integer, Long> countByYear = new TreeMap<>();
+        long unknownCount = 0;
+
+        for (ApplicationStatisticsRepository.StudentIdCount row : rows) {
+            Integer year = AdmissionYearBucketer.toAdmissionYear(row.getStudentId(), baseYear, minYear);
+            if (year == null) {
+                unknownCount += row.getCount();
+                continue;
+            }
+            countByYear.merge(year, row.getCount(), Long::sum);
+        }
+
+        List<RawBucket> buckets = new ArrayList<>();
+        countByYear.forEach((year, count) ->
+                buckets.add(RawBucket.of(String.valueOf(year), AdmissionYearBucketer.toLabel(year), count)));
 
         if (unknownCount > 0) {
             buckets.add(RawBucket.of(UNKNOWN_KEY, UNKNOWN_LABEL, unknownCount));

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/service/StatisticsAggregator.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/service/StatisticsAggregator.java
@@ -178,7 +178,7 @@ public class StatisticsAggregator {
             buckets.add(RawBucket.of(OLDER_KEY, OLDER_LABEL, olderCount));
         }
         countByYear.forEach((year, count) ->
-                buckets.add(RawBucket.of(String.valueOf(year), AdmissionYearBucketer.toLabel(year), count)));
+                buckets.add(RawBucket.of(AdmissionYearBucketer.toKey(year), AdmissionYearBucketer.toLabel(year), count)));
         if (unknownCount > 0) {
             buckets.add(RawBucket.of(UNKNOWN_KEY, UNKNOWN_LABEL, unknownCount));
         }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/util/AdmissionYearBucketer.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/util/AdmissionYearBucketer.java
@@ -1,0 +1,57 @@
+package com.kakaotech.team18.backend_server.domain.statistics.util;
+
+import java.util.regex.Pattern;
+
+/**
+ * 6자리 학번에서 입학연도를 뽑아냅니다.
+ * <p>
+ * <strong>이 클래스의 출력에는 학번 원본이 절대 포함되지 않는다.</strong> 앞 2자리에서 유도한 연도만 반환한다.
+ */
+public final class AdmissionYearBucketer {
+
+    /** 지원서 접수 단계에서 학번은 6자리 숫자로 검증되지만, 다른 경로로 만들어진 User가 있을 수 있어 다시 확인한다. */
+    private static final Pattern STUDENT_ID = Pattern.compile("\\d{6}");
+
+    private AdmissionYearBucketer() {
+    }
+
+    /**
+     * 학번을 4자리 입학연도로 변환합니다.
+     * <p>
+     * 두 자리 연도의 세기는 기준 연도로 판단한다. 기준 연도의 뒤 두 자리보다 크면 현재 세기에 존재할 수 없는
+     * 연도이므로 이전 세기로 해석한다. (기준 2026년 → {@code 22} → 2022, {@code 99} → 1999)
+     *
+     * @param studentId 학번
+     * @param baseYear  기준 연도 (보통 오늘 날짜의 연도)
+     * @param minYear   유효한 입학연도의 하한
+     * @return 4자리 입학연도. 6자리 숫자가 아니거나 유효 범위를 벗어나면 null
+     */
+    public static Integer toAdmissionYear(String studentId, int baseYear, int minYear) {
+        if (studentId == null || !STUDENT_ID.matcher(studentId).matches()) {
+            return null;
+        }
+
+        int twoDigit = Integer.parseInt(studentId.substring(0, 2));
+        int baseTwoDigit = baseYear % 100;
+        int century = (baseYear / 100) * 100;
+
+        int year = (twoDigit <= baseTwoDigit) ? century + twoDigit : century - 100 + twoDigit;
+
+        if (year < minYear || year > baseYear) {
+            return null;
+        }
+        return year;
+    }
+
+    /**
+     * 입학연도를 화면 표시용 라벨로 변환합니다.
+     * <p>
+     * 학년이 아니라 학번으로 표기한다. 휴학·편입 때문에 입학연도와 학년은 일치하지 않는다.
+     *
+     * @param year 4자리 입학연도
+     * @return {@code 22학번} 형식의 라벨
+     */
+    public static String toLabel(int year) {
+        return String.format("%02d학번", year % 100);
+    }
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/util/AdmissionYearBucketer.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/util/AdmissionYearBucketer.java
@@ -41,6 +41,18 @@ public final class AdmissionYearBucketer {
     }
 
     /**
+     * 입학연도를 버킷 코드값(두 자리 학번)으로 변환합니다.
+     * <p>
+     * 개별 연도 버킷은 최근 구간에 한정되어 세기 혼동이 없으므로 두 자리로 내보낸다. (내부 정렬은 네 자리 연도 기준)
+     *
+     * @param year 4자리 입학연도
+     * @return {@code 22} 형식의 두 자리 코드값
+     */
+    public static String toKey(int year) {
+        return String.format("%02d", year % 100);
+    }
+
+    /**
      * 입학연도를 화면 표시용 라벨로 변환합니다.
      * <p>
      * 학년이 아니라 학번으로 표기한다. 휴학·편입 때문에 입학연도와 학년은 일치하지 않는다.
@@ -49,6 +61,6 @@ public final class AdmissionYearBucketer {
      * @return {@code 22학번} 형식의 라벨
      */
     public static String toLabel(int year) {
-        return String.format("%02d학번", year % 100);
+        return toKey(year) + "학번";
     }
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/util/AdmissionYearBucketer.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/util/AdmissionYearBucketer.java
@@ -20,13 +20,15 @@ public final class AdmissionYearBucketer {
      * <p>
      * 두 자리 연도의 세기는 기준 연도로 판단한다. 기준 연도의 뒤 두 자리보다 크면 현재 세기에 존재할 수 없는
      * 연도이므로 이전 세기로 해석한다. (기준 2026년 → {@code 22} → 2022, {@code 99} → 1999)
+     * <p>
+     * 오래된 연도도 실제 옛 학번이므로 그대로 반환한다(버킷 묶음은 호출부가 판단). 6자리 숫자가 아닌 값
+     * (비지원서 경로로 만들어졌거나 7자리 이상 등)만 미입력으로 보고 {@code null}을 반환한다.
      *
      * @param studentId 학번
      * @param baseYear  기준 연도 (보통 오늘 날짜의 연도)
-     * @param minYear   유효한 입학연도의 하한
-     * @return 4자리 입학연도. 6자리 숫자가 아니거나 유효 범위를 벗어나면 null
+     * @return 4자리 입학연도. 6자리 숫자가 아니면 null
      */
-    public static Integer toAdmissionYear(String studentId, int baseYear, int minYear) {
+    public static Integer toAdmissionYear(String studentId, int baseYear) {
         if (studentId == null || !STUDENT_ID.matcher(studentId).matches()) {
             return null;
         }
@@ -35,12 +37,7 @@ public final class AdmissionYearBucketer {
         int baseTwoDigit = baseYear % 100;
         int century = (baseYear / 100) * 100;
 
-        int year = (twoDigit <= baseTwoDigit) ? century + twoDigit : century - 100 + twoDigit;
-
-        if (year < minYear || year > baseYear) {
-            return null;
-        }
-        return year;
+        return (twoDigit <= baseTwoDigit) ? century + twoDigit : century - 100 + twoDigit;
     }
 
     /**

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/statistics/repository/ApplicationStatisticsRepositoryIntegrationTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/statistics/repository/ApplicationStatisticsRepositoryIntegrationTest.java
@@ -8,6 +8,7 @@ import com.kakaotech.team18.backend_server.domain.club.entity.Club;
 import com.kakaotech.team18.backend_server.domain.clubApplyForm.entity.ClubApplyForm;
 import com.kakaotech.team18.backend_server.domain.statistics.repository.ApplicationStatisticsRepository.FacultyCount;
 import com.kakaotech.team18.backend_server.domain.statistics.repository.ApplicationStatisticsRepository.GenderCount;
+import com.kakaotech.team18.backend_server.domain.statistics.repository.ApplicationStatisticsRepository.StudentIdCount;
 import com.kakaotech.team18.backend_server.domain.user.entity.Faculty;
 import com.kakaotech.team18.backend_server.domain.user.entity.Gender;
 import com.kakaotech.team18.backend_server.domain.user.entity.User;
@@ -88,6 +89,18 @@ class ApplicationStatisticsRepositoryIntegrationTest {
                 .containsEntry(Faculty.NATURAL_SCIENCES, 1L)
                 .containsEntry(Faculty.ETC, 1L)
                 .containsEntry(null, 1L);
+    }
+
+    @Test
+    @DisplayName("학번 집계: 학번별로 묶어 해당 지원폼 지원자만 반환한다")
+    void aggregateByStudentId_groupsByStudentId() {
+        Map<String, Long> counts = new HashMap<>();
+        for (StudentIdCount row : repository.aggregateByStudentId(form.getId())) {
+            counts.put(row.getStudentId(), row.getCount());
+        }
+
+        assertThat(counts).containsOnlyKeys("230001", "230002", "230003", "230004", "230005");
+        assertThat(counts.values()).containsOnly(1L);
     }
 
     private ClubApplyForm persistForm(String clubName) {

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/statistics/repository/ApplicationStatisticsRepositoryIntegrationTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/statistics/repository/ApplicationStatisticsRepositoryIntegrationTest.java
@@ -8,7 +8,6 @@ import com.kakaotech.team18.backend_server.domain.club.entity.Club;
 import com.kakaotech.team18.backend_server.domain.clubApplyForm.entity.ClubApplyForm;
 import com.kakaotech.team18.backend_server.domain.statistics.repository.ApplicationStatisticsRepository.FacultyCount;
 import com.kakaotech.team18.backend_server.domain.statistics.repository.ApplicationStatisticsRepository.GenderCount;
-import com.kakaotech.team18.backend_server.domain.statistics.repository.ApplicationStatisticsRepository.StudentIdCount;
 import com.kakaotech.team18.backend_server.domain.user.entity.Faculty;
 import com.kakaotech.team18.backend_server.domain.user.entity.Gender;
 import com.kakaotech.team18.backend_server.domain.user.entity.User;

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/statistics/service/StatisticsAggregatorTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/statistics/service/StatisticsAggregatorTest.java
@@ -112,8 +112,8 @@ class StatisticsAggregatorTest {
         List<RawBucket> buckets = aggregator.bucketAdmissionYears(
                 List.of(y23a, y23b, y22, old2018, old2010, invalid), 2026);
 
-        // 순서: 그 이전 → 개별 연도 오름차순 → 미입력
-        assertThat(buckets).extracting(RawBucket::key).containsExactly("OLDER", "2022", "2023", "UNKNOWN");
+        // 순서: 그 이전 → 개별 연도 오름차순 → 미입력. key는 두 자리 학번.
+        assertThat(buckets).extracting(RawBucket::key).containsExactly("OLDER", "22", "23", "UNKNOWN");
         assertThat(buckets).extracting(RawBucket::count).containsExactly(2L, 1L, 2L, 1L);
         assertThat(buckets.get(0).label()).isEqualTo("그 이전");
         assertThat(buckets.get(1).label()).isEqualTo("22학번");

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/statistics/service/StatisticsAggregatorTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/statistics/service/StatisticsAggregatorTest.java
@@ -10,7 +10,7 @@ import com.kakaotech.team18.backend_server.domain.statistics.entity.StatisticsDi
 import com.kakaotech.team18.backend_server.domain.statistics.repository.ApplicationStatisticsRepository;
 import com.kakaotech.team18.backend_server.domain.statistics.repository.ApplicationStatisticsRepository.FacultyCount;
 import com.kakaotech.team18.backend_server.domain.statistics.repository.ApplicationStatisticsRepository.GenderCount;
-import com.kakaotech.team18.backend_server.domain.statistics.repository.ApplicationStatisticsRepository.StudentIdCount;
+import com.kakaotech.team18.backend_server.domain.statistics.repository.StudentIdCount;
 import com.kakaotech.team18.backend_server.domain.user.entity.Faculty;
 import com.kakaotech.team18.backend_server.domain.user.entity.Gender;
 import java.util.List;
@@ -99,21 +99,24 @@ class StatisticsAggregatorTest {
     }
 
     @Test
-    @DisplayName("입학연도는 4자리 연도 오름차순, 6자리 아님/범위 밖 학번은 '미입력'으로 마지막에 둔다")
-    void bucketAdmissionYears_ordersByYearUnknownLast() {
-        // baseYear=2026, minYear=2016 (lookback 10)
+    @DisplayName("최근 연도는 개별, 오래된 연도는 '그 이전'으로 묶고, 6자리 아님만 '미입력'으로 둔다")
+    void bucketAdmissionYears_olderGroupedUnknownLast() {
+        // baseYear=2026, RECENT_YEARS=6 → 개별 하한 2020, 그보다 오래되면 '그 이전'
         StudentIdCount y23a = studentIdCount("230001", 1);
         StudentIdCount y23b = studentIdCount("230002", 1);
         StudentIdCount y22 = studentIdCount("220001", 1);
-        StudentIdCount invalid = studentIdCount("abc", 1);   // 6자리 숫자 아님 → 미입력
-        StudentIdCount tooOld = studentIdCount("120001", 1); // 2012, 하한(2016) 밖 → 미입력
+        StudentIdCount old2018 = studentIdCount("180001", 1); // 2018 < 2020 → 그 이전
+        StudentIdCount old2010 = studentIdCount("100001", 1); // 2010 < 2020 → 그 이전
+        StudentIdCount invalid = studentIdCount("abc", 1);    // 6자리 숫자 아님 → 미입력
 
         List<RawBucket> buckets = aggregator.bucketAdmissionYears(
-                List.of(y23a, y23b, y22, invalid, tooOld), 2026);
+                List.of(y23a, y23b, y22, old2018, old2010, invalid), 2026);
 
-        assertThat(buckets).extracting(RawBucket::key).containsExactly("2022", "2023", "UNKNOWN");
-        assertThat(buckets).extracting(RawBucket::count).containsExactly(1L, 2L, 2L);
-        assertThat(buckets.get(0).label()).isEqualTo("22학번");
-        assertThat(buckets.get(2).label()).isEqualTo("미입력");
+        // 순서: 그 이전 → 개별 연도 오름차순 → 미입력
+        assertThat(buckets).extracting(RawBucket::key).containsExactly("OLDER", "2022", "2023", "UNKNOWN");
+        assertThat(buckets).extracting(RawBucket::count).containsExactly(2L, 1L, 2L, 1L);
+        assertThat(buckets.get(0).label()).isEqualTo("그 이전");
+        assertThat(buckets.get(1).label()).isEqualTo("22학번");
+        assertThat(buckets.get(3).label()).isEqualTo("미입력");
     }
 }

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/statistics/service/StatisticsAggregatorTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/statistics/service/StatisticsAggregatorTest.java
@@ -10,6 +10,7 @@ import com.kakaotech.team18.backend_server.domain.statistics.entity.StatisticsDi
 import com.kakaotech.team18.backend_server.domain.statistics.repository.ApplicationStatisticsRepository;
 import com.kakaotech.team18.backend_server.domain.statistics.repository.ApplicationStatisticsRepository.FacultyCount;
 import com.kakaotech.team18.backend_server.domain.statistics.repository.ApplicationStatisticsRepository.GenderCount;
+import com.kakaotech.team18.backend_server.domain.statistics.repository.ApplicationStatisticsRepository.StudentIdCount;
 import com.kakaotech.team18.backend_server.domain.user.entity.Faculty;
 import com.kakaotech.team18.backend_server.domain.user.entity.Gender;
 import java.util.List;
@@ -36,6 +37,13 @@ class StatisticsAggregatorTest {
         when(fc.getFaculty()).thenReturn(faculty);
         when(fc.getCount()).thenReturn(count);
         return fc;
+    }
+
+    private StudentIdCount studentIdCount(String studentId, long count) {
+        StudentIdCount sc = mock(StudentIdCount.class);
+        when(sc.getStudentId()).thenReturn(studentId);
+        when(sc.getCount()).thenReturn(count);
+        return sc;
     }
 
     private ClubApplyForm form(long id) {
@@ -88,5 +96,24 @@ class StatisticsAggregatorTest {
                 .containsExactly(74L, 37L, 20L, 3L);
         assertThat(buckets.get(2).label()).isEqualTo("기타");
         assertThat(buckets.get(3).label()).isEqualTo("미입력");
+    }
+
+    @Test
+    @DisplayName("입학연도는 4자리 연도 오름차순, 6자리 아님/범위 밖 학번은 '미입력'으로 마지막에 둔다")
+    void bucketAdmissionYears_ordersByYearUnknownLast() {
+        // baseYear=2026, minYear=2016 (lookback 10)
+        StudentIdCount y23a = studentIdCount("230001", 1);
+        StudentIdCount y23b = studentIdCount("230002", 1);
+        StudentIdCount y22 = studentIdCount("220001", 1);
+        StudentIdCount invalid = studentIdCount("abc", 1);   // 6자리 숫자 아님 → 미입력
+        StudentIdCount tooOld = studentIdCount("120001", 1); // 2012, 하한(2016) 밖 → 미입력
+
+        List<RawBucket> buckets = aggregator.bucketAdmissionYears(
+                List.of(y23a, y23b, y22, invalid, tooOld), 2026);
+
+        assertThat(buckets).extracting(RawBucket::key).containsExactly("2022", "2023", "UNKNOWN");
+        assertThat(buckets).extracting(RawBucket::count).containsExactly(1L, 2L, 2L);
+        assertThat(buckets.get(0).label()).isEqualTo("22학번");
+        assertThat(buckets.get(2).label()).isEqualTo("미입력");
     }
 }

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/statistics/util/AdmissionYearBucketerTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/statistics/util/AdmissionYearBucketerTest.java
@@ -42,6 +42,13 @@ class AdmissionYearBucketerTest {
     }
 
     @Test
+    @DisplayName("버킷 코드값(key)은 네 자리가 아닌 두 자리 학번 (2022 → 22)")
+    void key() {
+        assertThat(AdmissionYearBucketer.toKey(2022)).isEqualTo("22");
+        assertThat(AdmissionYearBucketer.toKey(2009)).isEqualTo("09");
+    }
+
+    @Test
     @DisplayName("라벨은 학년이 아닌 '22학번' 형식")
     void label() {
         assertThat(AdmissionYearBucketer.toLabel(2022)).isEqualTo("22학번");

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/statistics/util/AdmissionYearBucketerTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/statistics/util/AdmissionYearBucketerTest.java
@@ -9,39 +9,36 @@ import org.junit.jupiter.api.Test;
 class AdmissionYearBucketerTest {
 
     private static final int BASE_YEAR = 2026;
-    private static final int MIN_YEAR = 2016;
 
     @Test
     @DisplayName("앞 2자리를 4자리 입학연도로 변환한다 (22 → 2022)")
     void twoDigitToFourDigit() {
-        assertThat(AdmissionYearBucketer.toAdmissionYear("220001", BASE_YEAR, MIN_YEAR)).isEqualTo(2022);
-        assertThat(AdmissionYearBucketer.toAdmissionYear("260001", BASE_YEAR, MIN_YEAR)).isEqualTo(2026);
+        assertThat(AdmissionYearBucketer.toAdmissionYear("220001", BASE_YEAR)).isEqualTo(2022);
+        assertThat(AdmissionYearBucketer.toAdmissionYear("260001", BASE_YEAR)).isEqualTo(2026);
     }
 
     @Test
     @DisplayName("기준 연도 뒤 두 자리보다 크면 이전 세기로 해석한다 (99 → 1999)")
     void previousCenturyWhenAboveBase() {
-        // 기준 2000년 하한이면 1999도 유효 범위 안
-        assertThat(AdmissionYearBucketer.toAdmissionYear("990001", 2026, 1990)).isEqualTo(1999);
+        assertThat(AdmissionYearBucketer.toAdmissionYear("990001", BASE_YEAR)).isEqualTo(1999);
+        assertThat(AdmissionYearBucketer.toAdmissionYear("000001", BASE_YEAR)).isEqualTo(2000);
     }
 
     @Test
-    @DisplayName("기준 연도보다 미래이거나 하한보다 과거면 null (유효 범위 밖)")
-    void outOfRangeIsNull() {
-        // 27 → 2027, 기준 2026보다 미래 → null
-        assertThat(AdmissionYearBucketer.toAdmissionYear("270001", BASE_YEAR, MIN_YEAR)).isNull();
-        // 12 → 2012, 하한 2016보다 과거 → null
-        assertThat(AdmissionYearBucketer.toAdmissionYear("120001", BASE_YEAR, MIN_YEAR)).isNull();
+    @DisplayName("오래된 연도도 미입력이 아니라 실제 연도를 반환한다 (묶음 판단은 호출부)")
+    void oldYearsAreReturned() {
+        assertThat(AdmissionYearBucketer.toAdmissionYear("100001", BASE_YEAR)).isEqualTo(2010);
+        assertThat(AdmissionYearBucketer.toAdmissionYear("050001", BASE_YEAR)).isEqualTo(2005);
     }
 
     @Test
-    @DisplayName("6자리 숫자가 아니면 null (비지원서 경로 학번 등)")
+    @DisplayName("6자리 숫자가 아니면 null (7자리 이상·비지원서 경로 학번 등)")
     void nonSixDigitIsNull() {
-        assertThat(AdmissionYearBucketer.toAdmissionYear(null, BASE_YEAR, MIN_YEAR)).isNull();
-        assertThat(AdmissionYearBucketer.toAdmissionYear("", BASE_YEAR, MIN_YEAR)).isNull();
-        assertThat(AdmissionYearBucketer.toAdmissionYear("2201", BASE_YEAR, MIN_YEAR)).isNull();      // 4자리
-        assertThat(AdmissionYearBucketer.toAdmissionYear("2200011", BASE_YEAR, MIN_YEAR)).isNull();   // 7자리
-        assertThat(AdmissionYearBucketer.toAdmissionYear("22000a", BASE_YEAR, MIN_YEAR)).isNull();    // 숫자 아님
+        assertThat(AdmissionYearBucketer.toAdmissionYear(null, BASE_YEAR)).isNull();
+        assertThat(AdmissionYearBucketer.toAdmissionYear("", BASE_YEAR)).isNull();
+        assertThat(AdmissionYearBucketer.toAdmissionYear("2201", BASE_YEAR)).isNull();      // 4자리
+        assertThat(AdmissionYearBucketer.toAdmissionYear("2200011", BASE_YEAR)).isNull();   // 7자리
+        assertThat(AdmissionYearBucketer.toAdmissionYear("22000a", BASE_YEAR)).isNull();    // 숫자 아님
     }
 
     @Test

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/statistics/util/AdmissionYearBucketerTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/statistics/util/AdmissionYearBucketerTest.java
@@ -1,0 +1,53 @@
+package com.kakaotech.team18.backend_server.domain.statistics.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("AdmissionYearBucketer - 학번 → 입학연도")
+class AdmissionYearBucketerTest {
+
+    private static final int BASE_YEAR = 2026;
+    private static final int MIN_YEAR = 2016;
+
+    @Test
+    @DisplayName("앞 2자리를 4자리 입학연도로 변환한다 (22 → 2022)")
+    void twoDigitToFourDigit() {
+        assertThat(AdmissionYearBucketer.toAdmissionYear("220001", BASE_YEAR, MIN_YEAR)).isEqualTo(2022);
+        assertThat(AdmissionYearBucketer.toAdmissionYear("260001", BASE_YEAR, MIN_YEAR)).isEqualTo(2026);
+    }
+
+    @Test
+    @DisplayName("기준 연도 뒤 두 자리보다 크면 이전 세기로 해석한다 (99 → 1999)")
+    void previousCenturyWhenAboveBase() {
+        // 기준 2000년 하한이면 1999도 유효 범위 안
+        assertThat(AdmissionYearBucketer.toAdmissionYear("990001", 2026, 1990)).isEqualTo(1999);
+    }
+
+    @Test
+    @DisplayName("기준 연도보다 미래이거나 하한보다 과거면 null (유효 범위 밖)")
+    void outOfRangeIsNull() {
+        // 27 → 2027, 기준 2026보다 미래 → null
+        assertThat(AdmissionYearBucketer.toAdmissionYear("270001", BASE_YEAR, MIN_YEAR)).isNull();
+        // 12 → 2012, 하한 2016보다 과거 → null
+        assertThat(AdmissionYearBucketer.toAdmissionYear("120001", BASE_YEAR, MIN_YEAR)).isNull();
+    }
+
+    @Test
+    @DisplayName("6자리 숫자가 아니면 null (비지원서 경로 학번 등)")
+    void nonSixDigitIsNull() {
+        assertThat(AdmissionYearBucketer.toAdmissionYear(null, BASE_YEAR, MIN_YEAR)).isNull();
+        assertThat(AdmissionYearBucketer.toAdmissionYear("", BASE_YEAR, MIN_YEAR)).isNull();
+        assertThat(AdmissionYearBucketer.toAdmissionYear("2201", BASE_YEAR, MIN_YEAR)).isNull();      // 4자리
+        assertThat(AdmissionYearBucketer.toAdmissionYear("2200011", BASE_YEAR, MIN_YEAR)).isNull();   // 7자리
+        assertThat(AdmissionYearBucketer.toAdmissionYear("22000a", BASE_YEAR, MIN_YEAR)).isNull();    // 숫자 아님
+    }
+
+    @Test
+    @DisplayName("라벨은 학년이 아닌 '22학번' 형식")
+    void label() {
+        assertThat(AdmissionYearBucketer.toLabel(2022)).isEqualTo("22학번");
+        assertThat(AdmissionYearBucketer.toLabel(2009)).isEqualTo("09학번");
+    }
+}


### PR DESCRIPTION
## 🚀 작업 내용

성별·학부에 이어 **입학연도(ADMISSION_YEAR) dimension 집계**를 구현했습니다. `studentId` 앞 2자리에서 입학연도를 유도합니다.

- `AdmissionYearBucketer` 유틸: 6자리 학번 → 4자리 입학연도(세기 판정) / `22학번` 라벨. 6자리 숫자가 아니면 null.
- 리포지토리: `GROUP BY u.studentId` 쿼리 + `StudentIdCount` projection(별도 파일)
- 집계기: `aggregate(ADMISSION_YEAR)`
  - **최근 6년(기준 연도-6 이상)은 연도별 개별 버킷**
  - **그보다 오래된 입학연도는 '그 이전'(OLDER) 하나로 묶음** (오래된 건 모름이 아니라 실제 옛 코호트라서)
  - **'미입력'은 6자리 숫자가 아닌 학번에만** (7자리 등)
  - 순서: [그 이전 → 개별 연도 오름차순 → 미입력], 4자리 연도 기준 정렬
- **응답에 6자리 학번 원본은 포함되지 않음** (버킷 key는 연도/`OLDER`)

## ⏱️ 소요 시간


## 🤔 고민했던 내용

- **오래된 학번 처리**: 처음엔 하한(minYear) 밖을 '미입력'으로 뒀는데, 오래된 건 오타/모름이 아니라 실제 옛 학번이라 '그 이전' 버킷으로 묶는 게 맞다고 판단해 변경했습니다. 임계값은 `기준 연도-6`(상수, 설정값화는 후속).
- **기준 연도(baseYear)**: Clock 빈이 없어 `Year.now(KST)`를 쓰되, 시점 고정 테스트를 위해 `baseYear`를 인자로 받는 package-private `bucketAdmissionYears`로 분리(`RecruitStatusCalculator` 패턴).
- **projection 위치**: 저장소 관례(별도 top-level 파일: `InterviewSlotCountProjection`, `ClubSummary`)에 맞춰 `StudentIdCount`를 파일로 분리했습니다. 이미 머지된 `GenderCount`/`FacultyCount`도 같은 관례로 옮기는 별도 refactor PR을 이어서 올릴 예정입니다.
- **6자리 초과 학번**: 지원/회원가입은 `@Pattern(\d{6})`로 400 반환. 통계는 `.matches()`로 정확히 6자리만 통과 → 7자리는 '미입력'으로 안전 분류(에러 아님).

## 💬 리뷰 중점사항

- `AdmissionYearBucketer` 세기 판정(99→1999, 22→2022)과 형식 검사만 하는 변경
- '그 이전' 묶음 임계값(기준 연도-6)과 버킷 순서
- 학번 원본이 응답 어디에도 안 나가는지
- `@DataJpaTest`로 학번 그룹핑 쿼리 검증

## 🔗관련 이슈
- #335 (지원자 통계 - 입학연도 집계 단계, 다단계 이슈라 Close 아님)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 입학년도별 지원자 통계를 실제 학번 데이터 기반으로 제공합니다.
  * 최근 6년은 연도별로, 이전 연도는 ‘그 이전’으로 집계합니다.
  * 유효하지 않은 학번은 ‘미입력’으로 분류합니다.
  * 통계 응답의 입학년도 키 형식을 두 자리 연도로 통일했습니다.

* **테스트**
  * 학번별 지원자 수 집계와 입학년도 변환·버킷 분류 검증을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->