### PR TITLE
feat: 관리자 지원자 통계 API 추가 (#335)

### DIFF
--- a/src/main/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/repository/ClubApplyFormRepository.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/clubApplyForm/repository/ClubApplyFormRepository.java
@@ -3,6 +3,8 @@ package com.kakaotech.team18.backend_server.domain.clubApplyForm.repository;
 import com.kakaotech.team18.backend_server.domain.clubApplyForm.entity.ClubApplyForm;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -11,4 +13,14 @@ public interface ClubApplyFormRepository extends JpaRepository<ClubApplyForm,Lon
     Optional<ClubApplyForm> findByClubId(Long clubId);
 
     Optional<ClubApplyForm> findByTitle(String s);
+
+    /**
+     * 지원폼 ID로 소속 동아리 ID만 조회합니다. (인가 검사용 경량 projection)
+     */
+    @Query("""
+            SELECT caf.club.id
+            FROM ClubApplyForm caf
+            WHERE caf.id = :clubApplyFormId
+            """)
+    Optional<Long> findClubIdByClubApplyFormId(@Param("clubApplyFormId") Long clubApplyFormId);
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/controller/StatisticsAdminController.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/controller/StatisticsAdminController.java
@@ -1,0 +1,74 @@
+package com.kakaotech.team18.backend_server.domain.statistics.controller;
+
+import com.kakaotech.team18.backend_server.domain.statistics.dto.StatisticsResponseDto;
+import com.kakaotech.team18.backend_server.domain.statistics.entity.StatisticsDimension;
+import com.kakaotech.team18.backend_server.domain.statistics.service.StatisticsService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 지원자 통계 관리자 API.
+ * <p>
+ * 지원자를 직접 관리하는 동아리 관리자(CLUB_ADMIN/CLUB_EXECUTIVE)만 접근할 수 있으며, 공개 통계와 달리
+ * 재식별 방지 마스킹·최소 공개 기준·마감 blackout을 적용하지 않고 원본 수치를 실시간으로 반환한다.
+ * <p>
+ * 경로가 {@code /statistics/admin}이라 공개 permitAll 매처({@code GET /api/club-apply-forms/*&#47;statistics},
+ * 세그먼트 하나만 매치)에 걸리지 않고 인증 대상으로 떨어진다. 세부 인가는 {@link PreAuthorize}로 검사한다.
+ */
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/club-apply-forms/{clubApplyFormId}")
+@Tag(name = "Statistics Admin", description = "지원자 통계 관리자 API")
+public class StatisticsAdminController {
+
+    private final StatisticsService statisticsService;
+
+    @Operation(
+            summary = "지원폼 단위 지원자 통계 조회 (관리자)",
+            description = """
+                    지원폼에 접수된 지원자의 성별·학번·학부 분포와 일자별 지원 추이를 마스킹 없이 반환합니다.
+                    해당 동아리의 관리자(CLUB_ADMIN/CLUB_EXECUTIVE)만 조회할 수 있습니다.
+
+                    - `dimensions`를 생략하면 모든 항목을 반환합니다.
+                    - 공개 통계와 응답 형태는 동일하나, 재식별 방지 제약을 적용하지 않은 원본 수치입니다.
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "400", description = "지원하지 않는 dimension", content = @Content),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자", content = @Content),
+            @ApiResponse(responseCode = "403", description = "해당 동아리 관리자 권한 없음", content = @Content),
+            @ApiResponse(responseCode = "404", description = "지원폼을 찾을 수 없음", content = @Content)
+    })
+    @GetMapping("/statistics/admin")
+    @PreAuthorize("@customSecurityService.isClubAdminOrExecutiveForApplyForm(#clubApplyFormId)")
+    public ResponseEntity<StatisticsResponseDto> getStatisticsForAdmin(
+            @Parameter(description = "지원폼 ID", example = "12")
+            @PathVariable Long clubApplyFormId,
+
+            @Parameter(description = "조회할 집계 항목. 생략하면 전체를 반환합니다.",
+                    example = "GENDER,FACULTY")
+            @RequestParam(name = "dimensions", required = false) List<String> dimensions
+    ) {
+        List<StatisticsDimension> requested = StatisticsDimension.resolve(dimensions);
+
+        log.info("관리자 지원자 통계 조회 clubApplyFormId={}, dimensions={}", clubApplyFormId, requested);
+
+        return ResponseEntity.ok(statisticsService.getStatisticsForAdmin(clubApplyFormId, requested));
+    }
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/entity/StatisticsDimension.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/entity/StatisticsDimension.java
@@ -47,4 +47,18 @@ public enum StatisticsDimension {
     public static List<StatisticsDimension> defaults() {
         return List.of(values());
     }
+
+    /**
+     * 쿼리 파라미터 문자열 목록을 dimension 목록으로 해석합니다. 비어 있으면 전체({@link #defaults()})를,
+     * 지정돼 있으면 각 값을 {@link #from(String)}으로 변환해 중복을 제거한 목록을 반환합니다.
+     */
+    public static List<StatisticsDimension> resolve(List<String> raw) {
+        if (raw == null || raw.isEmpty()) {
+            return defaults();
+        }
+        return raw.stream()
+                .map(StatisticsDimension::from)
+                .distinct()
+                .toList();
+    }
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/service/StatisticsService.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/service/StatisticsService.java
@@ -14,4 +14,16 @@ public interface StatisticsService {
      * @return 공개 가능한 형태로 가공된 통계 응답
      */
     StatisticsResponseDto getStatistics(Long clubApplyFormId, List<StatisticsDimension> dimensions);
+
+    /**
+     * 지원폼의 관리자용 통계를 조회합니다.
+     * <p>
+     * 지원자를 직접 관리하는 동아리 관리자용이라 재식별 방지 마스킹·최소 공개 기준·마감 blackout을 적용하지 않고
+     * 원본 수치를 실시간으로 반환합니다. 접근 권한은 컨트롤러의 인가 검사로 보장합니다.
+     *
+     * @param clubApplyFormId 지원폼 ID
+     * @param dimensions      조회할 집계 항목
+     * @return 마스킹하지 않은 원본 통계 응답
+     */
+    StatisticsResponseDto getStatisticsForAdmin(Long clubApplyFormId, List<StatisticsDimension> dimensions);
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/service/StatisticsServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/service/StatisticsServiceImpl.java
@@ -41,6 +41,16 @@ public class StatisticsServiceImpl implements StatisticsService {
         return calculate(form, dimensions);
     }
 
+    @Override
+    public StatisticsResponseDto getStatisticsForAdmin(Long clubApplyFormId, List<StatisticsDimension> dimensions) {
+        ClubApplyForm form = clubApplyFormRepository.findById(clubApplyFormId)
+                .orElseThrow(() -> new ClubApplyFormNotFoundException("clubApplyFormId = " + clubApplyFormId));
+
+        // 관리자용은 마스킹 없이 원본을 그대로 반환한다. 공개 경로(getStatistics)에 이후 마스킹이 붙어도
+        // 이 경로는 calculate() 원본만 사용하므로 영향받지 않는다.
+        return calculate(form, dimensions);
+    }
+
     /**
      * 지원폼의 통계를 실제로 집계합니다.
      * <p>

--- a/src/main/java/com/kakaotech/team18/backend_server/global/security/CustomSecurityService.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/security/CustomSecurityService.java
@@ -1,6 +1,7 @@
 package com.kakaotech.team18.backend_server.global.security;
 
 import com.kakaotech.team18.backend_server.domain.application.repository.ApplicationRepository;
+import com.kakaotech.team18.backend_server.domain.clubApplyForm.repository.ClubApplyFormRepository;
 import com.kakaotech.team18.backend_server.domain.clubMember.entity.Role;
 import com.kakaotech.team18.backend_server.global.exception.code.ErrorCode;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.CustomException;
@@ -17,6 +18,26 @@ import org.springframework.transaction.annotation.Transactional;
 public class CustomSecurityService {
 
     private final ApplicationRepository applicationRepository;
+    private final ClubApplyFormRepository clubApplyFormRepository;
+
+    /**
+     * 특정 지원폼(clubApplyFormId)에 대한 접근 권한을 검사합니다.
+     * <p>
+     * 지원폼 ID로 소속 동아리를 조회한 뒤, 현재 사용자가 그 동아리의 CLUB_ADMIN/CLUB_EXECUTIVE인지
+     * {@link #isClubAdminOrExecutive(Long)}로 위임 검사합니다. 존재하지 않는 지원폼이면 접근을 거부합니다.
+     *
+     * @param clubApplyFormId 검사할 지원폼의 ID
+     * @return 권한이 있으면 true, 없으면 false
+     */
+    @Transactional(readOnly = true)
+    public boolean isClubAdminOrExecutiveForApplyForm(Long clubApplyFormId) {
+        Long clubId = clubApplyFormRepository.findClubIdByClubApplyFormId(clubApplyFormId)
+                .orElse(null);
+        if (clubId == null) {
+            return false;
+        }
+        return isClubAdminOrExecutive(clubId);
+    }
 
     /**
      * 특정 지원서(applicationId)에 대한 접근 권한을 검사합니다.

--- a/src/main/java/com/kakaotech/team18/backend_server/global/security/CustomSecurityService.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/global/security/CustomSecurityService.java
@@ -4,6 +4,7 @@ import com.kakaotech.team18.backend_server.domain.application.repository.Applica
 import com.kakaotech.team18.backend_server.domain.clubApplyForm.repository.ClubApplyFormRepository;
 import com.kakaotech.team18.backend_server.domain.clubMember.entity.Role;
 import com.kakaotech.team18.backend_server.global.exception.code.ErrorCode;
+import com.kakaotech.team18.backend_server.global.exception.exceptions.ClubApplyFormNotFoundException;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.CustomException;
 import java.util.Map;
 import java.util.Objects;
@@ -24,18 +25,21 @@ public class CustomSecurityService {
      * 특정 지원폼(clubApplyFormId)에 대한 접근 권한을 검사합니다.
      * <p>
      * 지원폼 ID로 소속 동아리를 조회한 뒤, 현재 사용자가 그 동아리의 CLUB_ADMIN/CLUB_EXECUTIVE인지
-     * {@link #isClubAdminOrExecutive(Long)}로 위임 검사합니다. 존재하지 않는 지원폼이면 접근을 거부합니다.
+     * {@link #isClubAdminOrExecutive(Long)}로 위임 검사합니다.
+     * <p>
+     * 존재하지 않는 지원폼이면 {@code false}(→ 403)가 아니라 {@link ClubApplyFormNotFoundException}(→ 404)을
+     * 던진다. 인가 검사가 컨트롤러·서비스보다 먼저 실행되므로, 여기서 막으면 인증된 사용자가 서비스의 404에
+     * 닿지 못하고 403을 받아 API 계약과 어긋난다. 미인증 요청은 시큐리티 필터 체인에서 먼저 401로 차단되므로
+     * 이 예외는 인증된 사용자에게만 도달한다.
      *
      * @param clubApplyFormId 검사할 지원폼의 ID
-     * @return 권한이 있으면 true, 없으면 false
+     * @return 해당 동아리의 관리자/운영진이면 true, 아니면 false
+     * @throws ClubApplyFormNotFoundException 지원폼이 존재하지 않는 경우 (404)
      */
     @Transactional(readOnly = true)
     public boolean isClubAdminOrExecutiveForApplyForm(Long clubApplyFormId) {
         Long clubId = clubApplyFormRepository.findClubIdByClubApplyFormId(clubApplyFormId)
-                .orElse(null);
-        if (clubId == null) {
-            return false;
-        }
+                .orElseThrow(() -> new ClubApplyFormNotFoundException("clubApplyFormId = " + clubApplyFormId));
         return isClubAdminOrExecutive(clubId);
     }
 

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/statistics/controller/StatisticsAdminControllerAuthTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/statistics/controller/StatisticsAdminControllerAuthTest.java
@@ -90,4 +90,15 @@ class StatisticsAdminControllerAuthTest {
         mockMvc.perform(get("/api/club-apply-forms/{id}/statistics/admin", 12L))
                 .andExpect(status().isUnauthorized());
     }
+
+    @Test
+    @DisplayName("존재하지 않는 지원폼 → 404 (인가 검사에서 전파)")
+    @WithMockCustomUser(memberships = {"1:CLUB_ADMIN"})
+    void getStatisticsForAdmin_missingForm_notFound() throws Exception {
+        // 99번 지원폼은 존재하지 않아 projection이 비어 있다.
+        given(clubApplyFormRepository.findClubIdByClubApplyFormId(99L)).willReturn(Optional.empty());
+
+        mockMvc.perform(get("/api/club-apply-forms/{id}/statistics/admin", 99L))
+                .andExpect(status().isNotFound());
+    }
 }

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/statistics/controller/StatisticsAdminControllerAuthTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/statistics/controller/StatisticsAdminControllerAuthTest.java
@@ -1,0 +1,93 @@
+package com.kakaotech.team18.backend_server.domain.statistics.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.kakaotech.team18.backend_server.domain.clubApplyForm.repository.ClubApplyFormRepository;
+import com.kakaotech.team18.backend_server.domain.statistics.dto.StatisticsResponseDto;
+import com.kakaotech.team18.backend_server.domain.statistics.service.StatisticsService;
+import com.kakaotech.team18.backend_server.global.security.WithMockCustomUser;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * 실제 {@code SecurityConfig}·메서드 시큐리티 하에서 관리자 통계 API의 인가를 검증하는 통합 테스트.
+ * <p>
+ * 공개 통계({@code /statistics})와 달리 이 경로({@code /statistics/admin})는 permitAll 매처에 걸리지 않아
+ * 인증이 필요하며, 세부 인가는 {@code @customSecurityService.isClubAdminOrExecutiveForApplyForm}가 담당한다.
+ * DB 조회(지원폼 → 동아리 매핑)는 {@link ClubApplyFormRepository}를 목킹해 대체한다.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@AutoConfigureMockMvc
+@ActiveProfiles("test") // DataInitializer(@Profile prod/default) 비활성화 → 리포지토리 목킹이 시드와 충돌하지 않게 한다
+@DisplayName("StatisticsAdminController 인가 테스트")
+class StatisticsAdminControllerAuthTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private StatisticsService statisticsService;
+
+    @MockitoBean
+    private ClubApplyFormRepository clubApplyFormRepository; // CustomSecurityService의 인가 조회를 대체
+
+    @BeforeEach
+    void setUp() {
+        // 12번 지원폼은 1번 동아리 소속이라고 가정한다.
+        given(clubApplyFormRepository.findClubIdByClubApplyFormId(12L)).willReturn(Optional.of(1L));
+        given(statisticsService.getStatisticsForAdmin(any(), any()))
+                .willReturn(new StatisticsResponseDto(12L, 0L, false, OffsetDateTime.now(), List.of()));
+    }
+
+    @Test
+    @DisplayName("동아리 관리자 → 200")
+    @WithMockCustomUser(memberships = {"1:CLUB_ADMIN"})
+    void getStatisticsForAdmin_withClubAdmin_ok() throws Exception {
+        mockMvc.perform(get("/api/club-apply-forms/{id}/statistics/admin", 12L))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("동아리 운영진 → 200")
+    @WithMockCustomUser(memberships = {"1:CLUB_EXECUTIVE"})
+    void getStatisticsForAdmin_withClubExecutive_ok() throws Exception {
+        mockMvc.perform(get("/api/club-apply-forms/{id}/statistics/admin", 12L))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("동아리 일반 회원 → 403")
+    @WithMockCustomUser(memberships = {"1:CLUB_MEMBER"})
+    void getStatisticsForAdmin_withClubMember_forbidden() throws Exception {
+        mockMvc.perform(get("/api/club-apply-forms/{id}/statistics/admin", 12L))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("다른 동아리 관리자 → 403")
+    @WithMockCustomUser(memberships = {"2:CLUB_ADMIN"})
+    void getStatisticsForAdmin_withOtherClubAdmin_forbidden() throws Exception {
+        mockMvc.perform(get("/api/club-apply-forms/{id}/statistics/admin", 12L))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("미인증 사용자 → 401")
+    void getStatisticsForAdmin_withUnauthenticatedUser_unauthorized() throws Exception {
+        mockMvc.perform(get("/api/club-apply-forms/{id}/statistics/admin", 12L))
+                .andExpect(status().isUnauthorized());
+    }
+}

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/statistics/controller/StatisticsAdminControllerUnitTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/statistics/controller/StatisticsAdminControllerUnitTest.java
@@ -1,0 +1,101 @@
+package com.kakaotech.team18.backend_server.domain.statistics.controller;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.kakaotech.team18.backend_server.domain.statistics.dto.StatisticsResponseDto;
+import com.kakaotech.team18.backend_server.domain.statistics.dto.StatisticsResponseDto.Bucket;
+import com.kakaotech.team18.backend_server.domain.statistics.dto.StatisticsResponseDto.DimensionResult;
+import com.kakaotech.team18.backend_server.domain.statistics.entity.DimensionType;
+import com.kakaotech.team18.backend_server.domain.statistics.entity.StatisticsDimension;
+import com.kakaotech.team18.backend_server.domain.statistics.service.StatisticsService;
+import com.kakaotech.team18.backend_server.global.config.SecurityConfig;
+import com.kakaotech.team18.backend_server.global.config.TestSecurityConfig;
+import com.kakaotech.team18.backend_server.global.exception.code.ErrorCode;
+import com.kakaotech.team18.backend_server.global.security.JwtAuthenticationFilter;
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * 관리자 통계 컨트롤러 슬라이스 단위 테스트. 보안은 {@link TestSecurityConfig}로 대체하므로 {@code @PreAuthorize}
+ * 인가 검사는 여기서 평가되지 않는다(메서드 시큐리티 미적용). 실제 인가는 {@code StatisticsAdminControllerAuthTest}가
+ * 검증하고, 이 테스트는 dimension 전달·직렬화·잘못된 dimension 처리 같은 컨트롤러 자체 로직에 집중한다.
+ */
+@WebMvcTest(
+        controllers = StatisticsAdminController.class,
+        excludeFilters = {
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = SecurityConfig.class),
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JwtAuthenticationFilter.class)
+        }
+)
+@Import(TestSecurityConfig.class)
+@DisplayName("StatisticsAdminController 단위 테스트")
+class StatisticsAdminControllerUnitTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private StatisticsService statisticsService;
+
+    private StatisticsResponseDto sampleResponse() {
+        return new StatisticsResponseDto(
+                12L, 200L, false, OffsetDateTime.now(),
+                List.of(new DimensionResult(
+                        StatisticsDimension.GENDER, DimensionType.CATEGORICAL,
+                        List.of(new Bucket("MALE", "남성", 121, new BigDecimal("0.605")))
+                ))
+        );
+    }
+
+    @Test
+    @DisplayName("요청한 dimension이 관리자 서비스에 그대로 전달되고 응답이 직렬화된다")
+    void getStatisticsForAdmin_passesRequestedDimensions() throws Exception {
+        given(statisticsService.getStatisticsForAdmin(eq(12L), eq(List.of(StatisticsDimension.GENDER))))
+                .willReturn(sampleResponse());
+
+        mockMvc.perform(get("/api/club-apply-forms/{id}/statistics/admin", 12L)
+                        .param("dimensions", "GENDER")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.clubApplyFormId").value(12))
+                .andExpect(jsonPath("$.results[0].dimension").value("GENDER"))
+                .andExpect(jsonPath("$.results[0].buckets[0].key").value("MALE"));
+    }
+
+    @Test
+    @DisplayName("dimensions 생략 시 전체(defaults)로 관리자 서비스를 호출한다")
+    void getStatisticsForAdmin_defaultsWhenOmitted() throws Exception {
+        given(statisticsService.getStatisticsForAdmin(eq(12L), eq(StatisticsDimension.defaults())))
+                .willReturn(sampleResponse());
+
+        mockMvc.perform(get("/api/club-apply-forms/{id}/statistics/admin", 12L)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.clubApplyFormId").value(12));
+    }
+
+    @Test
+    @DisplayName("지원하지 않는 dimension → 400")
+    void getStatisticsForAdmin_unsupportedDimension_badRequest() throws Exception {
+        mockMvc.perform(get("/api/club-apply-forms/{id}/statistics/admin", 12L)
+                        .param("dimensions", "NOT_A_DIMENSION")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error_code").value(ErrorCode.UNSUPPORTED_STATISTICS_DIMENSION.name()));
+    }
+}

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/statistics/service/StatisticsServiceImplTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/statistics/service/StatisticsServiceImplTest.java
@@ -76,6 +76,36 @@ class StatisticsServiceImplTest {
     }
 
     @Test
+    @DisplayName("관리자 조회도 존재하지 않는 지원폼이면 예외(404 매핑)")
+    void admin_notFound_throws() {
+        when(clubApplyFormRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.getStatisticsForAdmin(99L, List.of(StatisticsDimension.GENDER)))
+                .isInstanceOf(ClubApplyFormNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("관리자 조회는 마스킹 없이 집계기 원본 수치를 그대로 반환한다")
+    void admin_returnsRawAggregatedValues() {
+        ClubApplyForm form = mock(ClubApplyForm.class);
+        when(form.getId()).thenReturn(1L);
+        when(clubApplyFormRepository.findById(1L)).thenReturn(Optional.of(form));
+        when(aggregator.countApplicants(1L)).thenReturn(3L);
+        // 소수 버킷(재식별 위험)이 공개 경로에서는 마스킹 대상이 될 수 있으나 관리자 경로는 원본을 노출한다.
+        when(aggregator.aggregate(form, StatisticsDimension.GENDER)).thenReturn(List.of(
+                RawBucket.of("MALE", "남성", 2),
+                RawBucket.of("FEMALE", "여성", 1)
+        ));
+
+        StatisticsResponseDto res = service.getStatisticsForAdmin(1L, List.of(StatisticsDimension.GENDER));
+
+        assertThat(res.totalApplicants()).isEqualTo(3L);
+        assertThat(res.results().get(0).buckets())
+                .extracting(StatisticsResponseDto.Bucket::count)
+                .containsExactly(2L, 1L);
+    }
+
+    @Test
     @DisplayName("시계열(DAILY_APPLICATIONS) 버킷은 비율(ratio)을 채우지 않는다")
     void timeSeriesDimension_hasNoRatio() {
         ClubApplyForm form = mock(ClubApplyForm.class);


### PR DESCRIPTION
## 🚀 작업 내용
동아리 관리자 전용 지원자 통계 API를 추가합니다. 공개 통계(`/statistics`)는 지원자에게 노출되므로 이후 재식별 방지 마스킹·최소 공개 기준·마감 blackout이 적용되지만, 지원자를 직접 관리하는 동아리 관리자에게는 이런 제약이 불필요하므로 원본 수치를 실시간으로 반환합니다.

- **엔드포인트**: `GET /api/club-apply-forms/{clubApplyFormId}/statistics/admin`
- **인가**: 해당 동아리 `CLUB_ADMIN`/`CLUB_EXECUTIVE`만 접근 (`@PreAuthorize`)
- **집계 재사용**: 기존 `StatisticsAggregator` + `StatisticsServiceImpl.calculate()`를 그대로 재사용하고, 마스킹을 타지 않는 `getStatisticsForAdmin` 경로만 새로 분리
- 공개 통계와 응답 형태(`StatisticsResponseDto`)는 동일, 값만 원본

커밋은 관심사별로 분리했습니다.
1. 지원폼 기준 동아리 관리자 인가 검사(리포지토리 projection + `CustomSecurityService`)
2. 관리자용 무마스킹 통계 조회 서비스
3. 관리자 통계 API 컨트롤러 + 테스트

## ⏱️ 소요 시간


## 🤔 고민했던 내용
- **별도 컨트롤러로 분리**: 공개 통계 컨트롤러는 `permitAll`·비식별이라는 보안 계약을 갖습니다. 관리자 경로를 같은 컨트롤러에 두면 이 계약이 뒤섞이므로 `StatisticsAdminController`로 분리했습니다.
- **경로 설계**: 공개 permitAll 매처 `GET /api/club-apply-forms/*/statistics`는 세그먼트 하나만 매치하므로 `/statistics/admin`은 걸리지 않고 `authenticated()`로 떨어집니다. 별도 permitAll을 추가하지 않았고 SecurityConfig 변경도 없습니다.
- **집계 로직 재사용**: 관리자/공개 모두 `calculate()`(마스킹 없는 원본 조립)를 공유합니다. 이후 공개 경로에만 마스킹/캐시를 얹어도 관리자 경로는 `calculate()` 원본만 호출하므로 영향받지 않습니다.
- **현재 시점 한계**: 아직 공개 마스킹이 구현되지 않아 관리자 API와 공개 API의 반환값이 동일합니다. 다만 마스킹 도입 시 관리자 경로가 자연히 무마스킹으로 남도록 서비스 경로를 미리 분리해 둔 것입니다.

## 💬 리뷰 중점사항
- 인가 검사(`isClubAdminOrExecutiveForApplyForm`)가 기존 `isClubAdminOrExecutiveForApplication` 패턴과 일관적인지
- `/statistics/admin` 경로가 공개 permitAll 매처에 걸리지 않는다는 판단이 맞는지 (인가 테스트로 관리자 200 / 타 동아리·회원 403 / 미인증 401 검증)
- 관리자 경로가 마스킹을 타지 않도록 서비스가 분리된 구조가 적절한지

## 🔗관련 이슈
- #335


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 동아리 관리자 및 운영진이 지원폼별 지원자 통계를 조회할 수 있는 관리자용 API를 추가했습니다.
  - 조회할 통계 차원을 선택할 수 있으며, 미지정 시 기본 차원이 적용됩니다.
  - 관리자 조회에서는 원본 통계 수치와 전체 지원자 수를 확인할 수 있습니다.
  - 권한이 없거나 인증되지 않은 요청을 구분해 처리합니다.

- **테스트**
  - 권한별 접근 제어, 차원 검증, 오류 응답 및 통계 데이터 반환을 검증하는 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->