### PR TITLE
feat: 공개 통계 Redis TTL 캐시(cache-aside) 적용 (#335)

### DIFF
--- a/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/cache/RedisStatisticsCache.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/cache/RedisStatisticsCache.java
@@ -1,0 +1,69 @@
+package com.kakaotech.team18.backend_server.domain.statistics.cache;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kakaotech.team18.backend_server.domain.statistics.config.StatisticsProperties;
+import com.kakaotech.team18.backend_server.domain.statistics.dto.StatisticsResponseDto;
+import java.time.Duration;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+/**
+ * Redis 기반 공개 통계 캐시. 지원폼별 전체 결과를 JSON 문자열로 저장하고 TTL로 만료시킨다.
+ * <p>
+ * Redis 장애·직렬화 오류가 통계 조회를 막지 않도록, 모든 예외를 삼켜 조회는 '미스'로 저장은 '무시'로 처리한다.
+ * 그러면 호출부는 실시간 계산으로 폴백한다.
+ */
+@Slf4j
+@Component
+public class RedisStatisticsCache implements StatisticsCache {
+
+    /** 캐시 키 접두사. 응답 스키마가 바뀌면 v2 등으로 올려 이전 캐시와 충돌하지 않게 한다. */
+    private static final String KEY_PREFIX = "statistics:v1:";
+
+    private final StringRedisTemplate redisTemplate;
+    private final ObjectMapper objectMapper;
+    private final StatisticsProperties properties;
+
+    public RedisStatisticsCache(StringRedisTemplate redisTemplate, ObjectMapper objectMapper,
+                                StatisticsProperties properties) {
+        this.redisTemplate = redisTemplate;
+        // 캐시 왕복 시 calculatedAt의 offset(+09:00)이 UTC(Z)로 바뀌지 않도록, 파싱 때 컨텍스트 타임존으로 보정하지 않는다.
+        // (그래야 캐시 히트/미스 응답의 시각 표기가 KST로 일관된다.)
+        this.objectMapper = objectMapper.copy().disable(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE);
+        this.properties = properties;
+    }
+
+    @Override
+    public Optional<StatisticsResponseDto> find(Long clubApplyFormId) {
+        try {
+            String json = redisTemplate.opsForValue().get(key(clubApplyFormId));
+            if (json == null) {
+                return Optional.empty();
+            }
+            return Optional.of(objectMapper.readValue(json, StatisticsResponseDto.class));
+        } catch (Exception e) {
+            // 캐시 장애/역직렬화 실패는 조회를 막지 않는다. 미스로 간주해 실시간 계산으로 폴백한다.
+            log.warn("통계 캐시 조회 실패 clubApplyFormId={} : {}", clubApplyFormId, e.toString());
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public void put(Long clubApplyFormId, StatisticsResponseDto fullStatistics) {
+        try {
+            String json = objectMapper.writeValueAsString(fullStatistics);
+            redisTemplate.opsForValue()
+                    .set(key(clubApplyFormId), json, Duration.ofSeconds(properties.cacheTtlSeconds()));
+        } catch (Exception e) {
+            // 저장 실패도 조회를 막지 않는다. 다음 요청이 다시 계산·저장을 시도한다.
+            log.warn("통계 캐시 저장 실패 clubApplyFormId={} : {}", clubApplyFormId, e.toString());
+        }
+    }
+
+    private String key(Long clubApplyFormId) {
+        return KEY_PREFIX + clubApplyFormId;
+    }
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/cache/StatisticsCache.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/cache/StatisticsCache.java
@@ -1,0 +1,26 @@
+package com.kakaotech.team18.backend_server.domain.statistics.cache;
+
+import com.kakaotech.team18.backend_server.domain.statistics.dto.StatisticsResponseDto;
+import java.util.Optional;
+
+/**
+ * 공개 통계 결과 캐시.
+ * <p>
+ * 지원폼 단위로 <strong>마스킹하지 않은 전체 dimension 결과</strong>를 캐시한다. 마스킹·dimension subset은
+ * 조회 시점(serve time)에 적용하므로, 캐시에는 원본 계산 결과만 담는다.
+ * <p>
+ * 캐시 장애가 조회를 막아서는 안 된다. 구현체는 조회/저장 실패 시 예외를 던지지 말고 각각 '미스'와 '무시'로
+ * 처리해, 호출부가 실시간 계산으로 자연스럽게 폴백하도록 한다.
+ */
+public interface StatisticsCache {
+
+    /**
+     * 지원폼의 캐시된 전체 통계를 조회합니다. 없거나 캐시 장애면 빈 값을 반환합니다.
+     */
+    Optional<StatisticsResponseDto> find(Long clubApplyFormId);
+
+    /**
+     * 지원폼의 전체 통계를 캐시에 저장합니다. 저장에 실패해도 예외를 던지지 않습니다.
+     */
+    void put(Long clubApplyFormId, StatisticsResponseDto fullStatistics);
+}

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/config/StatisticsProperties.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/config/StatisticsProperties.java
@@ -11,10 +11,11 @@ import org.springframework.boot.context.properties.bind.DefaultValue;
  *                           무관하게 원본을 노출한다. 기준은 전체 지원자 수에만 걸리고 개별 버킷에는 걸지 않는다.
  * @param cacheTtlSeconds    공개 통계 캐시(Redis) TTL(초). 조회 시 캐시에 없으면 실시간 계산해 이 시간만큼 캐시한다.
  *                           관리자 통계는 캐시를 거치지 않는다. 스케줄러 없이 요청 시점에만 채우는 cache-aside 방식이다.
+ *                           응답의 {@code calculatedAt}이 그 스냅샷의 산출 시각이므로, 클라이언트는 이를 신선도로 표시한다.
  */
 @ConfigurationProperties(prefix = "statistics")
 public record StatisticsProperties(
         @DefaultValue("3") int minTotalApplicants,
-        @DefaultValue("60") long cacheTtlSeconds
+        @DefaultValue("1800") long cacheTtlSeconds
 ) {
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/config/StatisticsProperties.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/config/StatisticsProperties.java
@@ -9,9 +9,12 @@ import org.springframework.boot.context.properties.bind.DefaultValue;
  * @param minTotalApplicants 공개 통계 재식별 방지 최소 공개 기준. 전체 지원자 수가 이 값 미만이면 분포가 소수라
  *                           재식별 위험이 커지므로 공개 통계를 비공개(masked) 처리한다. 관리자 통계는 이 값과
  *                           무관하게 원본을 노출한다. 기준은 전체 지원자 수에만 걸리고 개별 버킷에는 걸지 않는다.
+ * @param cacheTtlSeconds    공개 통계 캐시(Redis) TTL(초). 조회 시 캐시에 없으면 실시간 계산해 이 시간만큼 캐시한다.
+ *                           관리자 통계는 캐시를 거치지 않는다. 스케줄러 없이 요청 시점에만 채우는 cache-aside 방식이다.
  */
 @ConfigurationProperties(prefix = "statistics")
 public record StatisticsProperties(
-        @DefaultValue("3") int minTotalApplicants
+        @DefaultValue("3") int minTotalApplicants,
+        @DefaultValue("60") long cacheTtlSeconds
 ) {
 }

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/dto/StatisticsResponseDto.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/dto/StatisticsResponseDto.java
@@ -33,7 +33,11 @@ public record StatisticsResponseDto(
                 example = "false")
         boolean masked,
 
-        @Schema(description = "집계가 수행된 시각", example = "2026-03-14T23:59:30+09:00")
+        @Schema(description = """
+                이 통계 스냅샷이 산출된 시각(KST). 공개 통계는 캐시되므로 조회 시각이 아니라 캐시된 스냅샷의
+                계산 시각이며, 최대 캐시 TTL만큼 과거일 수 있다. 클라이언트는 이 값으로 '언제 기준' 데이터인지
+                신선도를 표시한다.""",
+                example = "2026-03-14T23:59:30+09:00")
         OffsetDateTime calculatedAt,
 
         @Schema(description = "dimension별 집계 결과. 최소 공개 기준에 미달(masked=true)하면 빈 배열이다.")

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/service/StatisticsServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/service/StatisticsServiceImpl.java
@@ -2,6 +2,7 @@ package com.kakaotech.team18.backend_server.domain.statistics.service;
 
 import com.kakaotech.team18.backend_server.domain.clubApplyForm.entity.ClubApplyForm;
 import com.kakaotech.team18.backend_server.domain.clubApplyForm.repository.ClubApplyFormRepository;
+import com.kakaotech.team18.backend_server.domain.statistics.cache.StatisticsCache;
 import com.kakaotech.team18.backend_server.domain.statistics.config.StatisticsProperties;
 import com.kakaotech.team18.backend_server.domain.statistics.dto.RawBucket;
 import com.kakaotech.team18.backend_server.domain.statistics.dto.StatisticsResponseDto;
@@ -14,6 +15,10 @@ import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -37,21 +42,30 @@ public class StatisticsServiceImpl implements StatisticsService {
     private final ClubApplyFormRepository clubApplyFormRepository;
     private final StatisticsAggregator aggregator;
     private final StatisticsProperties properties;
+    private final StatisticsCache cache;
 
     @Override
     public StatisticsResponseDto getStatistics(Long clubApplyFormId, List<StatisticsDimension> dimensions) {
         ClubApplyForm form = clubApplyFormRepository.findById(clubApplyFormId)
                 .orElseThrow(() -> new ClubApplyFormNotFoundException("clubApplyFormId = " + clubApplyFormId));
 
-        // 공개 통계는 재식별 방지를 위해 전체 지원자 수가 최소 공개 기준 미만이면 분포를 비공개(masked)한다.
+        // 공개 통계는 폼별 전체 결과를 Redis에 TTL 캐시한다(스케줄러 없이 요청 시점에만 채우는 cache-aside).
+        // 캐시에는 마스킹하지 않은 전체 dimension 결과를 담고, 마스킹·subset은 serve 시점에 적용한다.
+        // 캐시 장애 시 find는 빈 값을 주므로 자연히 실시간 계산으로 폴백한다.
+        StatisticsResponseDto full = cache.find(clubApplyFormId).orElseGet(() -> {
+            StatisticsResponseDto computed = calculate(form, StatisticsDimension.defaults());
+            cache.put(clubApplyFormId, computed);
+            return computed;
+        });
+
+        // 재식별 방지: 전체 지원자 수가 최소 공개 기준 미만이면 분포를 비공개(masked)한다.
         // 기준은 전체 지원자 수에만 걸리고 개별 버킷에는 걸지 않는다(그래야 버킷 간 뺄셈 역산 문제가 없다).
-        // 지원자 수를 한 번만 읽어 기준 판정과 집계가 같은 값을 쓰도록 calculate에 그대로 넘긴다.
-        long totalApplicants = aggregator.countApplicants(form.getId());
-        if (totalApplicants < properties.minTotalApplicants()) {
-            return maskedResponse(form.getId(), totalApplicants);
+        // 판정과 응답이 같은 캐시 스냅샷의 totalApplicants를 쓰므로 서로 어긋나지 않는다.
+        if (full.totalApplicants() < properties.minTotalApplicants()) {
+            return maskedResponse(clubApplyFormId, full.totalApplicants());
         }
 
-        return calculate(form, dimensions, totalApplicants);
+        return filterDimensions(full, dimensions);
     }
 
     @Override
@@ -67,18 +81,12 @@ public class StatisticsServiceImpl implements StatisticsService {
     /**
      * 지원폼의 통계를 실제로 집계합니다.
      * <p>
-     * 조회 경로와 스케줄러 사전 계산 경로가 같은 결과를 내도록 이 메서드를 공유한다.
+     * 공개 캐시 채움 경로와 관리자 실시간 경로가 같은 결과를 내도록 이 메서드를 공유한다. 지원자 수를 한 번만
+     * 읽어 전체 수와 비율이 같은 스냅샷을 쓰도록 한다(클래스의 REPEATABLE_READ와 함께 집계 간 일관성 보장).
      */
     public StatisticsResponseDto calculate(ClubApplyForm form, List<StatisticsDimension> dimensions) {
-        return calculate(form, dimensions, aggregator.countApplicants(form.getId()));
-    }
+        long totalApplicants = aggregator.countApplicants(form.getId());
 
-    /**
-     * 이미 읽어둔 전체 지원자 수로 통계를 집계합니다.
-     * <p>
-     * 호출부가 최소 공개 기준 판정에 쓴 값과 동일한 지원자 수를 넘겨, 판정과 집계가 같은 스냅샷을 쓰도록 한다.
-     */
-    public StatisticsResponseDto calculate(ClubApplyForm form, List<StatisticsDimension> dimensions, long totalApplicants) {
         List<StatisticsResponseDto.DimensionResult> results = new ArrayList<>();
         for (StatisticsDimension dimension : dimensions) {
             // 지원자가 없으면 버킷은 빈 배열이 된다. dimension 자체는 응답에 그대로 남겨,
@@ -94,6 +102,31 @@ public class StatisticsServiceImpl implements StatisticsService {
                 false,
                 OffsetDateTime.now(KST),
                 results
+        );
+    }
+
+    /**
+     * 캐시된 전체 결과에서 요청한 dimension만 골라 응답을 만듭니다.
+     * <p>
+     * 캐시에는 항상 전체 dimension 결과가 들어 있으므로, subset 요청은 재계산 없이 여기서 걸러낸다.
+     * 순서는 요청한 dimension 순서를 따른다. totalApplicants·calculatedAt 등 나머지는 캐시 값 그대로 유지한다.
+     */
+    private StatisticsResponseDto filterDimensions(StatisticsResponseDto full, List<StatisticsDimension> dimensions) {
+        Map<StatisticsDimension, StatisticsResponseDto.DimensionResult> byDimension = full.results().stream()
+                .collect(Collectors.toMap(StatisticsResponseDto.DimensionResult::dimension, Function.identity()));
+
+        List<StatisticsResponseDto.DimensionResult> selected = dimensions.stream()
+                .map(byDimension::get)
+                .filter(Objects::nonNull)
+                .toList();
+
+        return new StatisticsResponseDto(
+                full.clubApplyFormId(),
+                full.totalApplicants(),
+                full.snapshot(),
+                full.masked(),
+                full.calculatedAt(),
+                selected
         );
     }
 

--- a/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/service/StatisticsServiceImpl.java
+++ b/src/main/java/com/kakaotech/team18/backend_server/domain/statistics/service/StatisticsServiceImpl.java
@@ -62,7 +62,9 @@ public class StatisticsServiceImpl implements StatisticsService {
         // 기준은 전체 지원자 수에만 걸리고 개별 버킷에는 걸지 않는다(그래야 버킷 간 뺄셈 역산 문제가 없다).
         // 판정과 응답이 같은 캐시 스냅샷의 totalApplicants를 쓰므로 서로 어긋나지 않는다.
         if (full.totalApplicants() < properties.minTotalApplicants()) {
-            return maskedResponse(clubApplyFormId, full.totalApplicants());
+            // 마스킹 응답의 총원·산출 시각 모두 같은 캐시 스냅샷에서 가져와, calculatedAt이 조회 시각이 아니라
+            // 스냅샷 산출 시각으로 일관되게 한다(캐시 히트 시에도 신선도 표기가 정확).
+            return maskedResponse(clubApplyFormId, full.totalApplicants(), full.calculatedAt());
         }
 
         return filterDimensions(full, dimensions);
@@ -136,13 +138,14 @@ public class StatisticsServiceImpl implements StatisticsService {
      * {@code masked=true}와 빈 results로, '지원자가 적어 비공개'임을 '지원자 0명'(results가 있고 버킷 count가 0)과
      * 구분해 알린다. totalApplicants는 분포가 아니므로 그대로 노출한다.
      */
-    private StatisticsResponseDto maskedResponse(Long clubApplyFormId, long totalApplicants) {
+    private StatisticsResponseDto maskedResponse(Long clubApplyFormId, long totalApplicants,
+                                                 OffsetDateTime calculatedAt) {
         return new StatisticsResponseDto(
                 clubApplyFormId,
                 totalApplicants,
                 false,
                 true,
-                OffsetDateTime.now(KST),
+                calculatedAt,
                 List.of()
         );
     }

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/statistics/cache/RedisStatisticsCacheTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/statistics/cache/RedisStatisticsCacheTest.java
@@ -1,0 +1,93 @@
+package com.kakaotech.team18.backend_server.domain.statistics.cache;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.kakaotech.team18.backend_server.domain.statistics.config.StatisticsProperties;
+import com.kakaotech.team18.backend_server.domain.statistics.dto.StatisticsResponseDto;
+import com.kakaotech.team18.backend_server.domain.statistics.entity.DimensionType;
+import com.kakaotech.team18.backend_server.domain.statistics.entity.StatisticsDimension;
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+@DisplayName("RedisStatisticsCache")
+class RedisStatisticsCacheTest {
+
+    private final StringRedisTemplate redisTemplate = mock(StringRedisTemplate.class);
+    @SuppressWarnings("unchecked")
+    private final ValueOperations<String, String> valueOps = mock(ValueOperations.class);
+    // 운영 ObjectMapper처럼 시간을 타임스탬프가 아닌 ISO 문자열로 직렬화해 offset을 보존한다.
+    private final ObjectMapper objectMapper = new ObjectMapper()
+            .findAndRegisterModules()
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+    private final StatisticsProperties properties = new StatisticsProperties(3, 60);
+    private final RedisStatisticsCache cache = new RedisStatisticsCache(redisTemplate, objectMapper, properties);
+
+    private StatisticsResponseDto sample() {
+        return new StatisticsResponseDto(
+                12L, 200L, false, false, OffsetDateTime.parse("2026-03-14T23:59:30+09:00"),
+                List.of(new StatisticsResponseDto.DimensionResult(
+                        StatisticsDimension.GENDER, DimensionType.CATEGORICAL,
+                        List.of(new StatisticsResponseDto.Bucket("MALE", "남성", 121L, new BigDecimal("0.605"))))));
+    }
+
+    @Test
+    @DisplayName("put으로 저장한 값을 find로 되읽으면 원본과 같다(레코드·OffsetDateTime·BigDecimal 직렬화 왕복)")
+    void putThenFind_roundTrips() {
+        StatisticsResponseDto dto = sample();
+        when(redisTemplate.opsForValue()).thenReturn(valueOps);
+
+        cache.put(12L, dto);
+
+        ArgumentCaptor<String> jsonCaptor = ArgumentCaptor.forClass(String.class);
+        org.mockito.Mockito.verify(valueOps)
+                .set(eq("statistics:v1:12"), jsonCaptor.capture(), eq(Duration.ofSeconds(60)));
+
+        when(valueOps.get("statistics:v1:12")).thenReturn(jsonCaptor.getValue());
+        Optional<StatisticsResponseDto> found = cache.find(12L);
+
+        assertThat(found).contains(dto);
+    }
+
+    @Test
+    @DisplayName("캐시에 값이 없으면 빈 Optional")
+    void find_miss_returnsEmpty() {
+        when(redisTemplate.opsForValue()).thenReturn(valueOps);
+        when(valueOps.get("statistics:v1:12")).thenReturn(null);
+
+        assertThat(cache.find(12L)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Redis 장애로 조회가 실패해도 예외 대신 빈 Optional로 폴백한다")
+    void find_onError_returnsEmpty() {
+        when(redisTemplate.opsForValue()).thenReturn(valueOps);
+        when(valueOps.get("statistics:v1:12")).thenThrow(new RuntimeException("redis down"));
+
+        assertThat(cache.find(12L)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Redis 장애로 저장이 실패해도 예외를 던지지 않는다")
+    void put_onError_doesNotThrow() {
+        when(redisTemplate.opsForValue()).thenReturn(valueOps);
+        doThrow(new RuntimeException("redis down")).when(valueOps).set(any(), any(), any(Duration.class));
+
+        assertThatCode(() -> cache.put(12L, sample())).doesNotThrowAnyException();
+    }
+}

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/statistics/cache/RedisStatisticsCacheTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/statistics/cache/RedisStatisticsCacheTest.java
@@ -35,7 +35,7 @@ class RedisStatisticsCacheTest {
     private final ObjectMapper objectMapper = new ObjectMapper()
             .findAndRegisterModules()
             .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
-    private final StatisticsProperties properties = new StatisticsProperties(3, 60);
+    private final StatisticsProperties properties = new StatisticsProperties(3, 1800);
     private final RedisStatisticsCache cache = new RedisStatisticsCache(redisTemplate, objectMapper, properties);
 
     private StatisticsResponseDto sample() {
@@ -56,7 +56,7 @@ class RedisStatisticsCacheTest {
 
         ArgumentCaptor<String> jsonCaptor = ArgumentCaptor.forClass(String.class);
         org.mockito.Mockito.verify(valueOps)
-                .set(eq("statistics:v1:12"), jsonCaptor.capture(), eq(Duration.ofSeconds(60)));
+                .set(eq("statistics:v1:12"), jsonCaptor.capture(), eq(Duration.ofSeconds(1800)));
 
         when(valueOps.get("statistics:v1:12")).thenReturn(jsonCaptor.getValue());
         Optional<StatisticsResponseDto> found = cache.find(12L);

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/statistics/service/StatisticsServiceImplTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/statistics/service/StatisticsServiceImplTest.java
@@ -132,6 +132,25 @@ class StatisticsServiceImplTest {
     }
 
     @Test
+    @DisplayName("공개 조회: 캐시 히트인데 기준 미만이면 비공개하되 calculatedAt은 캐시 스냅샷 시각을 유지한다")
+    void publicView_cacheHitBelowMinTotal_maskedButKeepsSnapshotTime() {
+        when(clubApplyFormRepository.findById(1L)).thenReturn(Optional.of(mock(ClubApplyForm.class)));
+        OffsetDateTime snapshotTime = OffsetDateTime.parse("2026-03-14T23:59:30+09:00");
+        StatisticsResponseDto cached = new StatisticsResponseDto(
+                1L, 2L, false, false, snapshotTime, // total 2 < MIN_TOTAL(3)
+                List.of(new StatisticsResponseDto.DimensionResult(
+                        StatisticsDimension.GENDER, DimensionType.CATEGORICAL,
+                        List.of(new StatisticsResponseDto.Bucket("MALE", "남성", 2L, new BigDecimal("1.000"))))));
+        when(cache.find(1L)).thenReturn(Optional.of(cached));
+
+        StatisticsResponseDto res = service.getStatistics(1L, List.of(StatisticsDimension.GENDER));
+
+        assertThat(res.masked()).isTrue();
+        assertThat(res.results()).isEmpty();
+        assertThat(res.calculatedAt()).isEqualTo(snapshotTime); // 조회 시각이 아니라 스냅샷 산출 시각
+    }
+
+    @Test
     @DisplayName("공개 조회: 전체 지원자가 기준 이상이면 masked=false로 정상 노출한다(경계값)")
     void publicView_atMinTotal_notMasked() {
         ClubApplyForm form = mock(ClubApplyForm.class);

--- a/src/test/java/com/kakaotech/team18/backend_server/domain/statistics/service/StatisticsServiceImplTest.java
+++ b/src/test/java/com/kakaotech/team18/backend_server/domain/statistics/service/StatisticsServiceImplTest.java
@@ -3,6 +3,8 @@ package com.kakaotech.team18.backend_server.domain.statistics.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -10,6 +12,7 @@ import static org.mockito.Mockito.when;
 
 import com.kakaotech.team18.backend_server.domain.clubApplyForm.entity.ClubApplyForm;
 import com.kakaotech.team18.backend_server.domain.clubApplyForm.repository.ClubApplyFormRepository;
+import com.kakaotech.team18.backend_server.domain.statistics.cache.StatisticsCache;
 import com.kakaotech.team18.backend_server.domain.statistics.config.StatisticsProperties;
 import com.kakaotech.team18.backend_server.domain.statistics.dto.RawBucket;
 import com.kakaotech.team18.backend_server.domain.statistics.dto.StatisticsResponseDto;
@@ -17,7 +20,9 @@ import com.kakaotech.team18.backend_server.domain.statistics.entity.DimensionTyp
 import com.kakaotech.team18.backend_server.domain.statistics.entity.StatisticsDimension;
 import com.kakaotech.team18.backend_server.global.exception.exceptions.ClubApplyFormNotFoundException;
 import java.math.BigDecimal;
+import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -30,8 +35,20 @@ class StatisticsServiceImplTest {
 
     private final ClubApplyFormRepository clubApplyFormRepository = mock(ClubApplyFormRepository.class);
     private final StatisticsAggregator aggregator = mock(StatisticsAggregator.class);
-    private final StatisticsServiceImpl service =
-            new StatisticsServiceImpl(clubApplyFormRepository, aggregator, new StatisticsProperties(MIN_TOTAL));
+    private final StatisticsCache cache = mock(StatisticsCache.class);
+    private final StatisticsServiceImpl service = new StatisticsServiceImpl(
+            clubApplyFormRepository, aggregator, new StatisticsProperties(MIN_TOTAL, 60), cache);
+
+    /**
+     * 공개 cache-aside 경로가 캐시 미스로 전체(all-dimension)를 계산하도록 캐시를 비우고, 지정한 dimension 외에는
+     * 빈 집계로 채운다(미스 시 calculate가 모든 dimension을 순회하므로).
+     */
+    private void cacheMissWithAggregates(ClubApplyForm form, Map<StatisticsDimension, List<RawBucket>> byDimension) {
+        when(cache.find(anyLong())).thenReturn(Optional.empty());
+        for (StatisticsDimension dimension : StatisticsDimension.values()) {
+            when(aggregator.aggregate(form, dimension)).thenReturn(byDimension.getOrDefault(dimension, List.of()));
+        }
+    }
 
     @Test
     @DisplayName("존재하지 않는 지원폼이면 예외(404 매핑)")
@@ -43,29 +60,59 @@ class StatisticsServiceImplTest {
     }
 
     @Test
-    @DisplayName("집계기가 준 버킷을 응답으로 조립하고 비율을 소수점 3자리로 채운다")
-    void assemblesBucketsWithRatio() {
+    @DisplayName("캐시 미스면 집계기가 준 버킷을 응답으로 조립하고 비율을 채운 뒤 캐시에 저장한다")
+    void cacheMiss_assemblesBucketsWithRatioAndCaches() {
         ClubApplyForm form = mock(ClubApplyForm.class);
         when(form.getId()).thenReturn(1L);
         when(clubApplyFormRepository.findById(1L)).thenReturn(Optional.of(form));
         when(aggregator.countApplicants(1L)).thenReturn(200L);
-        when(aggregator.aggregate(form, StatisticsDimension.GENDER)).thenReturn(List.of(
+        cacheMissWithAggregates(form, Map.of(StatisticsDimension.GENDER, List.of(
                 RawBucket.of("MALE", "남성", 121),
                 RawBucket.of("FEMALE", "여성", 79)
-        ));
+        )));
 
         StatisticsResponseDto res = service.getStatistics(1L, List.of(StatisticsDimension.GENDER));
 
         assertThat(res.clubApplyFormId()).isEqualTo(1L);
         assertThat(res.totalApplicants()).isEqualTo(200L);
-        assertThat(res.snapshot()).isFalse();
         assertThat(res.masked()).isFalse();
-        assertThat(res.results()).hasSize(1);
+        assertThat(res.results()).hasSize(1); // 요청한 GENDER만 걸러짐
 
         StatisticsResponseDto.DimensionResult gender = res.results().get(0);
         assertThat(gender.dimension()).isEqualTo(StatisticsDimension.GENDER);
-        assertThat(gender.buckets()).extracting(b -> b.ratio())
+        assertThat(gender.buckets()).extracting(StatisticsResponseDto.Bucket::ratio)
                 .containsExactly(new BigDecimal("0.605"), new BigDecimal("0.395"));
+
+        // 계산 결과는 전체 dimension으로 캐시된다.
+        verify(cache).put(eq(1L), any(StatisticsResponseDto.class));
+    }
+
+    @Test
+    @DisplayName("캐시 히트면 재계산 없이 캐시 결과에서 요청 dimension만 걸러 반환한다")
+    void cacheHit_servesFromCacheWithoutRecompute() {
+        when(clubApplyFormRepository.findById(1L)).thenReturn(Optional.of(mock(ClubApplyForm.class)));
+        StatisticsResponseDto cached = new StatisticsResponseDto(
+                1L, 200L, false, false, OffsetDateTime.now(),
+                List.of(
+                        new StatisticsResponseDto.DimensionResult(
+                                StatisticsDimension.GENDER, DimensionType.CATEGORICAL,
+                                List.of(new StatisticsResponseDto.Bucket("MALE", "남성", 121L, new BigDecimal("0.605")))),
+                        new StatisticsResponseDto.DimensionResult(
+                                StatisticsDimension.FACULTY, DimensionType.CATEGORICAL,
+                                List.of(new StatisticsResponseDto.Bucket("ENGINEERING", "공과대학", 74L, new BigDecimal("0.346"))))
+                ));
+        when(cache.find(1L)).thenReturn(Optional.of(cached));
+
+        StatisticsResponseDto res = service.getStatistics(1L, List.of(StatisticsDimension.GENDER));
+
+        // 캐시 히트면 집계·카운트 쿼리를 전혀 호출하지 않고, 캐시를 다시 쓰지도 않는다.
+        verify(aggregator, never()).aggregate(any(), any());
+        verify(aggregator, never()).countApplicants(anyLong());
+        verify(cache, never()).put(any(), any());
+
+        assertThat(res.masked()).isFalse();
+        assertThat(res.results()).hasSize(1);
+        assertThat(res.results().get(0).dimension()).isEqualTo(StatisticsDimension.GENDER);
     }
 
     @Test
@@ -75,14 +122,13 @@ class StatisticsServiceImplTest {
         when(form.getId()).thenReturn(1L);
         when(clubApplyFormRepository.findById(1L)).thenReturn(Optional.of(form));
         when(aggregator.countApplicants(1L)).thenReturn(2L); // < MIN_TOTAL(3)
+        cacheMissWithAggregates(form, Map.of());
 
         StatisticsResponseDto res = service.getStatistics(1L, List.of(StatisticsDimension.GENDER));
 
         assertThat(res.masked()).isTrue();
         assertThat(res.results()).isEmpty();
         assertThat(res.totalApplicants()).isEqualTo(2L); // 분포가 아니므로 전체 수는 노출
-        // 비공개면 dimension 집계까지 갈 필요가 없다.
-        verify(aggregator, never()).aggregate(any(), any());
     }
 
     @Test
@@ -92,10 +138,10 @@ class StatisticsServiceImplTest {
         when(form.getId()).thenReturn(1L);
         when(clubApplyFormRepository.findById(1L)).thenReturn(Optional.of(form));
         when(aggregator.countApplicants(1L)).thenReturn(3L); // == MIN_TOTAL(3) → 공개
-        when(aggregator.aggregate(form, StatisticsDimension.GENDER)).thenReturn(List.of(
+        cacheMissWithAggregates(form, Map.of(StatisticsDimension.GENDER, List.of(
                 RawBucket.of("MALE", "남성", 2),
                 RawBucket.of("FEMALE", "여성", 1)
-        ));
+        )));
 
         StatisticsResponseDto res = service.getStatistics(1L, List.of(StatisticsDimension.GENDER));
 
@@ -115,8 +161,8 @@ class StatisticsServiceImplTest {
     }
 
     @Test
-    @DisplayName("관리자 조회는 최소 공개 기준 미만이어도 비공개하지 않고 원본을 그대로 반환한다")
-    void admin_returnsRawEvenBelowMinTotal() {
+    @DisplayName("관리자 조회는 캐시를 거치지 않고, 최소 공개 기준 미만이어도 비공개하지 않는다")
+    void admin_bypassesCacheAndReturnsRawEvenBelowMinTotal() {
         ClubApplyForm form = mock(ClubApplyForm.class);
         when(form.getId()).thenReturn(1L);
         when(clubApplyFormRepository.findById(1L)).thenReturn(Optional.of(form));
@@ -133,6 +179,9 @@ class StatisticsServiceImplTest {
         assertThat(res.results().get(0).buckets())
                 .extracting(StatisticsResponseDto.Bucket::count)
                 .containsExactly(1L, 1L);
+        // 관리자 경로는 캐시를 조회하지도 저장하지도 않는다.
+        verify(cache, never()).find(anyLong());
+        verify(cache, never()).put(any(), any());
     }
 
     @Test
@@ -142,9 +191,9 @@ class StatisticsServiceImplTest {
         when(form.getId()).thenReturn(1L);
         when(clubApplyFormRepository.findById(1L)).thenReturn(Optional.of(form));
         when(aggregator.countApplicants(1L)).thenReturn(10L);
-        when(aggregator.aggregate(form, StatisticsDimension.DAILY_APPLICATIONS)).thenReturn(List.of(
+        cacheMissWithAggregates(form, Map.of(StatisticsDimension.DAILY_APPLICATIONS, List.of(
                 RawBucket.of("2026-03-02", "3월 2일", 4)
-        ));
+        )));
 
         StatisticsResponseDto res = service.getStatistics(1L, List.of(StatisticsDimension.DAILY_APPLICATIONS));
 
@@ -161,9 +210,9 @@ class StatisticsServiceImplTest {
         when(form.getId()).thenReturn(1L);
         when(clubApplyFormRepository.findById(1L)).thenReturn(Optional.of(form));
         when(aggregator.countApplicants(1L)).thenReturn(10L); // >= MIN_TOTAL → 공개
-        when(aggregator.aggregate(form, StatisticsDimension.DAILY_APPLICATIONS)).thenReturn(List.of(
+        cacheMissWithAggregates(form, Map.of(StatisticsDimension.DAILY_APPLICATIONS, List.of(
                 RawBucket.of("2026-03-02", "3월 2일", 0)
-        ));
+        )));
 
         StatisticsResponseDto res = service.getStatistics(1L, List.of(StatisticsDimension.DAILY_APPLICATIONS));
 


### PR DESCRIPTION
## 🚀 작업 내용
공개 통계 조회에 **Redis TTL 캐시(cache-aside)** 를 적용합니다. 매 요청마다 집계 쿼리를 돌리지 않도록 지원폼별 결과를 Redis에 캐시하고, TTL이 지나면 만료됩니다.

- **cache-aside(요청 시 채움)**: 조회 시 캐시에 없으면 실시간 계산 후 Redis에 저장. **스케줄러/백그라운드 잡 없음.** 원본 DB에는 캐시 미스 때만 읽기(집계 SELECT)만 합니다.
- **캐시 내용**: 마스킹하지 않은 **전체 dimension 결과**를 담고, 재식별 방지 마스킹과 dimension subset은 **serve 시점**에 적용. subset 요청은 재계산 없이 캐시에서 걸러냅니다(`filterDimensions`).
- **관리자 통계는 캐시 우회** — 항상 실시간 계산.
- **장애 격리(fail-open)**: Redis 장애·역직렬화 실패 시 `find`가 빈 값을 주므로 **실시간 계산으로 자연 폴백**. 통계 조회가 캐시 때문에 실패하지 않습니다.
- `StatisticsProperties.cacheTtlSeconds`(기본 60)로 TTL 설정값화.

## ⏱️ 소요 시간


## 🤔 고민했던 내용
- **스케줄러(사전계산) vs cache-aside**: 이 워크로드(핫패스 아님, 폼 수는 많고 조회는 들쭉날쭉, 다중 인스턴스)에선 cache-aside가 구조적으로 더 맞다고 판단했습니다. ①작업량이 조회 수요에 비례(안 보는 폼은 계산 0) ②다중 인스턴스에서 분산락(ShedLock) 불필요 ③사전계산도 미스 시 결국 cache-aside가 필요하므로 사실상 상위집합 ④Redis 장애 시 실시간 계산으로 우아하게 열화. 스케줄러의 "균일 저지연/부하 상한" 이점은 이 규모에서 지배적이지 않다고 봤습니다.
- **전체 담고 serve에서 마스킹/subset**: 캐시 키를 (폼)만으로 단순화(2^4 dimension 조합 파편화 방지). 마스킹 임계값이 바뀌어도 캐시 재계산 없이 serve 시점 판정에 반영됩니다. 판정·응답이 같은 캐시 스냅샷의 `totalApplicants`를 쓰므로 서로 어긋나지 않습니다.
- **calculatedAt offset 보존**: Jackson 기본 역직렬화가 `+09:00`을 `Z`(UTC)로 정규화해 캐시 히트/미스 응답의 시각 표기가 달라지는 걸 막고자, 캐시 전용 ObjectMapper에서 `ADJUST_DATES_TO_CONTEXT_TIME_ZONE`을 꺼 offset을 보존했습니다.
- **키 버저닝**: 응답 스키마 변경 시 이전 캐시와 충돌하지 않도록 `statistics:v1:` 접두사를 둠.

## 💬 리뷰 중점사항
- cache-aside 방향이 이 프로젝트에 적절한지(스케줄러 미도입 근거 포함)
- fail-open 처리로 캐시 장애가 조회를 막지 않는지(RedisStatisticsCacheTest로 검증)
- 마스킹/ subset이 serve 시점에 올바르게 적용되고 판정이 캐시 스냅샷과 일관적인지
- 직렬화 왕복(레코드·OffsetDateTime·BigDecimal·enum)이 안전한지

## 🔗관련 이슈
- #335


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 공개 통계 조회 결과를 캐시하여 반복 조회 속도를 개선했습니다.
  * 캐시 유효 기간을 설정할 수 있으며 기본값은 30분입니다.
  * 캐시된 전체 통계에서 요청한 항목만 반환하고, 최소 지원자 수 마스킹 정책을 유지합니다.
  * 통계 결과의 기준 시각을 확인할 수 있습니다.

* **버그 수정**
  * 캐시가 없거나 일시적인 오류가 발생하면 실시간 통계 집계로 자동 전환됩니다.
  * 캐시 저장·조회 오류가 발생해도 통계 조회가 중단되지 않습니다.
  * 관리자 통계는 캐시를 사용하지 않도록 분리했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->