### PR TITLE
feat: 공개 통계 재식별 방지 최소 공개 기준 마스킹 (#335)

### DIFF
--- a/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/config/StatisticsConfig.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/config/StatisticsConfig.java
@@ -1,0 +1,12 @@
+package com.kakaotech.team18.backend_server.domain.statistics.config;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * 통계 도메인 설정. {@link StatisticsProperties}를 빈으로 등록한다.
+ */
+@Configuration
+@EnableConfigurationProperties(StatisticsProperties.class)
+public class StatisticsConfig {
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/config/StatisticsProperties.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/config/StatisticsProperties.java
@@ -1,0 +1,17 @@
+package com.kakaotech.team18.backend_server.domain.statistics.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.bind.DefaultValue;
+
+/**
+ * 지원자 통계 정책 설정값.
+ *
+ * @param minBucketSize 공개 통계 재식별 방지 최소 공개 기준(k). 버킷 인원이 {@code 0 < count < k}이면
+ *                      해당 버킷의 count/ratio를 마스킹한다. {@code k <= 1}이면 마스킹하지 않는다(관리자 경로).
+ *                      count가 0인 버킷(예: 시계열 zero-fill)은 식별 대상이 없으므로 마스킹하지 않는다.
+ */
+@ConfigurationProperties(prefix = "statistics")
+public record StatisticsProperties(
+        @DefaultValue("5") int minBucketSize
+) {
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/controller/StatisticsController.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/controller/StatisticsController.java
@@ -44,6 +44,8 @@ public class StatisticsController {
 
                     - `dimensions`를 생략하면 모든 항목을 반환합니다.
                     - 응답에는 지원자를 식별할 수 있는 값(이름·이메일·전화번호·6자리 학번)이 포함되지 않습니다.
+                    - 재식별 방지를 위해 인원이 최소 공개 기준 미만인 버킷은 `count`/`ratio`가 생략(마스킹)됩니다.
+                      버킷 자체는 남으므로, `count`가 없으면 '소수라 비공개'로 해석하면 됩니다.
                     """
     )
     @ApiResponses({
@@ -65,7 +67,7 @@ public class StatisticsController {
                                           "buckets": [
                                             { "key": "MALE", "label": "남성", "count": 121, "ratio": 0.565 },
                                             { "key": "FEMALE", "label": "여성", "count": 91, "ratio": 0.425 },
-                                            { "key": "UNKNOWN", "label": "미입력", "count": 2, "ratio": 0.010 }
+                                            { "key": "UNKNOWN", "label": "미입력" }
                                           ]
                                         },
                                         {
@@ -88,7 +90,7 @@ public class StatisticsController {
                                           "dimension": "DAILY_APPLICATIONS",
                                           "type": "TIME_SERIES",
                                           "buckets": [
-                                            { "key": "2026-03-02", "label": "3월 2일", "count": 4 }
+                                            { "key": "2026-03-02", "label": "3월 2일", "count": 12 }
                                           ]
                                         }
                                       ]

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/dto/StatisticsResponseDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/dto/StatisticsResponseDto.java
@@ -59,10 +59,10 @@ public record StatisticsResponseDto(
             @Schema(description = "화면 표시용 문자열", example = "남성")
             String label,
 
-            @Schema(description = "해당 버킷의 지원자 수", example = "121")
-            long count,
+            @Schema(description = "해당 버킷의 지원자 수. 재식별 방지 최소 공개 기준 미달로 마스킹되면 생략된다(null).", example = "121")
+            Long count,
 
-            @Schema(description = "전체 대비 비율(소수점 3자리 고정). 시계열 등 비율이 의미 없는 버킷에서는 생략된다.", example = "0.565")
+            @Schema(description = "전체 대비 비율(소수점 3자리 고정). 시계열 등 비율이 의미 없는 버킷이거나 마스킹된 버킷에서는 생략된다.", example = "0.565")
             BigDecimal ratio
     ) {
     }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/service/StatisticsServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/service/StatisticsServiceImpl.java
@@ -2,6 +2,7 @@ package com.kakaotech.team18.backend_server.domain.statistics.service;
 
 import com.kakaotech.team18.backend_server.domain.clubApplyForm.entity.ClubApplyForm;
 import com.kakaotech.team18.backend_server.domain.clubApplyForm.repository.ClubApplyFormRepository;
+import com.kakaotech.team18.backend_server.domain.statistics.config.StatisticsProperties;
 import com.kakaotech.team18.backend_server.domain.statistics.dto.RawBucket;
 import com.kakaotech.team18.backend_server.domain.statistics.dto.StatisticsResponseDto;
 import com.kakaotech.team18.backend_server.domain.statistics.entity.DimensionType;
@@ -32,13 +33,15 @@ public class StatisticsServiceImpl implements StatisticsService {
 
     private final ClubApplyFormRepository clubApplyFormRepository;
     private final StatisticsAggregator aggregator;
+    private final StatisticsProperties properties;
 
     @Override
     public StatisticsResponseDto getStatistics(Long clubApplyFormId, List<StatisticsDimension> dimensions) {
         ClubApplyForm form = clubApplyFormRepository.findById(clubApplyFormId)
                 .orElseThrow(() -> new ClubApplyFormNotFoundException("clubApplyFormId = " + clubApplyFormId));
 
-        return calculate(form, dimensions);
+        // 공개 통계는 재식별 방지를 위해 최소 공개 기준(k) 미만 버킷을 마스킹한다.
+        return maskSmallBuckets(calculate(form, dimensions), properties.minBucketSize());
     }
 
     @Override
@@ -74,6 +77,46 @@ public class StatisticsServiceImpl implements StatisticsService {
                 OffsetDateTime.now(KST),
                 results
         );
+    }
+
+    /**
+     * 재식별 방지 최소 공개 기준(k)을 적용해, 인원이 적은 버킷의 수치를 가립니다.
+     * <p>
+     * {@code k <= 1}이면 마스킹 없이 원본을 그대로 반환한다(관리자 경로와 동일한 무마스킹). totalApplicants는
+     * 분포가 아니므로 가리지 않는다(전체 blackout은 적용하지 않는다). 모든 dimension에 동일하게 적용한다.
+     */
+    private StatisticsResponseDto maskSmallBuckets(StatisticsResponseDto res, int k) {
+        if (k <= 1) {
+            return res;
+        }
+
+        List<StatisticsResponseDto.DimensionResult> masked = res.results().stream()
+                .map(dr -> new StatisticsResponseDto.DimensionResult(
+                        dr.dimension(),
+                        dr.type(),
+                        dr.buckets().stream().map(b -> maskBucket(b, k)).toList()
+                ))
+                .toList();
+
+        return new StatisticsResponseDto(
+                res.clubApplyFormId(),
+                res.totalApplicants(),
+                res.snapshot(),
+                res.calculatedAt(),
+                masked
+        );
+    }
+
+    /**
+     * 버킷 하나를 마스킹합니다. 인원이 {@code 0 < count < k}이면 count와 ratio를 null로 가려 코호트 규모를
+     * 노출하지 않는다. count가 0인 버킷(예: 시계열 zero-fill)은 식별 대상이 없으므로 그대로 둔다.
+     */
+    private StatisticsResponseDto.Bucket maskBucket(StatisticsResponseDto.Bucket b, int k) {
+        Long count = b.count();
+        if (count != null && count > 0 && count < k) {
+            return new StatisticsResponseDto.Bucket(b.key(), b.label(), null, null);
+        }
+        return b;
     }
 
     /**

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/statistics/controller/StatisticsAdminControllerUnitTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/statistics/controller/StatisticsAdminControllerUnitTest.java
@@ -57,7 +57,7 @@ class StatisticsAdminControllerUnitTest {
                 12L, 200L, false, OffsetDateTime.now(),
                 List.of(new DimensionResult(
                         StatisticsDimension.GENDER, DimensionType.CATEGORICAL,
-                        List.of(new Bucket("MALE", "남성", 121, new BigDecimal("0.605")))
+                        List.of(new Bucket("MALE", "남성", 121L, new BigDecimal("0.605")))
                 ))
         );
     }

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/statistics/controller/StatisticsControllerUnitTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/statistics/controller/StatisticsControllerUnitTest.java
@@ -56,7 +56,7 @@ class StatisticsControllerUnitTest {
                 12L, 200L, false, OffsetDateTime.now(),
                 List.of(new DimensionResult(
                         StatisticsDimension.GENDER, DimensionType.CATEGORICAL,
-                        List.of(new Bucket("MALE", "남성", 121, new BigDecimal("0.605")))
+                        List.of(new Bucket("MALE", "남성", 121L, new BigDecimal("0.605")))
                 ))
         );
     }

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/statistics/service/StatisticsServiceImplTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/statistics/service/StatisticsServiceImplTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.when;
 
 import com.kakaotech.team18.backend_server.domain.clubApplyForm.entity.ClubApplyForm;
 import com.kakaotech.team18.backend_server.domain.clubApplyForm.repository.ClubApplyFormRepository;
+import com.kakaotech.team18.backend_server.domain.statistics.config.StatisticsProperties;
 import com.kakaotech.team18.backend_server.domain.statistics.dto.RawBucket;
 import com.kakaotech.team18.backend_server.domain.statistics.dto.StatisticsResponseDto;
 import com.kakaotech.team18.backend_server.domain.statistics.entity.DimensionType;
@@ -21,9 +22,12 @@ import org.junit.jupiter.api.Test;
 @DisplayName("StatisticsServiceImpl - 통계 조회")
 class StatisticsServiceImplTest {
 
+    private static final int K = 5;
+
     private final ClubApplyFormRepository clubApplyFormRepository = mock(ClubApplyFormRepository.class);
     private final StatisticsAggregator aggregator = mock(StatisticsAggregator.class);
-    private final StatisticsServiceImpl service = new StatisticsServiceImpl(clubApplyFormRepository, aggregator);
+    private final StatisticsServiceImpl service =
+            new StatisticsServiceImpl(clubApplyFormRepository, aggregator, new StatisticsProperties(K));
 
     @Test
     @DisplayName("존재하지 않는 지원폼이면 예외(404 매핑)")
@@ -122,5 +126,69 @@ class StatisticsServiceImplTest {
         assertThat(daily.type()).isEqualTo(DimensionType.TIME_SERIES);
         assertThat(daily.buckets()).hasSize(1);
         assertThat(daily.buckets().get(0).ratio()).isNull();
+    }
+
+    @Test
+    @DisplayName("공개 조회는 인원이 k 미만인 버킷의 count/ratio를 마스킹(null)하고, k 이상은 그대로 둔다")
+    void publicView_masksBucketsBelowThreshold() {
+        ClubApplyForm form = mock(ClubApplyForm.class);
+        when(form.getId()).thenReturn(1L);
+        when(clubApplyFormRepository.findById(1L)).thenReturn(Optional.of(form));
+        when(aggregator.countApplicants(1L)).thenReturn(100L);
+        when(aggregator.aggregate(form, StatisticsDimension.GENDER)).thenReturn(List.of(
+                RawBucket.of("MALE", "남성", 97),   // k 이상 → 노출
+                RawBucket.of("FEMALE", "여성", 3)   // 0 < count < k → 마스킹
+        ));
+
+        StatisticsResponseDto res = service.getStatistics(1L, List.of(StatisticsDimension.GENDER));
+
+        List<StatisticsResponseDto.Bucket> buckets = res.results().get(0).buckets();
+        // 버킷 자체는 남기되(요청 항목 존재 신호 유지) 소수 버킷의 수치만 가린다.
+        assertThat(buckets).hasSize(2);
+        StatisticsResponseDto.Bucket male = buckets.get(0);
+        StatisticsResponseDto.Bucket female = buckets.get(1);
+
+        assertThat(male.count()).isEqualTo(97L);
+        assertThat(male.ratio()).isEqualTo(new BigDecimal("0.970"));
+
+        assertThat(female.key()).isEqualTo("FEMALE");
+        assertThat(female.label()).isEqualTo("여성");
+        assertThat(female.count()).isNull();
+        assertThat(female.ratio()).isNull();
+    }
+
+    @Test
+    @DisplayName("count가 0인 버킷(시계열 zero-fill 등)은 식별 대상이 없어 마스킹하지 않는다")
+    void publicView_doesNotMaskZeroCountBuckets() {
+        ClubApplyForm form = mock(ClubApplyForm.class);
+        when(form.getId()).thenReturn(1L);
+        when(clubApplyFormRepository.findById(1L)).thenReturn(Optional.of(form));
+        when(aggregator.countApplicants(1L)).thenReturn(10L);
+        when(aggregator.aggregate(form, StatisticsDimension.DAILY_APPLICATIONS)).thenReturn(List.of(
+                RawBucket.of("2026-03-02", "3월 2일", 0)
+        ));
+
+        StatisticsResponseDto res = service.getStatistics(1L, List.of(StatisticsDimension.DAILY_APPLICATIONS));
+
+        assertThat(res.results().get(0).buckets().get(0).count()).isZero();
+    }
+
+    @Test
+    @DisplayName("관리자 조회는 k와 무관하게 소수 버킷도 마스킹하지 않는다")
+    void adminView_doesNotMaskSmallBuckets() {
+        ClubApplyForm form = mock(ClubApplyForm.class);
+        when(form.getId()).thenReturn(1L);
+        when(clubApplyFormRepository.findById(1L)).thenReturn(Optional.of(form));
+        when(aggregator.countApplicants(1L)).thenReturn(100L);
+        when(aggregator.aggregate(form, StatisticsDimension.GENDER)).thenReturn(List.of(
+                RawBucket.of("MALE", "남성", 97),
+                RawBucket.of("FEMALE", "여성", 3)
+        ));
+
+        StatisticsResponseDto res = service.getStatisticsForAdmin(1L, List.of(StatisticsDimension.GENDER));
+
+        assertThat(res.results().get(0).buckets())
+                .extracting(StatisticsResponseDto.Bucket::count)
+                .containsExactly(97L, 3L);
     }
 }


### PR DESCRIPTION
## 🚀 작업 내용
공개 통계에 **재식별 방지 최소 공개 기준(k) 마스킹**을 적용합니다. 인원이 적은 버킷은 소수 코호트라 재식별 위험이 있어, 공개 응답에서 해당 버킷의 수치를 가립니다. 지원자를 직접 관리하는 관리자 통계(#349)는 이 제약 없이 원본을 그대로 봅니다.

- **마스킹 규칙**: 버킷 인원이 `0 < count < k`이면 `count`/`ratio`를 `null`로 가림 → `@JsonInclude(NON_NULL)`로 JSON에서 생략. **버킷 자체는 남겨** '요청 항목은 존재하나 소수라 비공개'를 구분 가능하게 함.
- `count == 0` 버킷(시계열 zero-fill 등)은 식별 대상이 없으므로 **가리지 않음**.
- **적용 범위**: 모든 dimension (GENDER·FACULTY·ADMISSION_YEAR·DAILY_APPLICATIONS).
- **관리자 경로**: `getStatisticsForAdmin`은 마스킹을 타지 않음(사실상 k=1). 공개 경로만 `maskSmallBuckets`를 거침.
- **임계값 k**: `StatisticsProperties.min-bucket-size`로 외부 설정, 기본 **5**.

커밋은 관심사별로 분리했습니다.
1. 최소 공개 기준 설정값(`StatisticsProperties`) 추가
2. 공개 통계 마스킹 적용(DTO nullable + 서비스 + 테스트 + Swagger)

> ⚠️ `application.yml`은 리포지토리에서 `.gitignore` 대상이라(배포 시 `APPLICATION_YML` 시크릿으로 주입) 이 PR에는 포함되지 않았습니다. 기본값은 record의 `@DefaultValue("5")`로 보장되며, 운영에서 k를 바꾸려면 시크릿 yml에 `statistics.min-bucket-size`를 추가하면 됩니다.

## ⏱️ 소요 시간


## 🤔 고민했던 내용
- **버킷 제거 대신 count=null 마스킹**: 버킷을 아예 드롭하면 `buckets` 합이 `totalApplicants`와 안 맞고, '항목 없음'과 '소수라 비공개'가 구분되지 않습니다. 그래서 버킷·라벨은 남기고 수치만 가렸습니다. `ratio`도 함께 null로 둬야 `count = ratio × total`로 역산되지 않습니다.
- **count=0은 미마스킹**: 0명은 식별할 대상이 없어 위험이 없고, 시계열 zero-fill의 '그날 지원 0건' 같은 정보는 그대로 보여주는 게 유용합니다. 그래서 마스킹 조건을 `count < k`가 아니라 `0 < count < k`로 뒀고, 덕분에 관리자 경로의 k=1도 자연스러운 무마스킹이 됩니다.
- **calculate() 원본 보존**: 집계·조립을 담당하는 `calculate()`는 마스킹하지 않고, 공개 경로에서만 그 위에 `maskSmallBuckets`를 얹었습니다. 관리자/사전계산 경로가 같은 원본을 공유하도록 하기 위함입니다.
- **전체 blackout 미적용**: 전체 지원자가 극소수여도 별도 전체 감춤은 넣지 않았습니다. 그 경우 모든 버킷이 자연히 소수라 버킷 단위 마스킹으로 수치가 가려집니다.

## 💬 리뷰 중점사항
- **보완적 노출(뺄셈 역산) 한계**: 한 dimension에서 마스킹된 버킷이 하나뿐이고 나머지가 공개되면, `total − 공개합`으로 가려진 값을 근사 역산할 수 있습니다(예: total=100, 공개 97 → 가린 값 ≈ 3). 정통 통계 공개에서는 이럴 때 2차 억제(다음으로 작은 버킷도 마스킹)를 쓰지만, 큰 버킷까지 가리면 데이터 유용성이 크게 떨어져 이번엔 **1차 마스킹만** 넣었습니다. 이 잔여 위험을 어느 수준까지 막을지(2차 억제 도입 여부, 또는 total도 함께 가릴지)는 정책 판단이라 별도로 논의하고 싶습니다.
- 마스킹 조건(`0 < count < k`)과 적용 범위(모든 dimension)가 의도와 맞는지
- 관리자 경로가 마스킹을 확실히 우회하는지(서비스 테스트로 검증)

## 🔗관련 이슈
- #335


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 공개 통계에서 소수 인원 버킷의 인원 수와 비율을 마스킹합니다.
  * 기준 미만 버킷은 유지하되 해당 수치를 생략해 개인정보 노출을 줄입니다.
  * 관리자 통계에서는 기존처럼 전체 집계 수치를 확인할 수 있습니다.

* **문서**
  * 통계 API 설명과 응답 예시에 마스킹 정책을 반영했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->