### PR TITLE
feat: 공개 통계 재식별 방지 최소 공개 기준(총합) 비공개 처리 (#335)

### DIFF
--- a/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/config/StatisticsConfig.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/config/StatisticsConfig.java
@@ -1,0 +1,12 @@
+package com.kakaotech.team18.backend_server.domain.statistics.config;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * 통계 도메인 설정. {@link StatisticsProperties}를 빈으로 등록한다.
+ */
+@Configuration
+@EnableConfigurationProperties(StatisticsProperties.class)
+public class StatisticsConfig {
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/config/StatisticsProperties.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/config/StatisticsProperties.java
@@ -1,0 +1,17 @@
+package com.kakaotech.team18.backend_server.domain.statistics.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.bind.DefaultValue;
+
+/**
+ * 지원자 통계 정책 설정값.
+ *
+ * @param minTotalApplicants 공개 통계 재식별 방지 최소 공개 기준. 전체 지원자 수가 이 값 미만이면 분포가 소수라
+ *                           재식별 위험이 커지므로 공개 통계를 비공개(masked) 처리한다. 관리자 통계는 이 값과
+ *                           무관하게 원본을 노출한다. 기준은 전체 지원자 수에만 걸리고 개별 버킷에는 걸지 않는다.
+ */
+@ConfigurationProperties(prefix = "statistics")
+public record StatisticsProperties(
+        @DefaultValue("3") int minTotalApplicants
+) {
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/controller/StatisticsController.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/controller/StatisticsController.java
@@ -44,6 +44,9 @@ public class StatisticsController {
 
                     - `dimensions`를 생략하면 모든 항목을 반환합니다.
                     - 응답에는 지원자를 식별할 수 있는 값(이름·이메일·전화번호·6자리 학번)이 포함되지 않습니다.
+                    - 재식별 방지를 위해 **전체 지원자 수가 최소 공개 기준 미만이면** 분포를 비공개합니다.
+                      이때 `masked=true`, `results=[]`로 내려갑니다. 이는 다음과 구분됩니다:
+                      `masked=true`(소수라 비공개) vs 버킷 `count:0`(실제 0명) vs `미입력` 버킷(값 미기입).
                     """
     )
     @ApiResponses({
@@ -52,11 +55,13 @@ public class StatisticsController {
                     description = "조회 성공",
                     content = @Content(
                             schema = @Schema(implementation = StatisticsResponseDto.class),
-                            examples = @ExampleObject(name = "모집 진행 중", value = """
+                            examples = {
+                                    @ExampleObject(name = "모집 진행 중", value = """
                                     {
                                       "clubApplyFormId": 12,
                                       "totalApplicants": 214,
                                       "snapshot": false,
+                                      "masked": false,
                                       "calculatedAt": "2026-03-14T23:59:30+09:00",
                                       "results": [
                                         {
@@ -88,12 +93,23 @@ public class StatisticsController {
                                           "dimension": "DAILY_APPLICATIONS",
                                           "type": "TIME_SERIES",
                                           "buckets": [
-                                            { "key": "2026-03-02", "label": "3월 2일", "count": 4 }
+                                            { "key": "2026-03-02", "label": "3월 2일", "count": 12 }
                                           ]
                                         }
                                       ]
                                     }
+                                    """),
+                                    @ExampleObject(name = "최소 공개 기준 미달(비공개)", value = """
+                                    {
+                                      "clubApplyFormId": 12,
+                                      "totalApplicants": 2,
+                                      "snapshot": false,
+                                      "masked": true,
+                                      "calculatedAt": "2026-03-14T23:59:30+09:00",
+                                      "results": []
+                                    }
                                     """)
+                            }
                     )
             ),
             @ApiResponse(responseCode = "400", description = "지원하지 않는 dimension", content = @Content),

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/dto/StatisticsResponseDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/dto/StatisticsResponseDto.java
@@ -27,10 +27,16 @@ public record StatisticsResponseDto(
         @Schema(description = "모집 종료 후 확정된 스냅샷이면 true, 진행 중 집계본이면 false", example = "false")
         boolean snapshot,
 
+        @Schema(description = """
+                재식별 방지 최소 공개 기준(전체 지원자 수)에 미달해 분포를 비공개 처리했으면 true.
+                true이면 results는 빈 배열이다. '지원자 0명'(results는 존재하고 버킷 count가 0)과는 구분된다.""",
+                example = "false")
+        boolean masked,
+
         @Schema(description = "집계가 수행된 시각", example = "2026-03-14T23:59:30+09:00")
         OffsetDateTime calculatedAt,
 
-        @Schema(description = "dimension별 집계 결과. 최소 공개 기준에 미달하면 빈 배열이다.")
+        @Schema(description = "dimension별 집계 결과. 최소 공개 기준에 미달(masked=true)하면 빈 배열이다.")
         List<DimensionResult> results
 ) {
 
@@ -59,7 +65,7 @@ public record StatisticsResponseDto(
             @Schema(description = "화면 표시용 문자열", example = "남성")
             String label,
 
-            @Schema(description = "해당 버킷의 지원자 수", example = "121")
+            @Schema(description = "해당 버킷의 지원자 수. 0이면 실제로 0명임을 뜻한다(비공개와 구분).", example = "121")
             long count,
 
             @Schema(description = "전체 대비 비율(소수점 3자리 고정). 시계열 등 비율이 의미 없는 버킷에서는 생략된다.", example = "0.565")

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/service/StatisticsServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/service/StatisticsServiceImpl.java
@@ -2,6 +2,7 @@ package com.kakaotech.team18.backend_server.domain.statistics.service;
 
 import com.kakaotech.team18.backend_server.domain.clubApplyForm.entity.ClubApplyForm;
 import com.kakaotech.team18.backend_server.domain.clubApplyForm.repository.ClubApplyFormRepository;
+import com.kakaotech.team18.backend_server.domain.statistics.config.StatisticsProperties;
 import com.kakaotech.team18.backend_server.domain.statistics.dto.RawBucket;
 import com.kakaotech.team18.backend_server.domain.statistics.dto.StatisticsResponseDto;
 import com.kakaotech.team18.backend_server.domain.statistics.entity.DimensionType;
@@ -32,11 +33,19 @@ public class StatisticsServiceImpl implements StatisticsService {
 
     private final ClubApplyFormRepository clubApplyFormRepository;
     private final StatisticsAggregator aggregator;
+    private final StatisticsProperties properties;
 
     @Override
     public StatisticsResponseDto getStatistics(Long clubApplyFormId, List<StatisticsDimension> dimensions) {
         ClubApplyForm form = clubApplyFormRepository.findById(clubApplyFormId)
                 .orElseThrow(() -> new ClubApplyFormNotFoundException("clubApplyFormId = " + clubApplyFormId));
+
+        // 공개 통계는 재식별 방지를 위해 전체 지원자 수가 최소 공개 기준 미만이면 분포를 비공개(masked)한다.
+        // 기준은 전체 지원자 수에만 걸리고 개별 버킷에는 걸지 않는다(그래야 버킷 간 뺄셈 역산 문제가 없다).
+        long totalApplicants = aggregator.countApplicants(form.getId());
+        if (totalApplicants < properties.minTotalApplicants()) {
+            return maskedResponse(form.getId(), totalApplicants);
+        }
 
         return calculate(form, dimensions);
     }
@@ -71,8 +80,26 @@ public class StatisticsServiceImpl implements StatisticsService {
                 form.getId(),
                 totalApplicants,
                 false,
+                false,
                 OffsetDateTime.now(KST),
                 results
+        );
+    }
+
+    /**
+     * 최소 공개 기준 미달로 분포를 비공개 처리한 응답을 만듭니다.
+     * <p>
+     * {@code masked=true}와 빈 results로, '지원자가 적어 비공개'임을 '지원자 0명'(results가 있고 버킷 count가 0)과
+     * 구분해 알린다. totalApplicants는 분포가 아니므로 그대로 노출한다.
+     */
+    private StatisticsResponseDto maskedResponse(Long clubApplyFormId, long totalApplicants) {
+        return new StatisticsResponseDto(
+                clubApplyFormId,
+                totalApplicants,
+                false,
+                true,
+                OffsetDateTime.now(KST),
+                List.of()
         );
     }
 

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/service/StatisticsServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/service/StatisticsServiceImpl.java
@@ -17,12 +17,15 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
+// 최소 공개 기준 판정(지원자 수)과 dimension 집계가 같은 스냅샷을 보도록 반복 읽기로 고정한다.
+// 운영 MySQL(InnoDB)은 기본이 REPEATABLE_READ지만, DB 기본값에 의존하지 않고 요구사항을 명시한다.
+@Transactional(readOnly = true, isolation = Isolation.REPEATABLE_READ)
 public class StatisticsServiceImpl implements StatisticsService {
 
     /** 모든 일자·시각 집계의 기준 시간대. */
@@ -42,12 +45,13 @@ public class StatisticsServiceImpl implements StatisticsService {
 
         // 공개 통계는 재식별 방지를 위해 전체 지원자 수가 최소 공개 기준 미만이면 분포를 비공개(masked)한다.
         // 기준은 전체 지원자 수에만 걸리고 개별 버킷에는 걸지 않는다(그래야 버킷 간 뺄셈 역산 문제가 없다).
+        // 지원자 수를 한 번만 읽어 기준 판정과 집계가 같은 값을 쓰도록 calculate에 그대로 넘긴다.
         long totalApplicants = aggregator.countApplicants(form.getId());
         if (totalApplicants < properties.minTotalApplicants()) {
             return maskedResponse(form.getId(), totalApplicants);
         }
 
-        return calculate(form, dimensions);
+        return calculate(form, dimensions, totalApplicants);
     }
 
     @Override
@@ -66,8 +70,15 @@ public class StatisticsServiceImpl implements StatisticsService {
      * 조회 경로와 스케줄러 사전 계산 경로가 같은 결과를 내도록 이 메서드를 공유한다.
      */
     public StatisticsResponseDto calculate(ClubApplyForm form, List<StatisticsDimension> dimensions) {
-        long totalApplicants = aggregator.countApplicants(form.getId());
+        return calculate(form, dimensions, aggregator.countApplicants(form.getId()));
+    }
 
+    /**
+     * 이미 읽어둔 전체 지원자 수로 통계를 집계합니다.
+     * <p>
+     * 호출부가 최소 공개 기준 판정에 쓴 값과 동일한 지원자 수를 넘겨, 판정과 집계가 같은 스냅샷을 쓰도록 한다.
+     */
+    public StatisticsResponseDto calculate(ClubApplyForm form, List<StatisticsDimension> dimensions, long totalApplicants) {
         List<StatisticsResponseDto.DimensionResult> results = new ArrayList<>();
         for (StatisticsDimension dimension : dimensions) {
             // 지원자가 없으면 버킷은 빈 배열이 된다. dimension 자체는 응답에 그대로 남겨,

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/statistics/controller/StatisticsAdminControllerAuthTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/statistics/controller/StatisticsAdminControllerAuthTest.java
@@ -49,7 +49,7 @@ class StatisticsAdminControllerAuthTest {
         // 12번 지원폼은 1번 동아리 소속이라고 가정한다.
         given(clubApplyFormRepository.findClubIdByClubApplyFormId(12L)).willReturn(Optional.of(1L));
         given(statisticsService.getStatisticsForAdmin(any(), any()))
-                .willReturn(new StatisticsResponseDto(12L, 0L, false, OffsetDateTime.now(), List.of()));
+                .willReturn(new StatisticsResponseDto(12L, 0L, false, false, OffsetDateTime.now(), List.of()));
     }
 
     @Test

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/statistics/controller/StatisticsAdminControllerUnitTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/statistics/controller/StatisticsAdminControllerUnitTest.java
@@ -54,10 +54,10 @@ class StatisticsAdminControllerUnitTest {
 
     private StatisticsResponseDto sampleResponse() {
         return new StatisticsResponseDto(
-                12L, 200L, false, OffsetDateTime.now(),
+                12L, 200L, false, false, OffsetDateTime.now(),
                 List.of(new DimensionResult(
                         StatisticsDimension.GENDER, DimensionType.CATEGORICAL,
-                        List.of(new Bucket("MALE", "남성", 121, new BigDecimal("0.605")))
+                        List.of(new Bucket("MALE", "남성", 121L, new BigDecimal("0.605")))
                 ))
         );
     }

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/statistics/controller/StatisticsControllerAuthTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/statistics/controller/StatisticsControllerAuthTest.java
@@ -38,7 +38,7 @@ class StatisticsControllerAuthTest {
     @DisplayName("통계 조회는 비로그인 상태에서도 200 (permitAll)")
     void getStatistics_isPublic() throws Exception {
         given(statisticsService.getStatistics(any(), any()))
-                .willReturn(new StatisticsResponseDto(12L, 0L, false, OffsetDateTime.now(), List.of()));
+                .willReturn(new StatisticsResponseDto(12L, 0L, false, false, OffsetDateTime.now(), List.of()));
 
         mockMvc.perform(get("/api/club-apply-forms/{id}/statistics", 12L))
                 .andExpect(status().isOk());

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/statistics/controller/StatisticsControllerUnitTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/statistics/controller/StatisticsControllerUnitTest.java
@@ -53,10 +53,10 @@ class StatisticsControllerUnitTest {
 
     private StatisticsResponseDto sampleResponse() {
         return new StatisticsResponseDto(
-                12L, 200L, false, OffsetDateTime.now(),
+                12L, 200L, false, false, OffsetDateTime.now(),
                 List.of(new DimensionResult(
                         StatisticsDimension.GENDER, DimensionType.CATEGORICAL,
-                        List.of(new Bucket("MALE", "남성", 121, new BigDecimal("0.605")))
+                        List.of(new Bucket("MALE", "남성", 121L, new BigDecimal("0.605")))
                 ))
         );
     }

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/statistics/service/StatisticsServiceImplTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/statistics/service/StatisticsServiceImplTest.java
@@ -2,11 +2,15 @@ package com.kakaotech.team18.backend_server.domain.statistics.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.kakaotech.team18.backend_server.domain.clubApplyForm.entity.ClubApplyForm;
 import com.kakaotech.team18.backend_server.domain.clubApplyForm.repository.ClubApplyFormRepository;
+import com.kakaotech.team18.backend_server.domain.statistics.config.StatisticsProperties;
 import com.kakaotech.team18.backend_server.domain.statistics.dto.RawBucket;
 import com.kakaotech.team18.backend_server.domain.statistics.dto.StatisticsResponseDto;
 import com.kakaotech.team18.backend_server.domain.statistics.entity.DimensionType;
@@ -21,9 +25,13 @@ import org.junit.jupiter.api.Test;
 @DisplayName("StatisticsServiceImpl - 통계 조회")
 class StatisticsServiceImplTest {
 
+    /** 공개 최소 공개 기준: 전체 지원자 수가 이 값 미만이면 비공개. */
+    private static final int MIN_TOTAL = 3;
+
     private final ClubApplyFormRepository clubApplyFormRepository = mock(ClubApplyFormRepository.class);
     private final StatisticsAggregator aggregator = mock(StatisticsAggregator.class);
-    private final StatisticsServiceImpl service = new StatisticsServiceImpl(clubApplyFormRepository, aggregator);
+    private final StatisticsServiceImpl service =
+            new StatisticsServiceImpl(clubApplyFormRepository, aggregator, new StatisticsProperties(MIN_TOTAL));
 
     @Test
     @DisplayName("존재하지 않는 지원폼이면 예외(404 매핑)")
@@ -51,6 +59,7 @@ class StatisticsServiceImplTest {
         assertThat(res.clubApplyFormId()).isEqualTo(1L);
         assertThat(res.totalApplicants()).isEqualTo(200L);
         assertThat(res.snapshot()).isFalse();
+        assertThat(res.masked()).isFalse();
         assertThat(res.results()).hasSize(1);
 
         StatisticsResponseDto.DimensionResult gender = res.results().get(0);
@@ -60,19 +69,40 @@ class StatisticsServiceImplTest {
     }
 
     @Test
-    @DisplayName("지원자가 0명이면 빈 버킷과 totalApplicants=0을 반환한다")
-    void zeroApplicants_emptyButDimensionKept() {
+    @DisplayName("공개 조회: 전체 지원자가 최소 공개 기준 미만이면 masked=true·빈 results로 비공개한다")
+    void publicView_belowMinTotal_masked() {
         ClubApplyForm form = mock(ClubApplyForm.class);
         when(form.getId()).thenReturn(1L);
         when(clubApplyFormRepository.findById(1L)).thenReturn(Optional.of(form));
-        when(aggregator.countApplicants(1L)).thenReturn(0L);
-        when(aggregator.aggregate(form, StatisticsDimension.GENDER)).thenReturn(List.of());
+        when(aggregator.countApplicants(1L)).thenReturn(2L); // < MIN_TOTAL(3)
 
         StatisticsResponseDto res = service.getStatistics(1L, List.of(StatisticsDimension.GENDER));
 
-        assertThat(res.totalApplicants()).isZero();
-        assertThat(res.results()).hasSize(1);
-        assertThat(res.results().get(0).buckets()).isEmpty();
+        assertThat(res.masked()).isTrue();
+        assertThat(res.results()).isEmpty();
+        assertThat(res.totalApplicants()).isEqualTo(2L); // 분포가 아니므로 전체 수는 노출
+        // 비공개면 dimension 집계까지 갈 필요가 없다.
+        verify(aggregator, never()).aggregate(any(), any());
+    }
+
+    @Test
+    @DisplayName("공개 조회: 전체 지원자가 기준 이상이면 masked=false로 정상 노출한다(경계값)")
+    void publicView_atMinTotal_notMasked() {
+        ClubApplyForm form = mock(ClubApplyForm.class);
+        when(form.getId()).thenReturn(1L);
+        when(clubApplyFormRepository.findById(1L)).thenReturn(Optional.of(form));
+        when(aggregator.countApplicants(1L)).thenReturn(3L); // == MIN_TOTAL(3) → 공개
+        when(aggregator.aggregate(form, StatisticsDimension.GENDER)).thenReturn(List.of(
+                RawBucket.of("MALE", "남성", 2),
+                RawBucket.of("FEMALE", "여성", 1)
+        ));
+
+        StatisticsResponseDto res = service.getStatistics(1L, List.of(StatisticsDimension.GENDER));
+
+        assertThat(res.masked()).isFalse();
+        assertThat(res.results().get(0).buckets())
+                .extracting(StatisticsResponseDto.Bucket::count)
+                .containsExactly(2L, 1L);
     }
 
     @Test
@@ -85,24 +115,24 @@ class StatisticsServiceImplTest {
     }
 
     @Test
-    @DisplayName("관리자 조회는 마스킹 없이 집계기 원본 수치를 그대로 반환한다")
-    void admin_returnsRawAggregatedValues() {
+    @DisplayName("관리자 조회는 최소 공개 기준 미만이어도 비공개하지 않고 원본을 그대로 반환한다")
+    void admin_returnsRawEvenBelowMinTotal() {
         ClubApplyForm form = mock(ClubApplyForm.class);
         when(form.getId()).thenReturn(1L);
         when(clubApplyFormRepository.findById(1L)).thenReturn(Optional.of(form));
-        when(aggregator.countApplicants(1L)).thenReturn(3L);
-        // 소수 버킷(재식별 위험)이 공개 경로에서는 마스킹 대상이 될 수 있으나 관리자 경로는 원본을 노출한다.
+        when(aggregator.countApplicants(1L)).thenReturn(2L); // < MIN_TOTAL(3)이지만 관리자는 무관
         when(aggregator.aggregate(form, StatisticsDimension.GENDER)).thenReturn(List.of(
-                RawBucket.of("MALE", "남성", 2),
+                RawBucket.of("MALE", "남성", 1),
                 RawBucket.of("FEMALE", "여성", 1)
         ));
 
         StatisticsResponseDto res = service.getStatisticsForAdmin(1L, List.of(StatisticsDimension.GENDER));
 
-        assertThat(res.totalApplicants()).isEqualTo(3L);
+        assertThat(res.masked()).isFalse();
+        assertThat(res.totalApplicants()).isEqualTo(2L);
         assertThat(res.results().get(0).buckets())
                 .extracting(StatisticsResponseDto.Bucket::count)
-                .containsExactly(2L, 1L);
+                .containsExactly(1L, 1L);
     }
 
     @Test
@@ -122,5 +152,22 @@ class StatisticsServiceImplTest {
         assertThat(daily.type()).isEqualTo(DimensionType.TIME_SERIES);
         assertThat(daily.buckets()).hasSize(1);
         assertThat(daily.buckets().get(0).ratio()).isNull();
+    }
+
+    @Test
+    @DisplayName("공개 조회(기준 이상): count가 0인 버킷은 실제 0으로 노출되어 '비공개(masked)'와 구분된다")
+    void publicView_zeroCountBucketIsDistinctFromMasked() {
+        ClubApplyForm form = mock(ClubApplyForm.class);
+        when(form.getId()).thenReturn(1L);
+        when(clubApplyFormRepository.findById(1L)).thenReturn(Optional.of(form));
+        when(aggregator.countApplicants(1L)).thenReturn(10L); // >= MIN_TOTAL → 공개
+        when(aggregator.aggregate(form, StatisticsDimension.DAILY_APPLICATIONS)).thenReturn(List.of(
+                RawBucket.of("2026-03-02", "3월 2일", 0)
+        ));
+
+        StatisticsResponseDto res = service.getStatistics(1L, List.of(StatisticsDimension.DAILY_APPLICATIONS));
+
+        assertThat(res.masked()).isFalse();
+        assertThat(res.results().get(0).buckets().get(0).count()).isZero();
     }
 }


### PR DESCRIPTION
## 🚀 작업 내용
공개 통계에 **재식별 방지 최소 공개 기준**을 적용합니다. 기준은 **전체 지원자 수**에만 걸리며(개별 버킷 아님), 전체 지원자가 기준 미만이면 분포가 소수라 재식별 위험이 커지므로 공개 통계를 **비공개(masked)** 처리합니다. 지원자를 직접 관리하는 관리자 통계(#349)는 이 기준과 무관하게 원본을 그대로 봅니다.

- **판정 기준**: `전체 지원자 수 < min-total-applicants`(기본 **3**) → 비공개
- **비공개 응답**: `masked=true` + `results=[]`. 이때 dimension 집계 쿼리도 생략합니다.
- **관리자 경로**: `getStatisticsForAdmin`은 비공개하지 않음(원본 노출).
- **집계 재사용**: `calculate()`(원본 조립)는 그대로 두고, 공개 경로만 앞단에서 총합 기준을 검사합니다.

**세 상태를 클라이언트가 명확히 구분**할 수 있게 했습니다.
| 상태 | 표현 |
|---|---|
| 소수라 비공개 | `masked: true`, `results: []` |
| 실제 0명 | 버킷 `count: 0` (예: 시계열 그날 0건) |
| 값 미기입 | `미입력(UNKNOWN)` 버킷 |

커밋은 관심사별로 분리했습니다.
1. 최소 공개 기준 설정값(`StatisticsProperties`) 추가
2. 공개 통계 총합 기준 비공개 처리 (DTO `masked` + 서비스 + Swagger + 테스트)

> ⚠️ `application.yml`은 `.gitignore` 대상이라(배포 시 `APPLICATION_YML` 시크릿으로 주입) 이 PR에 포함되지 않습니다. 기본값은 `@DefaultValue("3")`으로 보장되며, 운영에서 바꾸려면 시크릿 yml에 `statistics.min-total-applicants`를 추가하면 됩니다.

## ⏱️ 소요 시간


## 🤔 고민했던 내용
- **총합 기준 vs 버킷별 마스킹**: 처음엔 버킷별(`0<count<k`)로 접근했다가, 한 dimension에서 소수 버킷이 하나만 가려지면 `total − 공개합`으로 그 값이 역산되는 문제가 있었습니다. 기준을 **전체 지원자 수**에만 걸면(계약 DTO도 "최소 공개 기준 미달 시 빈 배열"로 이미 명시) 특정 버킷만 가려지는 일이 없어 역산 문제가 원천적으로 사라집니다. 그래서 총합 기준으로 확정했습니다.
- **`masked` 플래그 도입**: '소수라 비공개'와 '실제 0명', '값 미기입'을 응답에서 뭉개지 않으려면 별도 신호가 필요합니다. `count`를 null로 가리는 방식은 이 셋을 구분 못 해서, 대신 top-level `masked` 불리언으로 비공개를 명시했습니다. `Bucket.count`는 `long` 그대로입니다.
- **비공개 시 total 노출**: 분포만 가리고 `totalApplicants`는 그대로 둡니다(전체 수 자체는 분포가 아니라 재식별 위험이 낮고, '아직 지원자가 적음' 신호로 유용). 필요하면 이후 조정 가능합니다.

## 💬 리뷰 중점사항
- 판정 기준(전체 지원자 수 < 3)과 비공개 응답 형태(`masked=true`, `results=[]`)가 의도와 맞는지
- 세 상태(비공개 / 실제 0 / 미입력)가 응답에서 잘 구분되는지
- 관리자 경로가 기준과 무관하게 원본을 노출하는지(서비스 테스트로 검증)

## 🔗관련 이슈
- #335


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 공개 통계 조회에 최소 지원자 수 기준을 적용했습니다.
  * 기준 미달 시 `masked=true`와 빈 결과를 반환해 통계가 보호됩니다.
  * 기준값을 설정으로 관리할 수 있습니다.
  * 관리자 통계 조회는 기존처럼 전체 결과를 제공합니다.

* **문서**
  * 통계 API 응답 및 Swagger 예시에 마스킹 상태와 결과 차이를 명확히 안내했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->