### PR TITLE
[REFACTOR] 통계 projection 인터페이스를 별도 파일로 분리 (#335)

### DIFF
--- a/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/repository/ApplicationStatisticsRepository.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/repository/ApplicationStatisticsRepository.java
@@ -1,8 +1,6 @@
 package com.kakaotech.team18.backend_server.domain.statistics.repository;
 
 import com.kakaotech.team18.backend_server.domain.application.entity.Application;
-import com.kakaotech.team18.backend_server.domain.user.entity.Faculty;
-import com.kakaotech.team18.backend_server.domain.user.entity.Gender;
 import java.util.List;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
@@ -44,14 +42,6 @@ public interface ApplicationStatisticsRepository extends Repository<Application,
             """)
     List<GenderCount> aggregateGender(@Param("clubApplyFormId") Long clubApplyFormId);
 
-    /** 성별 집계 결과 projection. */
-    interface GenderCount {
-
-        Gender getGender();
-
-        long getCount();
-    }
-
     /**
      * 학부 분포. 학부가 없는(null) 지원자도 하나의 그룹으로 반환된다.
      */
@@ -63,14 +53,6 @@ public interface ApplicationStatisticsRepository extends Repository<Application,
             GROUP BY u.faculty
             """)
     List<FacultyCount> aggregateFaculty(@Param("clubApplyFormId") Long clubApplyFormId);
-
-    /** 학부 집계 결과 projection. */
-    interface FacultyCount {
-
-        Faculty getFaculty();
-
-        long getCount();
-    }
 
     /**
      * 학번별 지원자 수. 입학연도로의 변환·버킷팅은 세기 판정이 필요해 애플리케이션에서 수행하므로,

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/repository/FacultyCount.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/repository/FacultyCount.java
@@ -1,0 +1,11 @@
+package com.kakaotech.team18.backend_server.domain.statistics.repository;
+
+import com.kakaotech.team18.backend_server.domain.user.entity.Faculty;
+
+/** 학부 집계 결과 projection. */
+public interface FacultyCount {
+
+    Faculty getFaculty();
+
+    long getCount();
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/repository/GenderCount.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/repository/GenderCount.java
@@ -1,0 +1,11 @@
+package com.kakaotech.team18.backend_server.domain.statistics.repository;
+
+import com.kakaotech.team18.backend_server.domain.user.entity.Gender;
+
+/** 성별 집계 결과 projection. */
+public interface GenderCount {
+
+    Gender getGender();
+
+    long getCount();
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/service/StatisticsAggregator.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/service/StatisticsAggregator.java
@@ -6,6 +6,8 @@ import com.kakaotech.team18.backend_server.domain.clubApplyForm.entity.ClubApply
 import com.kakaotech.team18.backend_server.domain.statistics.dto.RawBucket;
 import com.kakaotech.team18.backend_server.domain.statistics.entity.StatisticsDimension;
 import com.kakaotech.team18.backend_server.domain.statistics.repository.ApplicationStatisticsRepository;
+import com.kakaotech.team18.backend_server.domain.statistics.repository.FacultyCount;
+import com.kakaotech.team18.backend_server.domain.statistics.repository.GenderCount;
 import com.kakaotech.team18.backend_server.domain.statistics.repository.StudentIdCount;
 import com.kakaotech.team18.backend_server.domain.statistics.util.AdmissionYearBucketer;
 import com.kakaotech.team18.backend_server.domain.user.entity.Faculty;
@@ -83,13 +85,13 @@ public class StatisticsAggregator {
      * 순서를 따르고, '미입력'은 항상 마지막에 둔다.
      */
     private List<RawBucket> aggregateGender(Long clubApplyFormId) {
-        List<ApplicationStatisticsRepository.GenderCount> counts =
+        List<GenderCount> counts =
                 statisticsRepository.aggregateGender(clubApplyFormId);
 
         List<RawBucket> buckets = new ArrayList<>();
         long unknownCount = 0;
 
-        for (ApplicationStatisticsRepository.GenderCount row : counts) {
+        for (GenderCount row : counts) {
             Gender gender = row.getGender();
             if (gender == null) {
                 unknownCount += row.getCount();
@@ -114,13 +116,13 @@ public class StatisticsAggregator {
      * '미입력'은 항상 마지막에 둔다.
      */
     private List<RawBucket> aggregateFaculty(Long clubApplyFormId) {
-        List<ApplicationStatisticsRepository.FacultyCount> counts =
+        List<FacultyCount> counts =
                 statisticsRepository.aggregateFaculty(clubApplyFormId);
 
         List<RawBucket> buckets = new ArrayList<>();
         long unknownCount = 0;
 
-        for (ApplicationStatisticsRepository.FacultyCount row : counts) {
+        for (FacultyCount row : counts) {
             Faculty faculty = row.getFaculty();
             if (faculty == null) {
                 unknownCount += row.getCount();

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/statistics/repository/ApplicationStatisticsRepositoryIntegrationTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/statistics/repository/ApplicationStatisticsRepositoryIntegrationTest.java
@@ -6,8 +6,6 @@ import com.kakaotech.team18.backend_server.domain.application.entity.Application
 import com.kakaotech.team18.backend_server.domain.club.entity.Category;
 import com.kakaotech.team18.backend_server.domain.club.entity.Club;
 import com.kakaotech.team18.backend_server.domain.clubApplyForm.entity.ClubApplyForm;
-import com.kakaotech.team18.backend_server.domain.statistics.repository.ApplicationStatisticsRepository.FacultyCount;
-import com.kakaotech.team18.backend_server.domain.statistics.repository.ApplicationStatisticsRepository.GenderCount;
 import com.kakaotech.team18.backend_server.domain.user.entity.Faculty;
 import com.kakaotech.team18.backend_server.domain.user.entity.Gender;
 import com.kakaotech.team18.backend_server.domain.user.entity.User;

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/statistics/service/StatisticsAggregatorTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/statistics/service/StatisticsAggregatorTest.java
@@ -8,8 +8,8 @@ import com.kakaotech.team18.backend_server.domain.clubApplyForm.entity.ClubApply
 import com.kakaotech.team18.backend_server.domain.statistics.dto.RawBucket;
 import com.kakaotech.team18.backend_server.domain.statistics.entity.StatisticsDimension;
 import com.kakaotech.team18.backend_server.domain.statistics.repository.ApplicationStatisticsRepository;
-import com.kakaotech.team18.backend_server.domain.statistics.repository.ApplicationStatisticsRepository.FacultyCount;
-import com.kakaotech.team18.backend_server.domain.statistics.repository.ApplicationStatisticsRepository.GenderCount;
+import com.kakaotech.team18.backend_server.domain.statistics.repository.FacultyCount;
+import com.kakaotech.team18.backend_server.domain.statistics.repository.GenderCount;
 import com.kakaotech.team18.backend_server.domain.statistics.repository.StudentIdCount;
 import com.kakaotech.team18.backend_server.domain.user.entity.Faculty;
 import com.kakaotech.team18.backend_server.domain.user.entity.Gender;


### PR DESCRIPTION
## 🚀 작업 내용

리포지토리 안에 nested로 두던 projection 인터페이스를 저장소 관례에 맞춰 별도 top-level 파일로 분리했습니다. **동작 변경 없음(순수 refactor)**.

- `GenderCount`, `FacultyCount` → `GenderCount.java`, `FacultyCount.java`로 분리
- `ApplicationStatisticsRepository`에서 nested 정의 제거, 불필요해진 `Gender`/`Faculty` import 정리
- 집계기·테스트의 참조를 top-level 이름으로 변경
- (`StudentIdCount`는 앞 PR #346에서 이미 분리)

## ⏱️ 소요 시간


## 🤔 고민했던 내용

- 저장소의 기존 projection은 모두 별도 파일(`application/repository/InterviewSlotCountProjection`, `club/dto/ClubSummary`)이고, nested로 둔 건 통계 3개가 유일한 예외였습니다. `StudentIdCount`만 파일로 뺀 상태라 리포지토리 안 스타일이 갈려 있어, 나머지도 관례에 맞춰 통일했습니다.
- 기능/성능 차이는 없고 순수하게 하우스 스타일 일관성 목적입니다.

## 💬 리뷰 중점사항

- 동작 변경이 없는지(쿼리·projection 매핑 동일)
- 참조 정리 후 컴파일/테스트 정상

## 🔗관련 이슈
- #335 (지원자 통계 관련 정리, 다단계 이슈라 Close 아님)