### PR TITLE
[FEAT] 지원자 통계 - 일자별 지원 추이 집계 구현 (#335)

### DIFF
--- a/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/repository/ApplicationStatisticsRepository.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/repository/ApplicationStatisticsRepository.java
@@ -1,6 +1,7 @@
 package com.kakaotech.team18.backend_server.domain.statistics.repository;
 
 import com.kakaotech.team18.backend_server.domain.application.entity.Application;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
@@ -66,4 +67,17 @@ public interface ApplicationStatisticsRepository extends Repository<Application,
             GROUP BY u.studentId
             """)
     List<StudentIdCount> aggregateByStudentId(@Param("clubApplyFormId") Long clubApplyFormId);
+
+    /**
+     * 지원폼에 접수된 지원서들의 접수 시각 목록.
+     * <p>
+     * 일자 집계는 시간대(Asia/Seoul) 기준이라 DB의 날짜 함수 대신 접수 시각을 그대로 받아 애플리케이션에서
+     * 일자로 버킷팅한다. {@code createdAt}은 {@code BaseEntity}의 {@code @CreatedDate}로 항상 채워진다.
+     */
+    @Query("""
+            SELECT a.createdAt
+            FROM Application a
+            WHERE a.clubApplyForm.id = :clubApplyFormId
+            """)
+    List<LocalDateTime> findCreatedAtByClubApplyFormId(@Param("clubApplyFormId") Long clubApplyFormId);
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/service/StatisticsAggregator.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/service/StatisticsAggregator.java
@@ -2,6 +2,7 @@ package com.kakaotech.team18.backend_server.domain.statistics.service;
 
 import static com.kakaotech.team18.backend_server.domain.statistics.service.StatisticsServiceImpl.KST;
 
+import com.kakaotech.team18.backend_server.domain.club.entity.Club;
 import com.kakaotech.team18.backend_server.domain.clubApplyForm.entity.ClubApplyForm;
 import com.kakaotech.team18.backend_server.domain.statistics.dto.RawBucket;
 import com.kakaotech.team18.backend_server.domain.statistics.entity.StatisticsDimension;
@@ -12,6 +13,8 @@ import com.kakaotech.team18.backend_server.domain.statistics.repository.StudentI
 import com.kakaotech.team18.backend_server.domain.statistics.util.AdmissionYearBucketer;
 import com.kakaotech.team18.backend_server.domain.user.entity.Faculty;
 import com.kakaotech.team18.backend_server.domain.user.entity.Gender;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.Year;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -74,7 +77,7 @@ public class StatisticsAggregator {
             case GENDER -> aggregateGender(form.getId());
             case FACULTY -> aggregateFaculty(form.getId());
             case ADMISSION_YEAR -> aggregateAdmissionYear(form.getId());
-            case DAILY_APPLICATIONS -> List.of();
+            case DAILY_APPLICATIONS -> aggregateDailyApplications(form);
         };
     }
 
@@ -185,5 +188,54 @@ public class StatisticsAggregator {
             buckets.add(RawBucket.of(UNKNOWN_KEY, UNKNOWN_LABEL, unknownCount));
         }
         return buckets;
+    }
+
+    /**
+     * 일자별 지원 추이를 집계합니다. 모집 기간은 소속 동아리의 모집 시작·종료일을 사용한다.
+     */
+    private List<RawBucket> aggregateDailyApplications(ClubApplyForm form) {
+        Club club = form.getClub();
+        return bucketDailyApplications(
+                statisticsRepository.findCreatedAtByClubApplyFormId(form.getId()),
+                club.getRecruitStart() != null ? club.getRecruitStart().toLocalDate() : null,
+                club.getRecruitEnd() != null ? club.getRecruitEnd().toLocalDate() : null);
+    }
+
+    /**
+     * 접수 시각 목록을 일자별 버킷으로 변환합니다.
+     * <p>
+     * 접수 시각({@code LocalDateTime})을 Asia/Seoul 벽시계 기준 일자로 본다. 모집 시작·종료일이 모두 주어지면
+     * 그 사이 <strong>지원자가 없는 날도 {@code count:0}으로 채운다.</strong> 모집 기간 밖(예: 마감 이후)에 접수된
+     * 건도 유실하지 않고 해당 일자 버킷으로 포함한다. 모집일이 null이면 0채움 없이 실제 접수일만 반환한다.
+     * 버킷은 일자 오름차순으로 정렬한다.
+     *
+     * @param createdAts   접수 시각 목록
+     * @param recruitStart 모집 시작일(없으면 null)
+     * @param recruitEnd   모집 종료일(없으면 null)
+     */
+    List<RawBucket> bucketDailyApplications(
+            List<LocalDateTime> createdAts, LocalDate recruitStart, LocalDate recruitEnd) {
+        Map<LocalDate, Long> countByDate = new TreeMap<>();
+
+        for (LocalDateTime createdAt : createdAts) {
+            countByDate.merge(createdAt.toLocalDate(), 1L, Long::sum);
+        }
+
+        // 모집 기간이 온전하면 빈 날도 0으로 채운다.
+        if (recruitStart != null && recruitEnd != null && !recruitStart.isAfter(recruitEnd)) {
+            for (LocalDate day = recruitStart; !day.isAfter(recruitEnd); day = day.plusDays(1)) {
+                countByDate.putIfAbsent(day, 0L);
+            }
+        }
+
+        List<RawBucket> buckets = new ArrayList<>();
+        countByDate.forEach((date, count) ->
+                buckets.add(RawBucket.of(date.toString(), dailyLabel(date), count)));
+        return buckets;
+    }
+
+    /** 일자를 '3월 2일' 형식 라벨로 변환합니다. */
+    private static String dailyLabel(LocalDate date) {
+        return date.getMonthValue() + "월 " + date.getDayOfMonth() + "일";
     }
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/service/StatisticsAggregator.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/service/StatisticsAggregator.java
@@ -191,39 +191,44 @@ public class StatisticsAggregator {
     }
 
     /**
-     * 일자별 지원 추이를 집계합니다. 모집 기간은 소속 동아리의 모집 시작·종료일을 사용한다.
+     * 일자별 지원 추이를 집계합니다. 모집 기간은 소속 동아리의 모집 시작·종료일을 사용하고, 기준일은 오늘(KST)이다.
      */
     private List<RawBucket> aggregateDailyApplications(ClubApplyForm form) {
         Club club = form.getClub();
         return bucketDailyApplications(
                 statisticsRepository.findCreatedAtByClubApplyFormId(form.getId()),
                 club.getRecruitStart() != null ? club.getRecruitStart().toLocalDate() : null,
-                club.getRecruitEnd() != null ? club.getRecruitEnd().toLocalDate() : null);
+                club.getRecruitEnd() != null ? club.getRecruitEnd().toLocalDate() : null,
+                LocalDate.now(KST));
     }
 
     /**
      * 접수 시각 목록을 일자별 버킷으로 변환합니다.
      * <p>
      * 접수 시각({@code LocalDateTime})을 Asia/Seoul 벽시계 기준 일자로 본다. 모집 시작·종료일이 모두 주어지면
-     * 그 사이 <strong>지원자가 없는 날도 {@code count:0}으로 채운다.</strong> 모집 기간 밖(예: 마감 이후)에 접수된
-     * 건도 유실하지 않고 해당 일자 버킷으로 포함한다. 모집일이 null이면 0채움 없이 실제 접수일만 반환한다.
-     * 버킷은 일자 오름차순으로 정렬한다.
+     * 그 사이 <strong>지원자가 없는 날도 {@code count:0}으로 채운다.</strong> 단, 아직 오지 않은 미래 날짜는 채우지
+     * 않는다(0채움 종료일 = min(모집 종료일, 오늘)). 모집일이 null이면 0채움 없이 실제 접수일만 반환한다. 실제
+     * 접수 건은 유실하지 않고(기준일까지의 값이므로 항상 과거) 모두 포함하며, 버킷은 일자 오름차순으로 정렬한다.
+     * <p>
+     * 표시 구간(예: 최근 N일)은 프론트가 이 시계열을 잘라서 결정한다.
      *
      * @param createdAts   접수 시각 목록
      * @param recruitStart 모집 시작일(없으면 null)
      * @param recruitEnd   모집 종료일(없으면 null)
+     * @param today        기준일(보통 오늘). 이 날짜 이후는 0으로 채우지 않는다.
      */
     List<RawBucket> bucketDailyApplications(
-            List<LocalDateTime> createdAts, LocalDate recruitStart, LocalDate recruitEnd) {
+            List<LocalDateTime> createdAts, LocalDate recruitStart, LocalDate recruitEnd, LocalDate today) {
         Map<LocalDate, Long> countByDate = new TreeMap<>();
 
         for (LocalDateTime createdAt : createdAts) {
             countByDate.merge(createdAt.toLocalDate(), 1L, Long::sum);
         }
 
-        // 모집 기간이 온전하면 빈 날도 0으로 채운다.
-        if (recruitStart != null && recruitEnd != null && !recruitStart.isAfter(recruitEnd)) {
-            for (LocalDate day = recruitStart; !day.isAfter(recruitEnd); day = day.plusDays(1)) {
+        // 모집 기간이 온전하면 빈 날도 0으로 채우되, 아직 오지 않은 미래 날짜는 채우지 않는다.
+        if (recruitStart != null && recruitEnd != null) {
+            LocalDate fillEnd = recruitEnd.isBefore(today) ? recruitEnd : today;
+            for (LocalDate day = recruitStart; !day.isAfter(fillEnd); day = day.plusDays(1)) {
                 countByDate.putIfAbsent(day, 0L);
             }
         }

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/statistics/repository/ApplicationStatisticsRepositoryIntegrationTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/statistics/repository/ApplicationStatisticsRepositoryIntegrationTest.java
@@ -100,6 +100,12 @@ class ApplicationStatisticsRepositoryIntegrationTest {
         assertThat(counts.values()).containsOnly(1L);
     }
 
+    @Test
+    @DisplayName("접수 시각 조회: 해당 지원폼의 지원서 접수 시각만 반환한다")
+    void findCreatedAt_onlyThisForm() {
+        assertThat(repository.findCreatedAtByClubApplyFormId(form.getId())).hasSize(5);
+    }
+
     private ClubApplyForm persistForm(String clubName) {
         Club club = Club.builder()
                 .name(clubName)

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/statistics/service/StatisticsAggregatorTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/statistics/service/StatisticsAggregatorTest.java
@@ -13,6 +13,8 @@ import com.kakaotech.team18.backend_server.domain.statistics.repository.GenderCo
 import com.kakaotech.team18.backend_server.domain.statistics.repository.StudentIdCount;
 import com.kakaotech.team18.backend_server.domain.user.entity.Faculty;
 import com.kakaotech.team18.backend_server.domain.user.entity.Gender;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -118,5 +120,49 @@ class StatisticsAggregatorTest {
         assertThat(buckets.get(0).label()).isEqualTo("그 이전");
         assertThat(buckets.get(1).label()).isEqualTo("22학번");
         assertThat(buckets.get(3).label()).isEqualTo("미입력");
+    }
+
+    @Test
+    @DisplayName("일자별 추이: 모집 기간 중 지원자 없는 날도 count 0으로 채우고 일자 오름차순 정렬")
+    void bucketDailyApplications_zeroFillWithinRecruitPeriod() {
+        List<LocalDateTime> createdAts = List.of(
+                LocalDateTime.of(2026, 3, 2, 9, 0),
+                LocalDateTime.of(2026, 3, 2, 15, 0),
+                LocalDateTime.of(2026, 3, 4, 10, 0));
+
+        List<RawBucket> buckets = aggregator.bucketDailyApplications(
+                createdAts, LocalDate.of(2026, 3, 1), LocalDate.of(2026, 3, 5));
+
+        assertThat(buckets).extracting(RawBucket::key)
+                .containsExactly("2026-03-01", "2026-03-02", "2026-03-03", "2026-03-04", "2026-03-05");
+        assertThat(buckets).extracting(RawBucket::count).containsExactly(0L, 2L, 0L, 1L, 0L);
+        assertThat(buckets.get(0).label()).isEqualTo("3월 1일");
+        assertThat(buckets.get(1).label()).isEqualTo("3월 2일");
+    }
+
+    @Test
+    @DisplayName("일자별 추이: 마감 이후 접수 건도 유실 없이 포함한다")
+    void bucketDailyApplications_includesAfterDeadline() {
+        List<LocalDateTime> createdAts = List.of(LocalDateTime.of(2026, 3, 5, 10, 0)); // 마감(3/2) 이후
+
+        List<RawBucket> buckets = aggregator.bucketDailyApplications(
+                createdAts, LocalDate.of(2026, 3, 1), LocalDate.of(2026, 3, 2));
+
+        assertThat(buckets).extracting(RawBucket::key)
+                .containsExactly("2026-03-01", "2026-03-02", "2026-03-05");
+        assertThat(buckets).extracting(RawBucket::count).containsExactly(0L, 0L, 1L);
+    }
+
+    @Test
+    @DisplayName("일자별 추이: 모집일이 null이면 0채움 없이 실제 접수일만 반환")
+    void bucketDailyApplications_nullRecruitPeriod_noZeroFill() {
+        List<LocalDateTime> createdAts = List.of(
+                LocalDateTime.of(2026, 3, 2, 9, 0),
+                LocalDateTime.of(2026, 3, 4, 10, 0));
+
+        List<RawBucket> buckets = aggregator.bucketDailyApplications(createdAts, null, null);
+
+        assertThat(buckets).extracting(RawBucket::key).containsExactly("2026-03-02", "2026-03-04");
+        assertThat(buckets).extracting(RawBucket::count).containsExactly(1L, 1L);
     }
 }

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/statistics/service/StatisticsAggregatorTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/statistics/service/StatisticsAggregatorTest.java
@@ -131,7 +131,7 @@ class StatisticsAggregatorTest {
                 LocalDateTime.of(2026, 3, 4, 10, 0));
 
         List<RawBucket> buckets = aggregator.bucketDailyApplications(
-                createdAts, LocalDate.of(2026, 3, 1), LocalDate.of(2026, 3, 5));
+                createdAts, LocalDate.of(2026, 3, 1), LocalDate.of(2026, 3, 5), LocalDate.of(2026, 3, 5));
 
         assertThat(buckets).extracting(RawBucket::key)
                 .containsExactly("2026-03-01", "2026-03-02", "2026-03-03", "2026-03-04", "2026-03-05");
@@ -141,16 +141,17 @@ class StatisticsAggregatorTest {
     }
 
     @Test
-    @DisplayName("일자별 추이: 마감 이후 접수 건도 유실 없이 포함한다")
-    void bucketDailyApplications_includesAfterDeadline() {
-        List<LocalDateTime> createdAts = List.of(LocalDateTime.of(2026, 3, 5, 10, 0)); // 마감(3/2) 이후
+    @DisplayName("일자별 추이: 아직 오지 않은 미래 날짜(오늘 이후)는 0으로 채우지 않는다")
+    void bucketDailyApplications_doesNotPadFutureDays() {
+        List<LocalDateTime> createdAts = List.of(LocalDateTime.of(2026, 3, 2, 9, 0));
 
+        // 모집 종료일은 3/10이지만 오늘은 3/3 → 3/4~3/10은 채우지 않는다
         List<RawBucket> buckets = aggregator.bucketDailyApplications(
-                createdAts, LocalDate.of(2026, 3, 1), LocalDate.of(2026, 3, 2));
+                createdAts, LocalDate.of(2026, 3, 1), LocalDate.of(2026, 3, 10), LocalDate.of(2026, 3, 3));
 
         assertThat(buckets).extracting(RawBucket::key)
-                .containsExactly("2026-03-01", "2026-03-02", "2026-03-05");
-        assertThat(buckets).extracting(RawBucket::count).containsExactly(0L, 0L, 1L);
+                .containsExactly("2026-03-01", "2026-03-02", "2026-03-03");
+        assertThat(buckets).extracting(RawBucket::count).containsExactly(0L, 1L, 0L);
     }
 
     @Test
@@ -160,7 +161,8 @@ class StatisticsAggregatorTest {
                 LocalDateTime.of(2026, 3, 2, 9, 0),
                 LocalDateTime.of(2026, 3, 4, 10, 0));
 
-        List<RawBucket> buckets = aggregator.bucketDailyApplications(createdAts, null, null);
+        List<RawBucket> buckets = aggregator.bucketDailyApplications(
+                createdAts, null, null, LocalDate.of(2026, 3, 4));
 
         assertThat(buckets).extracting(RawBucket::key).containsExactly("2026-03-02", "2026-03-04");
         assertThat(buckets).extracting(RawBucket::count).containsExactly(1L, 1L);


### PR DESCRIPTION
## 🚀 작업 내용

마지막 남은 dimension인 **일자별 지원 추이(DAILY_APPLICATIONS, 시계열)** 집계를 구현했습니다.

- 리포지토리: 지원폼의 지원서 접수 시각(`createdAt`) 목록 조회 쿼리
- 집계기: `aggregate(DAILY_APPLICATIONS)`
  - 접수 시각을 **Asia/Seoul 벽시계 기준 일자**로 버킷팅
  - 모집 시작·종료일이 있으면 **지원자 없는 날도 `count:0`으로 채움**
  - **단, 오늘 이후 미래 날짜는 채우지 않음** (0채움 종료일 = `min(모집 종료일, 오늘)`)
  - 모집일이 null이면 0채움 없이 실제 접수일만
  - 항상 **일자 오름차순** 정렬. key는 ISO 일자(`2026-03-02`), label은 `3월 2일`
- 시계열이라 비율(ratio)은 붙지 않음(기존 `StatisticsServiceImpl` 처리)

## ⏱️ 소요 시간


## 🤔 고민했던 내용

- **미래 날짜 0채움 문제**: 초기 구현은 모집 종료일까지 0채움을 했는데, 종료일이 미래면 아직 안 온 날들이 "0 0 0"으로 찍혀 부자연스러웠습니다. 기준일(오늘)까지로 잘라 해결했습니다.
- **표시 구간(최근 N일)**: 프론트에서 너무 많은 날짜를 표시할 수 없어 최근 며칠만 보여주는 것을 고려 중입니다. 이는 표현 계층의 결정이므로, **백엔드는 오늘까지의 정확한 전체 시계열을 제공하고 프론트가 뒤에서 N일을 잘라** 쓰는 방향으로 두었습니다(백엔드 하드코딩 X). 필요하면 이후 윈도우 파라미터를 추가할 수 있습니다.
- **KST 집계**: `createdAt`은 `LocalDateTime`이라 저장된 벽시계 값을 그대로 KST 일자로 본다. DB 날짜 함수는 이식성 이슈로 쓰지 않고 앱에서 버킷팅.
- **테스트 가능성**: 접수시각·모집일·기준일을 인자로 받는 package-private `bucketDailyApplications`로 분리해 시점 고정.
- 참고: 백엔드는 현재 지원 시점에 모집기간을 검증하지 않습니다(프론트만 가드). 기간 외 접수는 통계에서 유실 없이 포함되며, 백엔드 기간 검증 추가는 예정에 없습니다.

## 💬 리뷰 중점사항

- 미래 날짜 미패딩(오늘까지만 0채움) + 모집일 null 처리
- 일자 정렬과 라벨 형식
- `@DataJpaTest`로 접수시각 조회 폼 필터 검증

## 🔗관련 이슈
- #335 (지원자 통계 - 일자별 추이 단계, 다단계 이슈라 Close 아님)