### PR TITLE
refactor: 공개 통계 컨트롤러 dimension 파싱을 공용 헬퍼로 일원화 (#335)

### DIFF
--- a/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/controller/StatisticsController.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/controller/StatisticsController.java
@@ -108,26 +108,11 @@ public class StatisticsController {
                     example = "GENDER,FACULTY")
             @RequestParam(name = "dimensions", required = false) List<String> dimensions
     ) {
-        List<StatisticsDimension> requested = resolveDimensions(dimensions);
+        // 관리자 컨트롤러와 동일하게 dimension 파싱은 StatisticsDimension.resolve()로 일원화한다.
+        List<StatisticsDimension> requested = StatisticsDimension.resolve(dimensions);
 
         log.info("지원자 통계 조회 clubApplyFormId={}, dimensions={}", clubApplyFormId, requested);
 
         return ResponseEntity.ok(statisticsService.getStatistics(clubApplyFormId, requested));
-    }
-
-    /**
-     * 쿼리 파라미터를 dimension 목록으로 변환합니다. 지정하지 않으면 전체를 조회합니다.
-     * <p>
-     * 문자열을 직접 파싱하는 이유는, 정의되지 않은 값이 들어왔을 때 사용 가능한 목록까지 담은 400을 돌려주기
-     * 위해서다. 컨트롤러 파라미터를 Enum으로 바로 바인딩하면 어떤 값이 왜 틀렸는지 알기 어렵다.
-     */
-    private List<StatisticsDimension> resolveDimensions(List<String> raw) {
-        if (raw == null || raw.isEmpty()) {
-            return StatisticsDimension.defaults();
-        }
-        return raw.stream()
-                .map(StatisticsDimension::from)
-                .distinct()
-                .toList();
     }
 }


### PR DESCRIPTION
## 🚀 작업 내용
공개 통계 컨트롤러(`StatisticsController`)의 dimension 파싱 중복을 제거합니다.

관리자 통계 API(#349)를 추가하면서 파싱 로직을 `StatisticsDimension.resolve()`로 뽑아 재사용하도록 했는데, 공개 컨트롤러는 동일 로직을 `private resolveDimensions()`로 그대로 남겨두어 **같은 코드가 두 벌** 존재하고 있었습니다. 공개 컨트롤러도 `resolve()`를 쓰도록 바꾸고 private 메서드를 삭제해, 관리자/공개가 같은 경로로 파싱하게 통일합니다.

## ⏱️ 소요 시간


## 🤔 고민했던 내용
- **동작 동일성**: 두 로직은 글자까지 동일했습니다(미지정 시 `defaults()`, 그 외 `map(from).distinct().toList()`). `resolve()`도 내부적으로 `from()`을 거치므로, 미정의 dimension에 대한 400(사용 가능 목록 포함)과 미지정 시 전체 반환이 그대로 유지됩니다.
- private 메서드 javadoc이 설명하던 "왜 문자열을 직접 파싱하는가(Enum 직접 바인딩 대신 친절한 400을 주려고)" 근거는 `resolve()`→`from()` 경로에 그대로 살아 있어, 설명 손실 없이 제거했습니다.

## 💬 리뷰 중점사항
- 공개/관리자 컨트롤러가 이제 같은 `StatisticsDimension.resolve()`로 파싱하는지
- 기존 컨트롤러 테스트(기본값·400)가 그대로 통과하는지

## 🔗관련 이슈
- #335


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선**
  - 통계 조회 요청의 차원 값 해석 방식이 일관되도록 정리되었습니다.
  - 기존과 동일하게 해석된 차원 정보가 통계 조회에 적용되므로 사용자 이용 방식이나 결과에는 변화가 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->